### PR TITLE
implement conj, real, imag and zero

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FillArrays"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "0.8.4"
+version = "0.8.5"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -4,9 +4,9 @@ using LinearAlgebra, SparseArrays
 import Base: size, getindex, setindex!, IndexStyle, checkbounds, convert,
     +, -, *, /, \, diff, sum, cumsum, maximum, minimum, sort, sort!,
     any, all, axes, isone, iterate, unique, allunique, permutedims, inv,
-    copy, vec, setindex!, count, ==, reshape, _throw_dmrs, map
+    copy, vec, setindex!, count, ==, reshape, _throw_dmrs, map, zero
 
-import LinearAlgebra: rank, svdvals!, tril, triu, tril!, triu!, diag, transpose, adjoint, fill!, 
+import LinearAlgebra: rank, svdvals!, tril, triu, tril!, triu!, diag, transpose, adjoint, fill!,
     norm2, norm1, normInf, normMinusInf, normp
 
 import Base.Broadcast: broadcasted, DefaultArrayStyle, broadcast_shape
@@ -434,6 +434,13 @@ diff(x::AbstractFill{T,1}) where T = Zeros{T}(length(x)-1)
 unique(x::AbstractFill{T}) where T = isempty(x) ? T[] : T[getindex_value(x)]
 allunique(x::AbstractFill) = length(x) < 2
 
+#########
+# zero
+#########
+
+zero(r::Zeros{T,N}) where {T,N} = r
+zero(r::Ones{T,N}) where {T,N} = Zeros{T,N}(r.axes)
+zero(r::Fill{T,N}) where {T,N} = Zeros{T,N}(r.axes)
 
 #########
 # any/all/isone/iszero
@@ -480,7 +487,7 @@ include("fillbroadcast.jl")
 ##
 # print
 ##
-Base.replace_in_print_matrix(::Zeros, ::Integer, ::Integer, s::AbstractString) = 
+Base.replace_in_print_matrix(::Zeros, ::Integer, ::Integer, s::AbstractString) =
     Base.replace_with_centered_mark(s)
 
 

--- a/src/fillbroadcast.jl
+++ b/src/fillbroadcast.jl
@@ -9,6 +9,12 @@ function broadcasted(::DefaultArrayStyle{N}, op, r::AbstractFill{T,N}) where {T,
     return Fill(op(getindex_value(r)), size(r))
 end
 
+broadcasted(::DefaultArrayStyle{N}, ::typeof(conj), r::Zeros{T,N}) where {T,N} = r
+broadcasted(::DefaultArrayStyle{N}, ::typeof(conj), r::Ones{T,N}) where {T,N} = r
+broadcasted(::DefaultArrayStyle{N}, ::typeof(real), r::Zeros{T,N}) where {T,N} = Zeros{real(T)}(r.axes)
+broadcasted(::DefaultArrayStyle{N}, ::typeof(real), r::Ones{T,N}) where {T,N} = Ones{real(T)}(r.axes)
+broadcasted(::DefaultArrayStyle{N}, ::typeof(imag), r::Zeros{T,N}) where {T,N} = Zeros{real(T)}(r.axes)
+broadcasted(::DefaultArrayStyle{N}, ::typeof(imag), r::Ones{T,N}) where {T,N} = Zeros{real(T)}(r.axes)
 
 ### Binary broadcasting
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -456,6 +456,7 @@ end
     @test (.-)(x) ≡ -x
     @test exp.(x) ≡ Fill(exp(5),5)
     @test x .+ 1 ≡ Fill(6,5)
+    @test 1 .+ x ≡ Fill(6,5)
     @test x .+ x ≡ Fill(10,5)
     @test x .+ Ones(5) ≡ Fill(6.0,5)
     f = (x,y) -> cos(x*y)
@@ -551,6 +552,8 @@ end
         @test Ones{Int}(5) .* Ones{Int}(5) ≡ Ones{Int}(5)
         @test Ones{Int}(5,2) .* (1:5) == Array(Ones{Int}(5,2)) .* Array(1:5)
         @test (1:5) .* Ones{Int}(5,2)  == Array(1:5) .* Array(Ones{Int}(5,2))
+        @test (1:0.5:5) .* Ones{Int}(9,2)  == Array(1:0.5:5) .* Array(Ones{Int}(9,2))
+        @test Ones{Int}(9,2) .* (1:0.5:5)  == Array(Ones{Int}(9,2)) .* Array(1:0.5:5)
         @test_throws DimensionMismatch Ones{Int}(6) .* (1:5)
         @test_throws DimensionMismatch (1:5) .* Ones{Int}(6)
         @test_throws DimensionMismatch Ones{Int}(5) .* Ones{Int}(6)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -409,6 +409,11 @@ end
     @test (1:5) - Zeros{Int}(5) === (1:5)
     @test Zeros{Int}(5) - (1:5) === -1:-1:-5
     @test Zeros(5) - (1:5) === -1.0:-1.0:-5.0
+
+    # test Base.zero
+    @test zero(Zeros(10)) == Zeros(10)
+    @test zero(Ones(10,10)) == Zeros(10,10)
+    @test zero(Fill(0.5, 10, 10)) == Zeros(10,10)
 end
 
 @testset "maximum/minimum/svd/sort" begin
@@ -492,9 +497,31 @@ end
 
     @test Zeros{Int}(5) .+ Zeros(5) isa Zeros{Float64}
 
+    # Test for conj, real and imag with complex element types
+    @test conj(Zeros{ComplexF64}(10)) isa Zeros{ComplexF64}
+    @test conj(Zeros{ComplexF64}(10,10)) isa Zeros{ComplexF64}
+    @test conj(Ones{ComplexF64}(10)) isa Ones{ComplexF64}
+    @test conj(Ones{ComplexF64}(10,10)) isa Ones{ComplexF64}
+    @test real(Zeros{Float64}(10)) isa Zeros{Float64}
+    @test real(Zeros{Float64}(10,10)) isa Zeros{Float64}
+    @test real(Zeros{ComplexF64}(10)) isa Zeros{Float64}
+    @test real(Zeros{ComplexF64}(10,10)) isa Zeros{Float64}
+    @test real(Ones{Float64}(10)) isa Ones{Float64}
+    @test real(Ones{Float64}(10,10)) isa Ones{Float64}
+    @test real(Ones{ComplexF64}(10)) isa Ones{Float64}
+    @test real(Ones{ComplexF64}(10,10)) isa Ones{Float64}
+    @test imag(Zeros{Float64}(10)) isa Zeros{Float64}
+    @test imag(Zeros{Float64}(10,10)) isa Zeros{Float64}
+    @test imag(Zeros{ComplexF64}(10)) isa Zeros{Float64}
+    @test imag(Zeros{ComplexF64}(10,10)) isa Zeros{Float64}
+    @test imag(Ones{Float64}(10)) isa Zeros{Float64}
+    @test imag(Ones{Float64}(10,10)) isa Zeros{Float64}
+    @test imag(Ones{ComplexF64}(10)) isa Zeros{Float64}
+    @test imag(Ones{ComplexF64}(10,10)) isa Zeros{Float64}
+
     rnge = range(-5.0, step=1.0, length=10)
     @test broadcast(*, Fill(5.0, 10), rnge) == broadcast(*, 5.0, rnge)
-    @test broadcast(*, Zeros(10, 10), rnge) == zeros(10, 10) 
+    @test broadcast(*, Zeros(10, 10), rnge) == zeros(10, 10)
     @test broadcast(*, rnge, Zeros(10, 10)) == zeros(10, 10)
     @test_throws DimensionMismatch broadcast(*, Fill(5.0, 11), rnge)
     @test broadcast(*, rnge, Fill(5.0, 10)) == broadcast(*, rnge, 5.0)
@@ -519,11 +546,11 @@ end
     end
 
     @testset "Special Ones" begin
-        @test Ones{Int}(5) .* (1:5) ≡ (1:5) .* Ones{Int}(5) ≡ 1:5 
-        @test Ones(5) .* (1:5) ≡ (1:5) .* Ones(5) ≡ 1.0:5 
-        @test Ones{Int}(5) .* Ones{Int}(5) ≡ Ones{Int}(5) 
+        @test Ones{Int}(5) .* (1:5) ≡ (1:5) .* Ones{Int}(5) ≡ 1:5
+        @test Ones(5) .* (1:5) ≡ (1:5) .* Ones(5) ≡ 1.0:5
+        @test Ones{Int}(5) .* Ones{Int}(5) ≡ Ones{Int}(5)
         @test Ones{Int}(5,2) .* (1:5) == Array(Ones{Int}(5,2)) .* Array(1:5)
-        @test (1:5) .* Ones{Int}(5,2)  == Array(1:5) .* Array(Ones{Int}(5,2)) 
+        @test (1:5) .* Ones{Int}(5,2)  == Array(1:5) .* Array(Ones{Int}(5,2))
         @test_throws DimensionMismatch Ones{Int}(6) .* (1:5)
         @test_throws DimensionMismatch (1:5) .* Ones{Int}(6)
         @test_throws DimensionMismatch Ones{Int}(5) .* Ones{Int}(6)
@@ -740,7 +767,7 @@ end
         @test_throws TypeError any(Ones(5))
         @test_throws TypeError all(Ones(5))
         @test_throws TypeError any(Eye(5))
-        @test_throws TypeError all(Eye(5))        
+        @test_throws TypeError all(Eye(5))
     end
 end
 
@@ -789,7 +816,7 @@ end
     @test (F[1] = 1) == 1
     @test_throws BoundsError (F[11] = 1)
     @test_throws ArgumentError (F[10] = 2)
-    
+
 
     F = Fill(1,10,5)
     @test (F[1] = 1) == 1
@@ -871,7 +898,7 @@ end
     @test E*(1:5) ≡ 1.0:5.0
     @test (1:5)'E == (1.0:5)'
     @test E*E ≡ E
-end  
+end
 
 @testset "count" begin
     @test count(Ones{Bool}(10)) == count(Fill(true,10)) == 10


### PR DESCRIPTION
Downstream I noticed that the conjugate of a `Ones` with complex element type returned a more general `Fill` type. Chasing this and looking at the related definitions in base, I implemented `conj`, `real` and `imag` for Ones and Zeros.
As part of that, due to [this line](https://github.com/JuliaLang/julia/blob/3608c84e6093594fe86923339fc315231492484c/base/abstractarraymath.jl#L95) in Base, I implemented `zero(x)` as well for Ones, Zeros and Fill.

So, for example:
```julia
julia> imag(Ones(3))
3-element Zeros{Float64,1,Tuple{Base.OneTo{Int64}}}:
  ⋅
  ⋅
  ⋅
```
And the one that started it:
```julia
julia> conj(Zeros{ComplexF64}(3))
3-element Zeros{Complex{Float64},1,Tuple{Base.OneTo{Int64}}}:
      ⋅
      ⋅
      ⋅
```
And finally:
```julia
julia> zero(Fill(0.5, 3))
3-element Zeros{Float64,1,Tuple{Base.OneTo{Int64}}}:
  ⋅
  ⋅
  ⋅
```
There are added tests and a bumped version number.