### PR TITLE
Binary broadcasting fix + tidy up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.jl.mem
 deps/deps.jl
 .DS_Store
+Manifest.toml

--- a/src/fillbroadcast.jl
+++ b/src/fillbroadcast.jl
@@ -1,4 +1,12 @@
-### Binary broadcasting implementation.
+
+### Unary broadcasting
+
+function broadcasted(::DefaultArrayStyle{N}, op, r::AbstractFill{T,N}) where {T,N}
+    return Fill(op(getindex_value(r)), size(r))
+end
+
+
+### Binary broadcasting
 
 function broadcasted(::DefaultArrayStyle, op, a::AbstractFill, b::AbstractFill)
     val = op(getindex_value(a), getindex_value(b))
@@ -40,40 +48,7 @@ broadcasted(::DefaultArrayStyle, ::typeof(*), a::Ones, b::Ones) = _broadcasted_o
 broadcasted(::DefaultArrayStyle, ::typeof(/), a::Ones, b::Ones) = _broadcasted_ones(a, b)
 broadcasted(::DefaultArrayStyle, ::typeof(\), a::Ones, b::Ones) = _broadcasted_ones(a, b)
 
-# function broadcasted(::DefaultArrayStyle{N}, ::typeof(*), a::Zeros{T,N}, b::Zeros{V,N}) where {T,V,N}
-#     axes(a) ≠ axes(b) && throw(DimensionMismatch("dimensions must match."))
-#     Zeros{promote_type(T,V)}(axes(a))
-# end
 
-# function _broadcasted_mul(a::AbstractArray{T}, b::Zeros{V}) where {T,V}
-#     axes(a) ≠ axes(b) && throw(DimensionMismatch("dimensions must match."))
-#     Zeros{promote_type(T,V)}(axes(a))
-# end
-# function broadcasted(::DefaultArrayStyle{N}, ::typeof(*), a::AbstractArray{T,N}, b::Zeros{V,N}) where {T,V,N}
-#     return _broadcasted_mul(a, b)
-# end
-# function broadcasted(::DefaultArrayStyle{N}, ::typeof(*), a::AbstractFill{T,N}, b::Zeros{V,N}) where {T,V,N}
-#     return _broadcasted_mul(a, b)
-# end
-
-# function _broadcasted_mul(a::Zeros{T}, b::AbstractArray{V}) where {T,V}
-#     axes(a) ≠ axes(b) && throw(DimensionMismatch("dimensions must match."))
-#     Zeros{promote_type(T,V)}(axes(a))
-# end
-# function broadcasted(::DefaultArrayStyle{N}, ::typeof(*), a::Zeros{T,N}, b::AbstractArray{V,N}) where {T,V,N}
-#     _broadcasted_mul(a, b)
-# end
-# function broadcasted(::DefaultArrayStyle{N}, ::typeof(*), a::Zeros{T,N}, b::AbstractFill{V,N}) where {T,V,N}
-#     _broadcasted_mul(a, b)
-# end
-
-# function broadcasted(::DefaultArrayStyle, ::typeof(*), a::Zeros, b::AbstractRange)
-#     return Zeros{promote_type(eltype(a), eltype(b))}(broadcast_shape(size(a), size(b)))
-# end
-
-# function broadcasted(::DefaultArrayStyle, ::typeof(*), a::AbstractRange, b::Zeros)
-#     return Zeros{promote_type(eltype(a), eltype(b))}(broadcast_shape(size(a), size(b)))
-# end
 
 function broadcasted(::DefaultArrayStyle, ::typeof(*), a::AbstractFill, b::AbstractRange)
     broadcast_shape(size(a), size(b)) # Check sizes are compatible.
@@ -85,19 +60,7 @@ function broadcasted(::DefaultArrayStyle, ::typeof(*), a::AbstractRange, b::Abst
     return broadcasted(*, a, getindex_value(b))
 end
 
-broadcasted(::DefaultArrayStyle{N}, op, r::AbstractFill{T,N}) where {T,N} = Fill(op(getindex_value(r)), size(r))
 broadcasted(::DefaultArrayStyle{N}, op, r::AbstractFill{T,N}, x::Number) where {T,N} = Fill(op(getindex_value(r),x), size(r))
 broadcasted(::DefaultArrayStyle{N}, op, x::Number, r::AbstractFill{T,N}) where {T,N} = Fill(op(x, getindex_value(r)), size(r))
 broadcasted(::DefaultArrayStyle{N}, op, r::AbstractFill{T,N}, x::Ref) where {T,N} = Fill(op(getindex_value(r),x[]), size(r))
 broadcasted(::DefaultArrayStyle{N}, op, x::Ref, r::AbstractFill{T,N}) where {T,N} = Fill(op(x[], getindex_value(r)), size(r))
-# function broadcasted(::DefaultArrayStyle{N}, op, r1::AbstractFill{T,N}, r2::AbstractFill{V,N}) where {T,V,N}
-#     size(r1) ≠ size(r2) && throw(DimensionMismatch("dimensions must match."))
-#     Fill(op(getindex_value(r1),getindex_value(r2)), size(r1))
-# end
-
-# for op in (:*, :/, :\)
-#     @eval function broadcasted(::DefaultArrayStyle{N}, ::typeof($op), r1::Ones{T,N}, r2::Ones{V,N}) where {T,V,N}
-#         size(r1) ≠ size(r2) && throw(DimensionMismatch("dimensions must match."))
-#         Ones{promote_type(T,V)}(size(r1))
-#     end
-# end

--- a/src/fillbroadcast.jl
+++ b/src/fillbroadcast.jl
@@ -1,42 +1,79 @@
-for op in (:+, :-)
-    @eval broadcasted(::DefaultArrayStyle{N}, ::typeof($op), r1::AbstractFill{T,N}, r2::AbstractFill{V,N}) where {T,V,N} =
-            $op(r1, r2)
+### Binary broadcasting implementation.
+
+function broadcasted(::DefaultArrayStyle, op, a::AbstractFill, b::AbstractFill)
+    val = op(getindex_value(a), getindex_value(b))
+    return Fill(val, broadcast_shape(size(a), size(b)))
 end
 
-function broadcasted(::DefaultArrayStyle{N}, ::typeof(*), a::Zeros{T,N}, b::Zeros{V,N}) where {T,V,N}
-    axes(a) ≠ axes(b) && throw(DimensionMismatch("dimensions must match."))
-    Zeros{promote_type(T,V)}(axes(a))
+function _broadcasted_zeros(a, b)
+    return Zeros{promote_type(eltype(a), eltype(b))}(broadcast_shape(size(a), size(b)))
+end
+function _broadcasted_ones(a, b)
+    return Ones{promote_type(eltype(a), eltype(b))}(broadcast_shape(size(a), size(b)))
 end
 
-function _broadcasted_mul(a::AbstractArray{T}, b::Zeros{V}) where {T,V}
-    axes(a) ≠ axes(b) && throw(DimensionMismatch("dimensions must match."))
-    Zeros{promote_type(T,V)}(axes(a))
-end
-function broadcasted(::DefaultArrayStyle{N}, ::typeof(*), a::AbstractArray{T,N}, b::Zeros{V,N}) where {T,V,N}
-    return _broadcasted_mul(a, b)
-end
-function broadcasted(::DefaultArrayStyle{N}, ::typeof(*), a::AbstractFill{T,N}, b::Zeros{V,N}) where {T,V,N}
-    return _broadcasted_mul(a, b)
-end
+broadcasted(::DefaultArrayStyle, ::typeof(+), a::Zeros, b::Zeros) = _broadcasted_zeros(a, b)
+broadcasted(::DefaultArrayStyle, ::typeof(+), a::Ones, b::Zeros) = _broadcasted_ones(a, b)
+broadcasted(::DefaultArrayStyle, ::typeof(+), a::Zeros, b::Ones) = _broadcasted_ones(a, b)
 
-function _broadcasted_mul(a::Zeros{T}, b::AbstractArray{V}) where {T,V}
-    axes(a) ≠ axes(b) && throw(DimensionMismatch("dimensions must match."))
-    Zeros{promote_type(T,V)}(axes(a))
-end
-function broadcasted(::DefaultArrayStyle{N}, ::typeof(*), a::Zeros{T,N}, b::AbstractArray{V,N}) where {T,V,N}
-    _broadcasted_mul(a, b)
-end
-function broadcasted(::DefaultArrayStyle{N}, ::typeof(*), a::Zeros{T,N}, b::AbstractFill{V,N}) where {T,V,N}
-    _broadcasted_mul(a, b)
-end
+broadcasted(::DefaultArrayStyle, ::typeof(*), a::Zeros, b::Zeros) = _broadcasted_zeros(a, b)
 
+broadcasted(::DefaultArrayStyle, ::typeof(*), a::Zeros, b::Ones) = _broadcasted_zeros(a, b)
+broadcasted(::DefaultArrayStyle, ::typeof(*), a::Zeros, b::Fill) = _broadcasted_zeros(a, b)
 function broadcasted(::DefaultArrayStyle, ::typeof(*), a::Zeros, b::AbstractRange)
-    return Zeros{promote_type(eltype(a), eltype(b))}(broadcast_shape(size(a), size(b)))
+    return _broadcasted_zeros(a, b)
+end
+function broadcasted(::DefaultArrayStyle, ::typeof(*), a::Zeros, b::AbstractArray)
+    return _broadcasted_zeros(a, b)
 end
 
+broadcasted(::DefaultArrayStyle, ::typeof(*), a::Ones, b::Zeros) = _broadcasted_zeros(a, b)
+broadcasted(::DefaultArrayStyle, ::typeof(*), a::Fill, b::Zeros) = _broadcasted_zeros(a, b)
 function broadcasted(::DefaultArrayStyle, ::typeof(*), a::AbstractRange, b::Zeros)
-    return Zeros{promote_type(eltype(a), eltype(b))}(broadcast_shape(size(a), size(b)))
+    return _broadcasted_zeros(a, b)
 end
+function broadcasted(::DefaultArrayStyle, ::typeof(*), a::AbstractArray, b::Zeros)
+    return _broadcasted_zeros(a, b)
+end
+
+broadcasted(::DefaultArrayStyle, ::typeof(*), a::Ones, b::Ones) = _broadcasted_ones(a, b)
+broadcasted(::DefaultArrayStyle, ::typeof(/), a::Ones, b::Ones) = _broadcasted_ones(a, b)
+broadcasted(::DefaultArrayStyle, ::typeof(\), a::Ones, b::Ones) = _broadcasted_ones(a, b)
+
+# function broadcasted(::DefaultArrayStyle{N}, ::typeof(*), a::Zeros{T,N}, b::Zeros{V,N}) where {T,V,N}
+#     axes(a) ≠ axes(b) && throw(DimensionMismatch("dimensions must match."))
+#     Zeros{promote_type(T,V)}(axes(a))
+# end
+
+# function _broadcasted_mul(a::AbstractArray{T}, b::Zeros{V}) where {T,V}
+#     axes(a) ≠ axes(b) && throw(DimensionMismatch("dimensions must match."))
+#     Zeros{promote_type(T,V)}(axes(a))
+# end
+# function broadcasted(::DefaultArrayStyle{N}, ::typeof(*), a::AbstractArray{T,N}, b::Zeros{V,N}) where {T,V,N}
+#     return _broadcasted_mul(a, b)
+# end
+# function broadcasted(::DefaultArrayStyle{N}, ::typeof(*), a::AbstractFill{T,N}, b::Zeros{V,N}) where {T,V,N}
+#     return _broadcasted_mul(a, b)
+# end
+
+# function _broadcasted_mul(a::Zeros{T}, b::AbstractArray{V}) where {T,V}
+#     axes(a) ≠ axes(b) && throw(DimensionMismatch("dimensions must match."))
+#     Zeros{promote_type(T,V)}(axes(a))
+# end
+# function broadcasted(::DefaultArrayStyle{N}, ::typeof(*), a::Zeros{T,N}, b::AbstractArray{V,N}) where {T,V,N}
+#     _broadcasted_mul(a, b)
+# end
+# function broadcasted(::DefaultArrayStyle{N}, ::typeof(*), a::Zeros{T,N}, b::AbstractFill{V,N}) where {T,V,N}
+#     _broadcasted_mul(a, b)
+# end
+
+# function broadcasted(::DefaultArrayStyle, ::typeof(*), a::Zeros, b::AbstractRange)
+#     return Zeros{promote_type(eltype(a), eltype(b))}(broadcast_shape(size(a), size(b)))
+# end
+
+# function broadcasted(::DefaultArrayStyle, ::typeof(*), a::AbstractRange, b::Zeros)
+#     return Zeros{promote_type(eltype(a), eltype(b))}(broadcast_shape(size(a), size(b)))
+# end
 
 function broadcasted(::DefaultArrayStyle, ::typeof(*), a::AbstractFill, b::AbstractRange)
     broadcast_shape(size(a), size(b)) # Check sizes are compatible.
@@ -53,14 +90,14 @@ broadcasted(::DefaultArrayStyle{N}, op, r::AbstractFill{T,N}, x::Number) where {
 broadcasted(::DefaultArrayStyle{N}, op, x::Number, r::AbstractFill{T,N}) where {T,N} = Fill(op(x, getindex_value(r)), size(r))
 broadcasted(::DefaultArrayStyle{N}, op, r::AbstractFill{T,N}, x::Ref) where {T,N} = Fill(op(getindex_value(r),x[]), size(r))
 broadcasted(::DefaultArrayStyle{N}, op, x::Ref, r::AbstractFill{T,N}) where {T,N} = Fill(op(x[], getindex_value(r)), size(r))
-function broadcasted(::DefaultArrayStyle{N}, op, r1::AbstractFill{T,N}, r2::AbstractFill{V,N}) where {T,V,N}
-    size(r1) ≠ size(r2) && throw(DimensionMismatch("dimensions must match."))
-    Fill(op(getindex_value(r1),getindex_value(r2)), size(r1))
-end
+# function broadcasted(::DefaultArrayStyle{N}, op, r1::AbstractFill{T,N}, r2::AbstractFill{V,N}) where {T,V,N}
+#     size(r1) ≠ size(r2) && throw(DimensionMismatch("dimensions must match."))
+#     Fill(op(getindex_value(r1),getindex_value(r2)), size(r1))
+# end
 
-for op in (:*, :/, :\)
-    @eval function broadcasted(::DefaultArrayStyle{N}, ::typeof($op), r1::Ones{T,N}, r2::Ones{V,N}) where {T,V,N}
-        size(r1) ≠ size(r2) && throw(DimensionMismatch("dimensions must match."))
-        Ones{promote_type(T,V)}(size(r1))
-    end
-end
+# for op in (:*, :/, :\)
+#     @eval function broadcasted(::DefaultArrayStyle{N}, ::typeof($op), r1::Ones{T,N}, r2::Ones{V,N}) where {T,V,N}
+#         size(r1) ≠ size(r2) && throw(DimensionMismatch("dimensions must match."))
+#         Ones{promote_type(T,V)}(size(r1))
+#     end
+# end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -460,6 +460,32 @@ end
     @test y .+ y ≡ Fill(2.0,5,5)
     @test y .* y ≡ y ./ y ≡ y .\ y ≡ y
 
+    rng = MersenneTwister(123456)
+    sizes = [(5, 4), (5, 1), (1, 4), (1, 1), (5,)]
+    for sx in sizes, sy in sizes
+        x, y = Fill(randn(rng), sx), Fill(randn(rng), sy)
+        x_one, y_one = Ones(sx), Ones(sy)
+        x_zero, y_zero = Zeros(sx), Zeros(sy)
+        x_dense, y_dense = randn(rng, sx), randn(rng, sy)
+
+        for x in [x, x_one, x_zero, x_dense], y in [y, y_one, y_zero, y_dense]
+            @test x .+ y == collect(x) .+ collect(y)
+        end
+        @test x_zero .+ y_zero isa Zeros
+        @test x_zero .+ y_one isa Ones
+        @test x_one .+ y_zero isa Ones
+
+        for x in [x, x_one, x_zero, x_dense], y in [y, y_one, y_zero, y_dense]
+            @test x .* y == collect(x) .* collect(y)
+        end
+        for x in [x, x_one, x_zero, x_dense]
+            @test x .* y_zero isa Zeros
+        end
+        for y in [y, y_one, y_zero, y_dense]
+            @test x_zero .* y isa Zeros
+        end
+    end
+
     @test Zeros{Int}(5) .+ Zeros(5) isa Zeros{Float64}
 
     rnge = range(-5.0, step=1.0, length=10)


### PR DESCRIPTION
On master we currently have a bug whereby
```julia
Fill(3.0, 5, 1) .+ Fill(4.0, 5, 4)
```
errors. This PR fixes this, tidies up `fillbroadcast.jl` a bit, and implements quite a few extra correctness tests.

All adds the Manifest to the gitignore for convenience.