### PR TITLE
isone

### DIFF
--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -208,6 +208,8 @@ function Base.iterate(iter::Eye{T}, istate = (1, 1)) where T
          j == m ? (i + 1, 1) : (i, j + 1))
 end
 
+Base.isone(::Eye) = true
+
 @deprecate Eye(n::Integer, m::Integer) view(Eye(max(n,m)), 1:n, 1:m)
 @deprecate Eye{T}(n::Integer, m::Integer) where T view(Eye{T}(max(n,m)), 1:n, 1:m)
 @deprecate Eye{T}(sz::Tuple{Vararg{Integer,2}}) where T Eye{T}(sz...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -476,3 +476,9 @@ end
         @test [x for x in m] == m
     end
 end
+
+@testset "properties" begin
+    for d in (0, 1, 2, 100)
+        @test isone(Eye(d))
+    end
+end


### PR DESCRIPTION
Before
```
julia> m = Eye(100);

julia> @btime isone($m)
  67.475 ns (0 allocations: 0 bytes)
true
```
After
```
julia> m = Eye(100);

julia> @btime isone($m)
  0.015 ns (0 allocations: 0 bytes)
true
```