### PR TITLE
Add permutedims

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FillArrays"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "0.7"
+version = "0.7.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -5,6 +5,8 @@ vec(a::Zeros{T}) where T = Zeros{T}(length(a))
 vec(a::Fill{T}) where T = Fill{T}(a.value,length(a))
 
 ## Transpose/Adjoint
+# cannot do this for vectors since that would destroy scalar dot product
+
 
 transpose(a::Ones{T,2}) where T = Ones{T}(reverse(a.axes))
 adjoint(a::Ones{T,2}) where T = Ones{T}(reverse(a.axes))
@@ -12,6 +14,21 @@ transpose(a::Zeros{T,2}) where T = Zeros{T}(reverse(a.axes))
 adjoint(a::Zeros{T,2}) where T = Zeros{T}(reverse(a.axes))
 transpose(a::Fill{T,2}) where T = Fill{T}(transpose(a.value), reverse(a.axes))
 adjoint(a::Fill{T,2}) where T = Fill{T}(adjoint(a.value), reverse(a.axes))
+
+fillsimilar(a::Ones{T}, axes) where T = Ones{T}(axes)
+fillsimilar(a::Zeros{T}, axes) where T = Zeros{T}(axes)
+fillsimilar(a::AbstractFill, axes) = Fill(getindex_value(a), axes)
+
+permutedims(a::AbstractFill{<:Any,1}) = fillsimilar(a, (1, length(a)))
+permutedims(a::AbstractFill{<:Any,2}) = fillsimilar(a, reverse(a.axes))
+
+function permutedims(B::AbstractFill, perm)
+    dimsB = size(B)
+    ndimsB = length(dimsB)
+    (ndimsB == length(perm) && isperm(perm)) || throw(ArgumentError("no valid permutation of dimensions"))
+    dimsP = ntuple(i->dimsB[perm[i]], ndimsB)::typeof(dimsB)
+    fillsimilar(B, dimsP)
+end
 
 ## Algebraic identities
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -721,7 +721,7 @@ end
     @test sparse(Zeros(4, 2)) == spzeros(4, 2)
 end
 
-@testset "Adjoint/Transpose" begin
+@testset "Adjoint/Transpose/permutedims" begin
     @test Ones{ComplexF64}(5,6)' ≡ transpose(Ones{ComplexF64}(5,6)) ≡ Ones{ComplexF64}(6,5)
     @test Zeros{ComplexF64}(5,6)' ≡ transpose(Zeros{ComplexF64}(5,6)) ≡ Zeros{ComplexF64}(6,5)
     @test Fill(1+im, 5, 6)' ≡ Fill(1-im, 6,5)
@@ -729,6 +729,18 @@ end
     @test Ones(5)' isa Adjoint # Vectors still need special dot product
     @test Fill([1+im 2; 3 4; 5 6], 2,3)' == Fill([1+im 2; 3 4; 5 6]', 3,2)
     @test transpose(Fill([1+im 2; 3 4; 5 6], 2,3)) == Fill(transpose([1+im 2; 3 4; 5 6]), 3,2)
+
+    @test permutedims(Ones(10)) ≡ Ones(1,10)
+    @test permutedims(Zeros(10)) ≡ Zeros(1,10)
+    @test permutedims(Fill(2.0,10)) ≡ Fill(2.0,1,10)
+    @test permutedims(Ones(10,3)) ≡ Ones(3,10)
+    @test permutedims(Zeros(10,3)) ≡ Zeros(3,10)
+    @test permutedims(Fill(2.0,10,3)) ≡ Fill(2.0,3,10)
+
+    @test permutedims(Ones(2,4,5), [3,2,1]) == permutedims(Array(Ones(2,4,5)), [3,2,1])
+    @test permutedims(Ones(2,4,5), [3,2,1]) ≡ Ones(5,4,2)
+    @test permutedims(Zeros(2,4,5), [3,2,1]) ≡ Zeros(5,4,2)
+    @test permutedims(Fill(2.0,2,4,5), [3,2,1]) ≡ Fill(2.0,5,4,2)
 end
 
 @testset "setindex!/fill!" begin


### PR DESCRIPTION
This adds `permutedims`.

I'm inclined to make this a minor tag: the chances that any user has mutated the result of `permutedims(::AbstractFill)` are probably zero, and if they had I feel like it's a "bug" that they assumed the result would be mutable. But one could also argue it's a breaking change.

 @sbromberger @willtebbutt @cstjean @fredrikekre any of you mind if its a minor tag?