### PR TITLE
Remove useless parameter in signature for iterate

### DIFF
--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -200,7 +200,7 @@ const Eye{T, Axes} = Diagonal{T, Ones{T,1,Tuple{Axes}}}
 Eye{T}(n::Integer) where T = Diagonal(Ones{T}(n))
 Eye(n::Integer) = Diagonal(Ones(n))
 
-function Base.iterate(iter::Eye{T}, istate = (1, 1)) where T
+function Base.iterate(iter::Eye, istate = (1, 1))
     (i::Int, j::Int) = istate
     m = size(iter, 1)
     return i > m ? nothing :

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -472,8 +472,12 @@ end
 
 @testset "iterate" begin
     for d in (0, 1, 2, 100)
-        m = Eye(d)
-        @test [x for x in m] == m
+        for T in (Float64, Int)
+            m = Eye(d)
+            mcp = [x for x in m]
+            @test mcp == m
+            @test eltype(mcp) == eltype(m)
+        end
     end
 end
 


### PR DESCRIPTION
* I removed the parameter T, which served no purpose.
* I added tests for the eltype of a Matrix constructed with the iterator.