### PR TITLE
Fix issue: copy should not copy the fill's element

### DIFF
--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -75,7 +75,7 @@ convert(::Type{AbstractFill}, F::AbstractFill) = F
 convert(::Type{AbstractFill{T}}, F::AbstractFill) where T = convert(AbstractArray{T}, F)
 convert(::Type{AbstractFill{T,N}}, F::AbstractFill) where {T,N} = convert(AbstractArray{T,N}, F)
 
-copy(F::Fill) = Fill(copy(F.value), F.axes)
+copy(F::Fill) = Fill(F.value, F.axes)
 
 """ Throws an error if `arr` does not contain one and only one unique value. """
 function unique_value(arr::AbstractArray)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -137,8 +137,9 @@ import FillArrays: AbstractFill, RectDiagonal
         @test copy(x) ≡ x
         x = Fill([1.,2.],10)
         @test copy(x) == x
-        @test copy(x) !== x
+        @test copy(x) === x   # because isbits(x)
         @test copy(x) isa Fill
+        @test copy(Fill(:a, 4)) == fill(:a, 4)    # FillArrays#63
     end
 
     @testset "vec" begin


### PR DESCRIPTION
Fix #63 

The `@test copy(x) !== x` test was failing on master, on my machine, which makes sense to me; it's wrong for `isbits(x)`. I don't understand how come the [travis build](https://travis-ci.org/JuliaArrays/FillArrays.jl) succeeded. In any case, I fixed it too in this PR.