### PR TITLE
Add support for block fill arrays via BlockArrays.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FillArrays"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "0.8.9"
+version = "0.8.10"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -7,7 +7,7 @@ import Base: size, getindex, setindex!, IndexStyle, checkbounds, convert,
     copy, vec, setindex!, count, ==, reshape, _throw_dmrs, map, zero
 
 import LinearAlgebra: rank, svdvals!, tril, triu, tril!, triu!, diag, transpose, adjoint, fill!,
-    norm2, norm1, normInf, normMinusInf, normp, lmul!, rmul!, diagzero
+    norm2, norm1, normInf, normMinusInf, normp, lmul!, rmul!, diagzero, AbstractTriangular
 
 import Base.Broadcast: broadcasted, DefaultArrayStyle, broadcast_shape
 
@@ -275,6 +275,7 @@ end
 
 # patch missing overload from Base
 axes(rd::Diagonal{<:Any,<:AbstractFill}) = (axes(rd.diag,1),axes(rd.diag,1))
+axes(T::AbstractTriangular{<:Any,<:AbstractFill}) = axes(parent(T))
 
 axes(rd::RectDiagonal) = rd.axes
 size(rd::RectDiagonal) = length.(rd.axes)
@@ -537,7 +538,12 @@ axes_print_matrix_row(_, io, X, A, i, cols, sep) =
                 io, X, A, i, cols, sep)
 
 Base.print_matrix_row(io::IO,
-        X::Union{AbstractFill,Diagonal{<:Any,<:AbstractFill},RectDiagonal}, A::Vector,
+        X::Union{AbstractFill{<:Any,1},
+                 AbstractFill{<:Any,2},
+                 Diagonal{<:Any,<:AbstractFill{<:Any,1}},
+                 RectDiagonal,
+                 AbstractTriangular{<:Any,<:AbstractFill{<:Any,2}}
+                 }, A::Vector,
         i::Integer, cols::AbstractVector, sep::AbstractString) =
         axes_print_matrix_row(axes(X), io, X, A, i, cols, sep)
 

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -272,6 +272,10 @@ end
 @inline RectDiagonal{T}(A::V, args...) where {T,V} = RectDiagonal{T,V}(A, args...)
 @inline RectDiagonal(A::V, args...) where {V} = RectDiagonal{eltype(V),V}(A, args...)
 
+
+# patch missing overload from Base
+axes(rd::Diagonal{<:Any,<:AbstractFill}) = (axes(rd.diag,1),axes(rd.diag,1))
+
 axes(rd::RectDiagonal) = rd.axes
 size(rd::RectDiagonal) = length.(rd.axes)
 
@@ -302,15 +306,23 @@ for f in (:triu, :triu!, :tril, :tril!)
 end
 
 
+Base.replace_in_print_matrix(A::RectDiagonal, i::Integer, j::Integer, s::AbstractString) = 
+    i == j ? s : Base.replace_with_centered_mark(s)
+
+
 const RectOrDiagonal{T,V,Axes} = Union{RectDiagonal{T,V,Axes}, Diagonal{T,V}}
 const SquareEye{T,Axes} = Diagonal{T,Ones{T,1,Tuple{Axes}}}
 const Eye{T,Axes} = RectOrDiagonal{T,Ones{T,1,Tuple{Axes}}}
 
 @inline SquareEye{T}(n::Integer) where T = Diagonal(Ones{T}(n))
 @inline SquareEye(n::Integer) = Diagonal(Ones(n))
+@inline SquareEye{T}(ax::Tuple{AbstractUnitRange{Int}}) where T = Diagonal(Ones{T}(ax))
+@inline SquareEye(ax::Tuple{AbstractUnitRange{Int}}) = Diagonal(Ones(ax))
 
-@inline Eye{T}(n::Integer) where T = Diagonal(Ones{T}(n))
-@inline Eye(n::Integer) = Diagonal(Ones(n))
+@inline Eye{T}(n::Integer) where T = SquareEye{T}(n)
+@inline Eye(n::Integer) = SquareEye(n)
+@inline Eye{T}(ax::Tuple{AbstractUnitRange{Int}}) where T = SquareEye{T}(ax)
+@inline Eye(ax::Tuple{AbstractUnitRange{Int}}) = SquareEye(ax)
 
 # function iterate(iter::Eye, istate = (1, 1))
 #     (i::Int, j::Int) = istate
@@ -328,8 +340,20 @@ end
 
 Eye(n::Integer, m::Integer) = RectDiagonal(Ones(min(n,m)), n, m)
 Eye{T}(n::Integer, m::Integer) where T = RectDiagonal{T}(Ones{T}(min(n,m)), n, m)
+function Eye{T}((a,b)::NTuple{2,AbstractUnitRange{Int}}) where T 
+    ab = length(a) ≤ length(b) ? a : b
+    RectDiagonal{T}(Ones{T}((ab,)), (a,b))
+end
+function Eye((a,b)::NTuple{2,AbstractUnitRange{Int}})
+    ab = length(a) ≤ length(b) ? a : b
+    RectDiagonal(Ones((ab,)), (a,b))
+end
+
+
 @deprecate Eye{T}(sz::Tuple{Vararg{Integer,2}}) where T Eye{T}(sz...)
 @deprecate Eye(sz::Tuple{Vararg{Integer,2}}) Eye{Float64}(sz...)
+
+
 
 @inline Eye{T}(A::AbstractMatrix) where T = Eye{T}(size(A)...)
 @inline Eye(A::AbstractMatrix) = Eye{eltype(A)}(size(A)...)
@@ -506,5 +530,15 @@ include("fillbroadcast.jl")
 Base.replace_in_print_matrix(::Zeros, ::Integer, ::Integer, s::AbstractString) =
     Base.replace_with_centered_mark(s)
 
+# following support blocked fill array printing via
+# BlockArrays.jl
+axes_print_matrix_row(_, io, X, A, i, cols, sep) =
+    Base.invoke(Base.print_matrix_row, Tuple{IO,AbstractVecOrMat,Vector,Integer,AbstractVector,AbstractString},
+                io, X, A, i, cols, sep)
+
+Base.print_matrix_row(io::IO,
+        X::Union{AbstractFill,Diagonal{<:Any,<:AbstractFill},RectDiagonal}, A::Vector,
+        i::Integer, cols::AbstractVector, sep::AbstractString) =
+        axes_print_matrix_row(axes(X), io, X, A, i, cols, sep)
 
 end # module

--- a/src/fillbroadcast.jl
+++ b/src/fillbroadcast.jl
@@ -6,7 +6,7 @@ map(f::Function, r::AbstractFill) = Fill(f(getindex_value(r)), axes(r))
 ### Unary broadcasting
 
 function broadcasted(::DefaultArrayStyle{N}, op, r::AbstractFill{T,N}) where {T,N}
-    return Fill(op(getindex_value(r)), size(r))
+    return Fill(op(getindex_value(r)), axes(r))
 end
 
 broadcasted(::DefaultArrayStyle{N}, ::typeof(conj), r::Zeros{T,N}) where {T,N} = r

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -196,7 +196,7 @@ end
     @test_throws ArgumentError mut[2, 1] = 9
 
     D = RectDiagonal([1.,2.], (Base.OneTo(3),Base.OneTo(2)))
-    @test stringmime("text/plain", D) == "3×2 RectDiagonal{Float64,Array{Float64,1},Tuple{Base.OneTo{Int64},Base.OneTo{Int64}}}:\n 1.0   ⋅ \n  ⋅   2.0\n  ⋅    ⋅ "
+    @test stringmime("text/plain", D) == "3×2 RectDiagonal{Float64,Array{Float64,1},Tuple{Base.OneTo{$Int},Base.OneTo{$Int}}}:\n 1.0   ⋅ \n  ⋅   2.0\n  ⋅    ⋅ "
 end
 
 # Check that all pair-wise combinations of + / - elements of As and Bs yield the correct

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -117,7 +117,7 @@ import FillArrays: AbstractFill, RectDiagonal, SquareEye
         @test AbstractArray{Float32}(E) == Eye{Float32}(5)
         @test AbstractArray{Float32}(E) == Eye{Float32}(5, 5)
 
-        @test Eye{T}(randn(4,5)) ≡ Eye{T}(4,5)
+        @test Eye{T}(randn(4,5)) ≡ Eye{T}(4,5) ≡ Eye{T}((Base.OneTo(4),Base.OneTo(5)))
         @test Eye{T}((Base.OneTo(5),)) ≡ SquareEye{T}((Base.OneTo(5),)) ≡ Eye{T}(5)
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -175,7 +175,6 @@ end
     @test expected[2, :] == expected_matrix[2, :]
     @test expected[5, :] == expected_matrix[5, :]
 
-    @test stringmime("text/plain", expected) == "5×3 RectDiagonal{Int64,UnitRange{Int64},Tuple{Base.OneTo{Int64},Base.OneTo{Int64}}}:\n 1  ⋅  ⋅\n ⋅  2  ⋅\n ⋅  ⋅  3\n ⋅  ⋅  ⋅\n ⋅  ⋅  ⋅"
 
     for Typ in (RectDiagonal, RectDiagonal{Int}, RectDiagonal{Int, UnitRange{Int}})
         @test Typ(data) == expected[1:3, 1:3]
@@ -195,6 +194,9 @@ end
     @test diag(mut) == [5, 2, 3]
     mut[2, 1] = 0
     @test_throws ArgumentError mut[2, 1] = 9
+
+    D = RectDiagonal([1.,2.], (Base.OneTo(3),Base.OneTo(2)))
+    @test stringmime("text/plain", D) == "3×2 RectDiagonal{Float64,Array{Float64,1},Tuple{Base.OneTo{Int64},Base.OneTo{Int64}}}:\n 1.0   ⋅ \n  ⋅   2.0\n  ⋅    ⋅ "
 end
 
 # Check that all pair-wise combinations of + / - elements of As and Bs yield the correct

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -631,14 +631,14 @@ end
 end
 
 @testset "Offset indexing" begin
-    A = Fill(3, (Base.IdentityUnitRange(-1:1),))
-    @test axes(A)  == (Base.IdentityUnitRange(-1:1),)
+    A = Fill(3, (Base.Slice(-1:1),))
+    @test axes(A)  == (Base.Slice(-1:1),)
     @test A[0] == 3
     @test_throws BoundsError A[2]
     @test_throws BoundsError A[-2]
 
-    A = Zeros((Base.IdentityUnitRange(-1:1),))
-    @test axes(A)  == (Base.IdentityUnitRange(-1:1),)
+    A = Zeros((Base.Slice(-1:1),))
+    @test axes(A)  == (Base.Slice(-1:1),)
     @test A[0] == 0
     @test_throws BoundsError A[2]
     @test_throws BoundsError A[-2]


### PR DESCRIPTION
This allows combining FillArrays.jl and BlockArrays.jl:
```julia
julia> using FillArrays, BlockArrays

julia> A = Fill(2,(blockedrange([1,2,2]),))
5-element Fill{Int64,1,Tuple{BlockedUnitRange{Array{Int64,1}}}} with indices 1:1:5:
 2
 ─
 2
 2
 ─
 2
 2

julia> B = Eye((blockedrange([1,2,2]),))
5×5 Diagonal{Float64,Ones{Float64,1,Tuple{BlockedUnitRange{Array{Int64,1}}}}} with indices 1:1:5×1:1:5:
 1.0  │   ⋅    ⋅   │   ⋅    ⋅ 
 ─────┼────────────┼──────────
  ⋅   │  1.0   ⋅   │   ⋅    ⋅ 
  ⋅   │   ⋅   1.0  │   ⋅    ⋅ 
 ─────┼────────────┼──────────
  ⋅   │   ⋅    ⋅   │  1.0   ⋅ 
  ⋅   │   ⋅    ⋅   │   ⋅   1.0

julia> C = Eye((blockedrange([1,2,2]),blockedrange([2,2])))
5×4 FillArrays.RectDiagonal{Float64,Ones{Float64,1,Tuple{BlockedUnitRange{Array{Int64,1}}}},Tuple{BlockedUnitRange{Array{Int64,1}},BlockedUnitRange{Array{Int64,1}}}} with indices 1:1:5×1:1:4:
 1.0   ⋅   │   ⋅    ⋅ 
 ──────────┼──────────
  ⋅   1.0  │   ⋅    ⋅ 
  ⋅    ⋅   │  1.0   ⋅ 
 ──────────┼──────────
  ⋅    ⋅   │   ⋅   1.0
  ⋅    ⋅   │   ⋅    ⋅ 
````