### PR TITLE
Add constructors for Fill(::Fill) and varients

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FillArrays"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "0.8.11"
+version = "0.8.12"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -76,6 +76,11 @@ Fill{T,0}(x::T, ::Tuple{}) where T = Fill{T,0,Tuple{}}(x, ()) # ambiguity fix
 @inline Fill(x::T, sz::Vararg{<:Integer,N}) where {T, N}  = Fill{T, N}(x, sz)
 @inline Fill(x::T, sz::Tuple{Vararg{<:Any,N}}) where {T, N}  = Fill{T, N}(x, sz)
 
+# We restrict to  when T is specified to avoid ambiguity with a Fill of a Fill
+@inline Fill{T}(F::Fill{T}) where T = F
+@inline Fill{T,N}(F::Fill{T,N}) where {T,N} = F
+@inline Fill{T,N,Axes}(F::Fill{T,N,Axes}) where {T,N,Axes} = F
+
 @inline axes(F::Fill) = F.axes
 @inline size(F::Fill) = length.(F.axes)
 
@@ -204,10 +209,10 @@ for (Typ, funcs, func) in ((:Zeros, :zeros, :zero), (:Ones, :ones, :one))
         @inline $Typ{T}(n::Integer) where T = $Typ{T,1}(n)
         @inline $Typ(n::Integer) = $Typ{Float64,1}(n)
 
-
+        @inline $Typ{T,N,Axes}(A::AbstractArray{V,N}) where{T,V,N,Axes} = $Typ{T,N,Axes}(axes(A))
         @inline $Typ{T,N}(A::AbstractArray{V,N}) where{T,V,N} = $Typ{T,N}(size(A))
         @inline $Typ{T}(A::AbstractArray) where{T} = $Typ{T}(size(A))
-        @inline $Typ(A::AbstractArray) = $Typ(size(A))
+        @inline $Typ(A::AbstractArray) = $Typ{eltype(A)}(A)
 
         @inline axes(Z::$Typ) = Z.axes
         @inline size(Z::$Typ) = length.(Z.axes)

--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -148,6 +148,7 @@ function +(a::Zeros{T}, b::Zeros{V}) where {T, V}
     return Zeros{promote_type(T,V)}(size(a)...)
 end
 -(a::Zeros, b::Zeros) = -(a + b)
+-(a::Ones, b::Ones) = Zeros(a)+Zeros(b)
 
 # Zeros +/- Fill and Fill +/- Zeros
 function +(a::AbstractFill{T}, b::Zeros{V}) where {T, V}

--- a/src/fillbroadcast.jl
+++ b/src/fillbroadcast.jl
@@ -34,6 +34,10 @@ broadcasted(::DefaultArrayStyle, ::typeof(+), a::Zeros, b::Zeros) = _broadcasted
 broadcasted(::DefaultArrayStyle, ::typeof(+), a::Ones, b::Zeros) = _broadcasted_ones(a, b)
 broadcasted(::DefaultArrayStyle, ::typeof(+), a::Zeros, b::Ones) = _broadcasted_ones(a, b)
 
+broadcasted(::DefaultArrayStyle, ::typeof(-), a::Zeros, b::Zeros) = _broadcasted_zeros(a, b)
+broadcasted(::DefaultArrayStyle, ::typeof(-), a::Ones, b::Zeros) = _broadcasted_ones(a, b)
+broadcasted(::DefaultArrayStyle, ::typeof(-), a::Ones, b::Ones) = _broadcasted_zeros(a, b)
+
 broadcasted(::DefaultArrayStyle, ::typeof(*), a::Zeros, b::Zeros) = _broadcasted_zeros(a, b)
 
 for op in (:*, :/)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -43,21 +43,24 @@ import FillArrays: AbstractFill, RectDiagonal, SquareEye
                 @test convert(Fill{Float64}, Fill(1.0,2)) ≡ Fill(1.0, 2) # was ambiguous
                 @test convert(Fill{Int}, Ones(20)) ≡ Fill(1, 20)
 
-                @test $Typ{T,2}(2ones(T,5,5)) == Z
-                @test $Typ{T}(2ones(T,5,5)) == Z
-                @test $Typ(2ones(T,5,5)) == Z
+                @test $Typ{T,2}(2ones(T,5,5)) ≡ $Typ{T}(5,5)
+                @test $Typ{T}(2ones(T,5,5)) ≡ $Typ{T}(5,5)
+                @test $Typ(2ones(T,5,5)) ≡ $Typ{T}(5,5)
 
-                @test AbstractArray{Float32}(Z) == $Typ{Float32}(5,5)
-                @test AbstractArray{Float32,2}(Z) == $Typ{Float32}(5,5)
+                @test $Typ(Z) ≡ $Typ{T}(Z) ≡ $Typ{T,2}(Z) ≡ typeof(Z)(Z) ≡ Z
+
+                @test AbstractArray{Float32}(Z) ≡ $Typ{Float32}(5,5)
+                @test AbstractArray{Float32,2}(Z) ≡ $Typ{Float32}(5,5)
             end
         end
     end
 
+    @test Fill(1) ≡ Fill{Int}(1) ≡ Fill{Int,0}(1) ≡ Fill{Int,0,Tuple{}}(1,())
     @test Fill(1,(-1,5)) ≡ Fill(1,(0,5))
     @test Fill(1.0,5) isa AbstractVector{Float64}
     @test Fill(1.0,5,5) isa AbstractMatrix{Float64}
-    @test Fill(1,5) == Fill(1,(5,))
-    @test Fill(1,5,5) == Fill(1,(5,5))
+    @test Fill(1,5) ≡ Fill(1,(5,))
+    @test Fill(1,5,5) ≡ Fill(1,(5,5))
     @test eltype(Fill(1.0,5,5)) == Float64
 
     @test Matrix{Float64}(Zeros{ComplexF64}(10,10)) == zeros(10,10)
@@ -82,11 +85,12 @@ import FillArrays: AbstractFill, RectDiagonal, SquareEye
         @test convert(AbstractArray{T},F) ≡ AbstractArray{T}(F) ≡ F
         @test convert(AbstractMatrix{T},F) ≡ AbstractMatrix{T}(F) ≡ F
 
+        @test convert(AbstractArray{Float32},F) ≡ AbstractArray{Float32}(F) ≡
+                Fill{Float32}(one(Float32),5,5)
+        @test convert(AbstractMatrix{Float32},F) ≡ AbstractMatrix{Float32}(F) ≡
+                Fill{Float32}(one(Float32),5,5)
 
-        @test convert(AbstractArray{Float32},F) == AbstractArray{Float32}(F) ==
-                Fill{Float32}(one(Float32),5,5)
-        @test convert(AbstractMatrix{Float32},F) == AbstractMatrix{Float32}(F) ==
-                Fill{Float32}(one(Float32),5,5)
+        @test Fill{T}(F) ≡ Fill{T,2}(F) ≡ typeof(F)(F) ≡ F
     end
 
     @test Eye(5) isa Diagonal{Float64}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -579,7 +579,12 @@ end
     @testset "Zeros -" begin
         @test Zeros(10) - Zeros(10) ≡ Zeros(10)
         @test Ones(10) - Zeros(10) ≡ Ones(10)
+        @test Ones(10) - Ones(10) ≡ Zeros(10)
         @test Fill(1,10) - Zeros(10) ≡ Fill(1.0,10)
+
+        @test Zeros(10) .- Zeros(1,9) ≡ Zeros(10,9)
+        @test Ones(10) .- Zeros(1,9) ≡ Ones(10,9)
+        @test Ones(10) .- Ones(1,9) ≡ Zeros(10,9)
     end
 
     @testset "Zero .*" begin


### PR DESCRIPTION
Some parts of Base/StdLib have calls like `typeof(A)(B)` for converting a matrix `B` to that of type `A`. 

This is a bit subtle for `Fill`: `Fill(x)` creates a 0-dimensional array whose only entry is `x`, so should `Fill(x::Fill)` return `x` or a `Fill{<:Fill,0}`? I've left it as the latter for now by only overriding `Fill{T}(F::Fill{T})`, but perhaps this needs more thought.