### PR TITLE
Add inline, SquareEye to work around type inferrence issues

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FillArrays"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "0.8.1"
+version = "0.8.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -185,6 +185,9 @@ for (Typ, funcs, func) in ((:Zeros, :zeros, :zero), (:Ones, :ones, :one))
         @inline $Typ{T}(sz::SZ) where SZ<:Tuple{Vararg{Any,N}} where {T, N} = $Typ{T, N}(sz)
         @inline $Typ(sz::Vararg{Any,N}) where N = $Typ{Float64,N}(sz)
         @inline $Typ(sz::SZ) where SZ<:Tuple{Vararg{Any,N}} where N = $Typ{Float64,N}(sz)
+        @inline $Typ{T}(n::Integer) where T = $Typ{T,1}(n)
+        @inline $Typ(n::Integer) = $Typ{Float64,1}(n)
+
 
         @inline $Typ{T,N}(A::AbstractArray{V,N}) where{T,V,N} = $Typ{T,N}(size(A))
         @inline $Typ{T}(A::AbstractArray) where{T} = $Typ{T}(size(A))
@@ -287,8 +290,11 @@ const RectOrDiagonal{T,V,Axes} = Union{RectDiagonal{T,V,Axes}, Diagonal{T,V}}
 const SquareEye{T,Axes} = Diagonal{T,Ones{T,1,Tuple{Axes}}}
 const Eye{T,Axes} = RectOrDiagonal{T,Ones{T,1,Tuple{Axes}}}
 
-Eye{T}(n::Integer) where T = Diagonal(Ones{T}(n))
-Eye(n::Integer) = Diagonal(Ones(n))
+@inline SquareEye{T}(n::Integer) where T = Diagonal(Ones{T}(n))
+@inline SquareEye(n::Integer) = Diagonal(Ones(n))
+
+@inline Eye{T}(n::Integer) where T = Diagonal(Ones{T}(n))
+@inline Eye(n::Integer) = Diagonal(Ones(n))
 
 # function iterate(iter::Eye, istate = (1, 1))
 #     (i::Int, j::Int) = istate

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using FillArrays, LinearAlgebra, SparseArrays, Random, Base64, Test
-import FillArrays: AbstractFill, RectDiagonal
+import FillArrays: AbstractFill, RectDiagonal, SquareEye
 
 @testset "fill array constructors and convert" begin
     for (Typ, funcs) in ((:Zeros, :zeros), (:Ones, :ones))
@@ -90,7 +90,8 @@ import FillArrays: AbstractFill, RectDiagonal
     end
 
     @test Eye(5) isa Diagonal{Float64}
-    @test Eye(5) == Eye{Float64}(5)
+    @test SquareEye(5) isa Diagonal{Float64}
+    @test Eye(5) == Eye{Float64}(5) == SquareEye(5) == SquareEye{Float64}(5)
     @test Eye(5,6) == Eye{Float64}(5,6)
     @test Eye(Ones(5,6)) == Eye{Float64}(5,6)
     @test eltype(Eye(5)) == Float64


### PR DESCRIPTION
The compiler seems to not like `Eye` in some situations. This works around it by adding a `SquareEye` short-hand.