### PR TITLE
Resolve some AdjOrTrans * Zeros{T, 1} ambiguities

### DIFF
--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -4,7 +4,7 @@ using Compat
 using Compat.LinearAlgebra, Compat.SparseArrays
 import Base: size, getindex, setindex!, IndexStyle, checkbounds, convert,
                 +, -, *, /, \
-import Compat.LinearAlgebra: rank, Adjoint
+import Compat.LinearAlgebra: rank
 import Compat: AbstractRange
 
 export Zeros, Ones, Fill, Eye
@@ -293,19 +293,25 @@ const ZerosVecOrMat{T} = Union{Zeros{T,1}, Zeros{T,2}}
 *(a::AbstractVector, b::ZerosVecOrMat) = mult_zeros(a, b)
 *(a::ZerosVecOrMat, b::ZerosVecOrMat) = mult_zeros(a, b)
 
-function *(a::Adjoint{T, <:AbstractVector{T}}, b::Zeros{S, 1}) where {T, S}
-    la, lb = length(a), length(b)
-    la ≠ lb && throw(DimensionMismatch("dot product arguments have lengths $la and $lb"))
-    return zero(promote_type(T, S))
-end
-*(a::Adjoint{T, <:AbstractMatrix{T}} where T, b::Zeros{<:Any, 1}) = mult_zeros(a, b)
+if VERSION >= v"1.0.0"
+    function *(a::Adjoint{T, <:AbstractVector{T}}, b::Zeros{S, 1}) where {T, S}
+        la, lb = length(a), length(b)
+        if la ≠ lb
+            throw(DimensionMismatch("dot product arguments have lengths $la and $lb"))
+        end
+        return zero(promote_type(T, S))
+    end
+    *(a::Adjoint{T, <:AbstractMatrix{T}} where T, b::Zeros{<:Any, 1}) = mult_zeros(a, b)
 
-function *(a::Transpose{T, <:AbstractVector{T}}, b::Zeros{T, 1}) where T<:Real
-    la, lb = length(a), length(b)
-    la ≠ lb && throw(DimensionMismatch("dot product arguments have lengths $la and $lb"))
-    return zero(T)
+    function *(a::Transpose{T, <:AbstractVector{T}}, b::Zeros{T, 1}) where T<:Real
+        la, lb = length(a), length(b)
+        if la ≠ lb
+            throw(DimensionMismatch("dot product arguments have lengths $la and $lb"))
+        end
+        return zero(T)
+    end
+    *(a::Transpose{T, <:AbstractMatrix{T}}, b::Zeros{T, 1}) where T<:Real = mult_zeros(a, b)
 end
-*(a::Transpose{T, <:AbstractMatrix{T}}, b::Zeros{T, 1}) where T<:Real = mult_zeros(a, b)
 
 +(a::Zeros) = a
 -(a::Zeros) = a

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -293,7 +293,7 @@ const ZerosVecOrMat{T} = Union{Zeros{T,1}, Zeros{T,2}}
 *(a::AbstractVector, b::ZerosVecOrMat) = mult_zeros(a, b)
 *(a::ZerosVecOrMat, b::ZerosVecOrMat) = mult_zeros(a, b)
 
-if VERSION >= v"1.0.0"
+if VERSION >= v"0.7"
     function *(a::Adjoint{T, <:AbstractVector{T}}, b::Zeros{S, 1}) where {T, S}
         la, lb = length(a), length(b)
         if la ≠ lb

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -4,7 +4,7 @@ using Compat
 using Compat.LinearAlgebra, Compat.SparseArrays
 import Base: size, getindex, setindex!, IndexStyle, checkbounds, convert,
                 +, -, *, /, \
-import Compat.LinearAlgebra: rank
+import Compat.LinearAlgebra: rank, Adjoint
 import Compat: AbstractRange
 
 export Zeros, Ones, Fill, Eye

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -293,6 +293,19 @@ const ZerosVecOrMat{T} = Union{Zeros{T,1}, Zeros{T,2}}
 *(a::AbstractVector, b::ZerosVecOrMat) = mult_zeros(a, b)
 *(a::ZerosVecOrMat, b::ZerosVecOrMat) = mult_zeros(a, b)
 
+function *(a::Adjoint{T, <:AbstractVector{T}}, b::Zeros{S, 1}) where {T, S}
+    la, lb = length(a), length(b)
+    la ≠ lb && throw(DimensionMismatch("dot product arguments have lengths $la and $lb"))
+    return zero(promote_type(T, S))
+end
+*(a::Adjoint{T, <:AbstractMatrix{T}} where T, b::Zeros{<:Any, 1}) = mult_zeros(a, b)
+
+function *(a::Transpose{T, <:AbstractVector{T}}, b::Zeros{T, 1}) where T<:Real
+    la, lb = length(a), length(b)
+    la ≠ lb && throw(DimensionMismatch("dot product arguments have lengths $la and $lb"))
+    return zero(T)
+end
+*(a::Transpose{T, <:AbstractMatrix{T}}, b::Zeros{T, 1}) where T<:Real = mult_zeros(a, b)
 
 +(a::Zeros) = a
 -(a::Zeros) = a

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -255,7 +255,7 @@ end
     @test Zeros(3, 4) * randn(4) == Zeros(3, 4) * Zeros(4) == Zeros(3)
     @test Zeros(3, 4) * Zeros(4, 5) === Zeros(3, 5)
 
-    if VERSION >= v"1.0.0"
+    if VERSION >= v"0.7"
         # Check multiplication by Adjoint vectors works as expected.
         @test randn(4, 3)' * Zeros(4) === Zeros(3)
         @test randn(4)' * Zeros(4) === zero(Float64)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -255,17 +255,19 @@ end
     @test Zeros(3, 4) * randn(4) == Zeros(3, 4) * Zeros(4) == Zeros(3)
     @test Zeros(3, 4) * Zeros(4, 5) === Zeros(3, 5)
 
-    # Check multiplication by Adjoint vectors works as expected.
-    @test randn(4, 3)' * Zeros(4) === Zeros(3)
-    @test randn(4)' * Zeros(4) === zero(Float64)
-    @test [1, 2, 3]' * Zeros{Int}(3) === zero(Int)
-    @test_throws DimensionMismatch randn(4)' * Zeros(3)
+    if VERSION >= v"1.0.0"
+        # Check multiplication by Adjoint vectors works as expected.
+        @test randn(4, 3)' * Zeros(4) === Zeros(3)
+        @test randn(4)' * Zeros(4) === zero(Float64)
+        @test [1, 2, 3]' * Zeros{Int}(3) === zero(Int)
+        @test_throws DimensionMismatch randn(4)' * Zeros(3)
 
-    # Check multiplication by Transpose-d vectors works as expected.
-    @test transpose(randn(4, 3)) * Zeros(4) === Zeros(3)
-    @test transpose(randn(4)) * Zeros(4) === zero(Float64)
-    @test transpose([1, 2, 3]) * Zeros{Int}(3) === zero(Int)
-    @test_throws DimensionMismatch transpose(randn(4)) * Zeros(3)
+        # Check multiplication by Transpose-d vectors works as expected.
+        @test transpose(randn(4, 3)) * Zeros(4) === Zeros(3)
+        @test transpose(randn(4)) * Zeros(4) === zero(Float64)
+        @test transpose([1, 2, 3]) * Zeros{Int}(3) === zero(Int)
+        @test_throws DimensionMismatch transpose(randn(4)) * Zeros(3)
+    end
 
     @test +(Zeros{Float64}(3, 5)) === Zeros{Float64}(3, 5)
     @test -(Zeros{Float32}(5, 2)) === Zeros{Float32}(5, 2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -255,6 +255,18 @@ end
     @test Zeros(3, 4) * randn(4) == Zeros(3, 4) * Zeros(4) == Zeros(3)
     @test Zeros(3, 4) * Zeros(4, 5) === Zeros(3, 5)
 
+    # Check multiplication by Adjoint vectors works as expected.
+    @test randn(4, 3)' * Zeros(4) === Zeros(3)
+    @test randn(4)' * Zeros(4) === zero(Float64)
+    @test [1, 2, 3]' * Zeros{Int}(3) === zero(Int)
+    @test_throws DimensionMismatch randn(4)' * Zeros(3)
+
+    # Check multiplication by Transpose-d vectors works as expected.
+    @test transpose(randn(4, 3)) * Zeros(4) === Zeros(3)
+    @test transpose(randn(4)) * Zeros(4) === zero(Float64)
+    @test transpose([1, 2, 3]) * Zeros{Int}(3) === zero(Int)
+    @test_throws DimensionMismatch transpose(randn(4)) * Zeros(3)
+
     @test +(Zeros{Float64}(3, 5)) === Zeros{Float64}(3, 5)
     @test -(Zeros{Float32}(5, 2)) === Zeros{Float32}(5, 2)
 


### PR DESCRIPTION
Fixes ambiguities arising from the following:
```julia
using FillArrays
randn(5, 4)' * Zeros(5)
randn(5)' * Zeros(5)
```
and for the `transpose` equivalents.