### PR TITLE
Concise version of "show"

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FillArrays"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "0.8.13"
+version = "0.8.14"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -4,7 +4,8 @@ using LinearAlgebra, SparseArrays
 import Base: size, getindex, setindex!, IndexStyle, checkbounds, convert,
     +, -, *, /, \, diff, sum, cumsum, maximum, minimum, sort, sort!,
     any, all, axes, isone, iterate, unique, allunique, permutedims, inv,
-    copy, vec, setindex!, count, ==, reshape, _throw_dmrs, map, zero
+    copy, vec, setindex!, count, ==, reshape, _throw_dmrs, map, zero,
+    show
 
 import LinearAlgebra: rank, svdvals!, tril, triu, tril!, triu!, diag, transpose, adjoint, fill!,
     norm2, norm1, normInf, normMinusInf, normp, lmul!, rmul!, diagzero, AbstractTriangular
@@ -551,5 +552,18 @@ Base.print_matrix_row(io::IO,
                  }, A::Vector,
         i::Integer, cols::AbstractVector, sep::AbstractString) =
         axes_print_matrix_row(axes(X), io, X, A, i, cols, sep)
+
+
+"""
+    show(io::IO, x::AbstractFill)
+    show(io::IO, ::MIME"text/plain", x::AbstractFill)
+Display concise description.
+"""
+Base.show(io::IO, x::AbstractFill) =
+    print(io, "$(summary(x)) = $(getindex_value(x))")
+
+function Base.show(io::IO, ::MIME"text/plain", x::AbstractFill)
+    show(io, x)
+end
 
 end # module

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -1,3 +1,4 @@
+""" `FillArrays` module to lazily represent matrices with a single value """
 module FillArrays
 
 using LinearAlgebra, SparseArrays

--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -228,7 +228,7 @@ end
 
 function rmul!(z::AbstractFill, x::Number)
     λ = getindex_value(z)
-	# Following check ensures consistency w/ lmul!(x, Array(z))
+    # Following check ensures consistency w/ lmul!(x, Array(z))
     # for, e.g., lmul!(NaN, z)
     λ*x == λ || throw(ArgumentError("Cannot scale by $x"))
     z

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -91,6 +91,8 @@ import FillArrays: AbstractFill, RectDiagonal, SquareEye
                 Fill{Float32}(one(Float32),5,5)
 
         @test Fill{T}(F) ≡ Fill{T,2}(F) ≡ typeof(F)(F) ≡ F
+
+        show(devnull, MIME("text/plain"), F)
     end
 
     @test Eye(5) isa Diagonal{Float64}
@@ -964,7 +966,7 @@ end
 end
 
 @testset "print" begin
-    @test stringmime("text/plain", Zeros(3)) == "3-element Zeros{Float64,1,Tuple{Base.OneTo{$Int}}}:\n  ⋅ \n  ⋅ \n  ⋅ "
+    @test stringmime("text/plain", Zeros(3)) == "3-element Zeros{Float64,1,Tuple{Base.OneTo{$Int}}} = 0.0"
 end
 
 @testset "reshape" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -92,7 +92,7 @@ import FillArrays: AbstractFill, RectDiagonal, SquareEye
 
         @test Fill{T}(F) ≡ Fill{T,2}(F) ≡ typeof(F)(F) ≡ F
 
-        show(devnull, MIME("text/plain"), F)
+        show(devnull, MIME("text/plain"), F) # for codecov
     end
 
     @test Eye(5) isa Diagonal{Float64}


### PR DESCRIPTION
The default way that `AbstractFill` types are displayed at the REPL produces reams of repeated output values for large dimensions, despite a `Fill` containing essentially just one value.
Simply displaying the dimensions, the axes and the value suffices to describe concisely a `Fill` object.
This PR simply provides a concise `show` method for any `Fill` type.

To see the benefit, compare the REPL output of
`Ones(100,100,100)`
for this version, which becomes
`100×100×100 Ones{Float64,3,Tuple{Base.OneTo{Int64},Base.OneTo{Int64},Base.OneTo{Int64}}} = 1.0`
versus the original version (that is too long to paste here).

I also added a few docstrings to partially address #95.

