### PR TITLE
Proposal: Broadcasting multiplication with AbstractRanges

### DIFF
--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -9,7 +9,7 @@ import Base.\
 
 import LinearAlgebra: rank, svdvals!, tril, triu, tril!, triu!
 
-import Base.Broadcast: broadcasted, DefaultArrayStyle
+import Base.Broadcast: broadcasted, DefaultArrayStyle, broadcast_shape
 
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -392,11 +392,11 @@ end
 
     @test Zeros{Int}(5) .+ Zeros(5) isa Zeros{Float64}
 
-    for op in (+, -, *)
-        rnge = range(-5.0, step=1.0, length=10)
-        @test broadcast(op, Fill(5.0, 10), rnge) == broadcast(op, 5.0, rnge)
-        @test_throws DimensionMismatch broadcast(op, Fill(5.0, 11), rnge)
-    end
+    rnge = range(-5.0, step=1.0, length=10)
+    @test broadcast(*, Fill(5.0, 10), rnge) == broadcast(*, 5.0, rnge)
+    @test_throws DimensionMismatch broadcast(*, Fill(5.0, 11), rnge)
+    @test broadcast(*, rnge, Fill(5.0, 10)) == broadcast(*, rnge, 5.0)
+    @test_throws DimensionMismatch broadcast(*, rnge, Fill(5.0, 11))
 end
 
 @testset "Sub-arrays" begin
@@ -471,8 +471,11 @@ end
 end
 
 @testset "Zero .*" begin
-    @test (1:10) .* Zeros(10) ≡ Zeros(10) .* (1:10) ≡ Zeros(10) .* randn(10) ≡ Zeros(10)
-    @test (1:10) .* Zeros{Int}(10) ≡ Zeros{Int}(10)
+    @test Zeros{Int}(10) .* Zeros{Int}(10) ≡ Zeros{Int}(10)
+    @test randn(10) .* Zeros(10) ≡ Zeros(10)
+    @test Zeros(10) .* randn(10) ≡ Zeros(10)
+    @test (1:10) .* Zeros(10) ≡ Zeros(10)
+    @test Zeros(10) .* (1:10) ≡ Zeros(10)
     @test_throws DimensionMismatch (1:11) .* Zeros(10)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -391,6 +391,12 @@ end
     @test y .* y ≡ y ./ y ≡ y .\ y ≡ y
 
     @test Zeros{Int}(5) .+ Zeros(5) isa Zeros{Float64}
+
+    for op in (+, -, *)
+        rnge = range(-5.0, step=1.0, length=10)
+        @test broadcast(op, Fill(5.0, 10), rnge) == broadcast(op, 5.0, rnge)
+        @test_throws DimensionMismatch broadcast(op, Fill(5.0, 11), rnge)
+    end
 end
 
 @testset "Sub-arrays" begin


### PR DESCRIPTION
More or less what the title says - adds support for broadcasting `*` over combinations of `AbstractRange`s and `AbstractFills`, with a specialisation for `Zeros`.

I'm of course happy to extend a little / refactor as required if people are generally open to this PR.
