### PR TITLE
Add adjoint and transpose for matrices, and override vec (#59)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.jl.*.cov
 *.jl.mem
 deps/deps.jl
+.DS_Store

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -6,7 +6,7 @@ import Base: size, getindex, setindex!, IndexStyle, checkbounds, convert,
     any, all, axes, isone, iterate, unique, allunique, permutedims, inv,
     copy
 
-import LinearAlgebra: rank, svdvals!, tril, triu, tril!, triu!, diag
+import LinearAlgebra: rank, svdvals!, tril, triu, tril!, triu!, diag, transpose, adjoint
 
 import Base.Broadcast: broadcasted, DefaultArrayStyle, broadcast_shape
 

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -4,7 +4,7 @@ using LinearAlgebra, SparseArrays
 import Base: size, getindex, setindex!, IndexStyle, checkbounds, convert,
     +, -, *, /, \, diff, sum, cumsum, maximum, minimum, sort, sort!,
     any, all, axes, isone, iterate, unique, allunique, permutedims, inv,
-    copy
+    copy, vec
 
 import LinearAlgebra: rank, svdvals!, tril, triu, tril!, triu!, diag, transpose, adjoint
 

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -373,14 +373,14 @@ end
 sum(x::AbstractFill) = getindex_value(x)*length(x)
 sum(x::Zeros) = getindex_value(x)
 
-cumsum(x::AbstractFill) = range(getindex_value(x); step=getindex_value(x),
+cumsum(x::AbstractFill{<:Any,1}) = range(getindex_value(x); step=getindex_value(x),
                                                     length=length(x))
 
-cumsum(x::Zeros) = x
-cumsum(x::Zeros{Bool}) = x
-cumsum(x::Ones{II}) where II<:Integer = Base.OneTo{II}(length(x))
-cumsum(x::Ones{Bool}) = Base.OneTo{Int}(length(x))
-cumsum(x::AbstractFill{Bool}) = cumsum(convert(AbstractFill{Int}, x))
+cumsum(x::Zeros{<:Any,1}) = x
+cumsum(x::Zeros{Bool,1}) = x
+cumsum(x::Ones{II,1}) where II<:Integer = Base.OneTo{II}(length(x))
+cumsum(x::Ones{Bool,1}) = Base.OneTo{Int}(length(x))
+cumsum(x::AbstractFill{Bool,1}) = cumsum(convert(AbstractFill{Int}, x))
 
 
 #########

--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -1,3 +1,12 @@
+## Transpose/Adjoint
+
+transpose(a::Ones{T,2}) where T = Ones{T}(reverse(a.axes))
+adjoint(a::Ones{T,2}) where T = Ones{T}(reverse(a.axes))
+transpose(a::Zeros{T,2}) where T = Zeros{T}(reverse(a.axes))
+adjoint(a::Zeros{T,2}) where T = Zeros{T}(reverse(a.axes))
+transpose(a::Fill{T,2}) where T = Fill{T}(transpose(a.value), reverse(a.axes))
+adjoint(a::Fill{T,2}) where T = Fill{T}(adjoint(a.value), reverse(a.axes))
+
 ## Algebraic identities
 
 function mult_zeros(a, b::AbstractMatrix)

--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -1,3 +1,9 @@
+## vec
+
+vec(a::Ones{T}) where T = Ones{T}(length(a))
+vec(a::Zeros{T}) where T = Zeros{T}(length(a))
+vec(a::Fill{T}) where T = Fill{T}(a.value,length(a))
+
 ## Transpose/Adjoint
 
 transpose(a::Ones{T,2}) where T = Ones{T}(reverse(a.axes))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -146,7 +146,7 @@ import FillArrays: AbstractFill, RectDiagonal
         @test vec(Zeros{Int}(5,10)) ≡ Zeros{Int}(50)
         @test vec(Zeros{Int}(5,10,20)) ≡ Zeros{Int}(1000)
         @test vec(Fill(1,5,10)) ≡ Fill(1,50)
-end
+    end
 end
 
 
@@ -435,8 +435,9 @@ end
 
     @test diff(Fill(1,10)) ≡ Zeros{Int}(9)
     @test diff(Ones{Float64}(10)) ≡ Zeros{Float64}(9)
-
-    @test_throws UndefKeywordError cumsum(Fill(1,1,5))
+    if VERSION ≥ v"1.0"
+        @test_throws UndefKeywordError cumsum(Fill(1,1,5))
+    end
 end
 
 @testset "Broadcast" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -140,7 +140,14 @@ import FillArrays: AbstractFill, RectDiagonal
         @test copy(x) !== x
         @test copy(x) isa Fill
     end
+
+    @testset "vec" begin
+        @test vec(Ones{Int}(5,10)) ≡ Ones{Int}(50)
+        @test vec(Zeros{Int}(5,10)) ≡ Zeros{Int}(50)
+        @test vec(Zeros{Int}(5,10,20)) ≡ Zeros{Int}(1000)
+        @test vec(Fill(1,5,10)) ≡ Fill(1,50)
 end
+
 
 @testset "RectDiagonal" begin
     data = 1:3
@@ -179,6 +186,7 @@ end
     mut[2, 1] = 0
     @test_throws ArgumentError mut[2, 1] = 9
 end
+
 
 # Check that all pair-wise combinations of + / - elements of As and Bs yield the correct
 # type, and produce numerically correct results.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -657,3 +657,13 @@ end
     @test convert(SparseMatrixCSC{Float64,Int64}, Zeros{Float64}(3, 3)) == spzeros(3, 3)
     @test sparse(Zeros(4, 2)) == spzeros(4, 2)
 end
+
+@testset "Adjoint/Transpose" begin
+    @test Ones{ComplexF64}(5,6)' ≡ transpose(Ones{ComplexF64}(5,6)) ≡ Ones{ComplexF64}(6,5)
+    @test Zeros{ComplexF64}(5,6)' ≡ transpose(Zeros{ComplexF64}(5,6)) ≡ Zeros{ComplexF64}(6,5)
+    @test Fill(1+im, 5, 6)' ≡ Fill(1-im, 6,5)
+    @test transpose(Fill(1+im, 5, 6)) ≡ Fill(1+im, 6,5)
+    @test Ones(5)' isa Adjoint # Vectors still need special dot product
+    @test Fill([1+im 2; 3 4; 5 6], 2,3)' == Fill([1+im 2; 3 4; 5 6]', 3,2)
+    @test transpose(Fill([1+im 2; 3 4; 5 6], 2,3)) == Fill(transpose([1+im 2; 3 4; 5 6]), 3,2)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -147,6 +147,7 @@ import FillArrays: AbstractFill, RectDiagonal
         @test vec(Zeros{Int}(5,10,20)) ≡ Zeros{Int}(1000)
         @test vec(Fill(1,5,10)) ≡ Fill(1,50)
 end
+end
 
 
 @testset "RectDiagonal" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -426,6 +426,8 @@ end
 
     @test diff(Fill(1,10)) ≡ Zeros{Int}(9)
     @test diff(Ones{Float64}(10)) ≡ Zeros{Float64}(9)
+
+    @test_throws UndefKeywordError cumsum(Fill(1,1,5))
 end
 
 @testset "Broadcast" begin


### PR DESCRIPTION
Vectors are left as before to maintain special dot product.