### PR TITLE
Implement faster "iterate" for Eye

### DIFF
--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -200,7 +200,13 @@ const Eye{T, Axes} = Diagonal{T, Ones{T,1,Tuple{Axes}}}
 Eye{T}(n::Integer) where T = Diagonal(Ones{T}(n))
 Eye(n::Integer) = Diagonal(Ones(n))
 
-
+function Base.iterate(iter::Eye{T}, istate = (1, 1)) where T
+    (i::Int, j::Int) = istate
+    m = size(iter, 1)
+    return i > m ? nothing :
+        ((@inbounds getindex(iter, i, j)),
+         j == m ? (i + 1, 1) : (i, j + 1))
+end
 
 @deprecate Eye(n::Integer, m::Integer) view(Eye(max(n,m)), 1:n, 1:m)
 @deprecate Eye{T}(n::Integer, m::Integer) where T view(Eye{T}(max(n,m)), 1:n, 1:m)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,7 +35,7 @@ import FillArrays: AbstractFill
                 @test convert(AbstractArray,Z) ≡ convert(AbstractFill,Z) ≡ Z
                 @test convert(AbstractArray{T},Z) ≡ convert(AbstractFill{T},Z) ≡ AbstractArray{T}(Z) ≡ Z
                 @test convert(AbstractMatrix{T},Z) ≡ convert(AbstractFill{T,2},Z) ≡ AbstractMatrix{T}(Z) ≡ Z
-                
+
                 @test_throws Exception convert(Fill{Float64}, [1,1,2])
                 @test_throws Exception convert(Fill, [])
                 @test convert(Fill{Float64}, [1,1,1]) ≡ Fill(1.0, 3)
@@ -468,4 +468,11 @@ end
     @test (1:10) .* Zeros(10) ≡ Zeros(10) .* (1:10) ≡ Zeros(10) .* randn(10) ≡ Zeros(10)
     @test (1:10) .* Zeros{Int}(10) ≡ Zeros{Int}(10)
     @test_throws DimensionMismatch (1:11) .* Zeros(10)
+end
+
+@testset "iterate" begin
+    for d in (0, 1, 2, 100)
+        m = Eye(d)
+        @test [x for x in m] == m
+    end
 end


### PR DESCRIPTION
```
julia> m = Eye(100);

julia> @btime [x for x in $m];                 # before commit
  24.396 μs (2 allocations: 78.20 KiB)

julia> @btime [x for x in $m];                 # new iterate method
  11.949 μs (2 allocations: 78.20 KiB)
```