### PR TITLE
Fix #85

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ os:
   - osx
 julia:
   - 1.0
-  - 1.1
-  - 1.2
-  - 1.3
   - 1.4
   - nightly
 matrix:

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FillArrays"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "0.8.5"
+version = "0.8.6"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,6 @@
 environment:
   matrix:
   - julia_version: 1
-  - julia_version: 1.1
-  - julia_version: 1.2
-  - julia_version: 1.3
   - julia_version: 1.4
   - julia_version: nightly
 

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -165,8 +165,20 @@ function fill_reshape(parent, dims::Integer...)
     Fill(getindex_value(parent), dims...)
 end
 
-reshape(parent::AbstractFill, dims::Integer...) = fill_reshape(parent, dims...)
-reshape(parent::AbstractFill, dims::Int...) = fill_reshape(parent, dims...)
+reshape(parent::AbstractFill, dims::Integer...) = reshape(parent, dims)
+reshape(parent::AbstractFill, dims::Union{Int,Colon}...) = reshape(parent, dims)
+reshape(parent::AbstractFill, dims::Union{Integer,Colon}...) = reshape(parent, dims)
+
+reshape(parent::AbstractFill, dims::Tuple{Vararg{Union{Integer,Colon}}}) = 
+    fill_reshape(parent, Base._reshape_uncolon(parent, dims)...)
+reshape(parent::AbstractFill, dims::Tuple{Vararg{Union{Int,Colon}}}) = 
+    fill_reshape(parent, Base._reshape_uncolon(parent, dims)...)
+reshape(parent::AbstractFill, shp::Tuple{Union{Integer,Base.OneTo}, Vararg{Union{Integer,Base.OneTo}}}) = 
+    reshape(parent, Base.to_shape(shp))    
+reshape(parent::AbstractFill, dims::Dims)        = Base._reshape(parent, dims)    
+reshape(parent::AbstractFill, dims::Tuple{Integer, Vararg{Integer}})        = Base._reshape(parent, dims)    
+Base._reshape(parent::AbstractFill, dims::Dims) = fill_reshape(parent, dims...)
+Base._reshape(parent::AbstractFill, dims::Tuple{Integer,Vararg{Integer}}) = fill_reshape(parent, dims...)
 
 for (Typ, funcs, func) in ((:Zeros, :zeros, :zero), (:Ones, :ones, :one))
     @eval begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -943,9 +943,11 @@ end
 end
 
 @testset "reshape" begin
-    @test reshape(Fill(2,6),2,3) ≡ Fill(2,2,3)
-    @test reshape(Fill(2,6),big(2),3) == Fill(2,big(2),3)
+    @test reshape(Fill(2,6),2,3) ≡ reshape(Fill(2,6),(2,3)) ≡ reshape(Fill(2,6),:,3) ≡ reshape(Fill(2,6),2,:) ≡ Fill(2,2,3)
+    @test reshape(Fill(2,6),big(2),3) == reshape(Fill(2,6), (big(2),3)) == reshape(Fill(2,6), big(2),:) == Fill(2,big(2),3)
     @test_throws DimensionMismatch reshape(Fill(2,6),2,4)
+    @test reshape(Ones(6),2,3) ≡ reshape(Ones(6),(2,3)) ≡ reshape(Ones(6),:,3) ≡ reshape(Ones(6),2,:) ≡ Ones(2,3)
     @test reshape(Zeros(6),2,3) ≡ Zeros(2,3)
     @test reshape(Zeros(6),big(2),3) == Zeros(big(2),3)
+    @test reshape(Fill(2,2,3),Val(1)) ≡ Fill(2,6)
 end


### PR DESCRIPTION
I also now only test on the stable release (1.0) and current release (1.4) to minimise CI burden. In any case I think it's reasonable to only support these two releases (if it were to break on 1.2 we would tell the user to upgrade to 1.4)