### PR TITLE
Add `Trues` type and methods

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FillArrays"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "0.8.13"
+version = "0.8.14"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FillArrays"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "0.8.14"
+version = "0.9"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -127,11 +127,11 @@ function getindex(F::Fill, kj::Vararg{AbstractVector{II},N}) where {II<:Integer,
 end
 
 function getindex(A::Fill, kr::AbstractVector{Bool})
-   length(A) == length(kr) || throw(DimensionMismatch())
+   length(A) == length(kr) || throw(DimensionMismatch("lengths must match"))
    Fill(getindex_value(A), count(kr))
 end
 function getindex(A::Fill, kr::AbstractArray{Bool})
-   size(A) == size(kr) || throw(DimensionMismatch())
+   size(A) == size(kr) || throw(DimensionMismatch("sizes must match"))
    Fill(getindex_value(A), count(kr))
 end
 
@@ -235,11 +235,11 @@ for (Typ, funcs, func) in ((:Zeros, :zeros, :zero), (:Ones, :ones, :one))
             $Typ{T}(length.(kj))
         end
         function getindex(A::$Typ{T}, kr::AbstractVector{Bool}) where T
-            length(A) == length(kr) || throw(DimensionMismatch())
+            length(A) == length(kr) || throw(DimensionMismatch("lengths must match"))
             $Typ{T}(count(kr))
         end
         function getindex(A::$Typ{T}, kr::AbstractArray{Bool}) where T
-            size(A) == size(kr) || throw(DimensionMismatch())
+            size(A) == size(kr) || throw(DimensionMismatch("sizes must match"))
             $Typ{T}(count(kr))
         end
 

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -529,6 +529,7 @@ count(f, x::AbstractFill) = f(getindex_value(x)) ? length(x) : 0
 
 include("fillalgebra.jl")
 include("fillbroadcast.jl")
+include("trues.jl")
 
 ##
 # print

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -13,7 +13,7 @@ import Base.Broadcast: broadcasted, DefaultArrayStyle, broadcast_shape
 
 
 
-export Zeros, Ones, Fill, Eye
+export Zeros, Ones, Fill, Eye, Trues, Falses
 
 abstract type AbstractFill{T, N, Axes} <: AbstractArray{T, N} end
 

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -159,11 +159,11 @@ function getindex(F::Fill, kj::Vararg{AbstractVector{II},N}) where {II<:Integer,
 end
 
 function getindex(A::Fill, kr::AbstractVector{Bool})
-   length(A) == length(kr) || throw(DimensionMismatch("lengths must match"))
+   length(A) == length(kr) || throw(DimensionMismatch())
    Fill(getindex_value(A), count(kr))
 end
 function getindex(A::Fill, kr::AbstractArray{Bool})
-   size(A) == size(kr) || throw(DimensionMismatch("sizes must match"))
+   size(A) == size(kr) || throw(DimensionMismatch())
    Fill(getindex_value(A), count(kr))
 end
 

--- a/src/trues.jl
+++ b/src/trues.jl
@@ -21,17 +21,17 @@ const Trues = Ones{Bool, N, Axes} where {N, Axes}
 const Falses = Zeros{Bool, N, Axes} where {N, Axes}
 
 
-# y[mask] = x when mask isa Trues
+# y[mask] = x when mask isa Trues (cf y[:] = x)
 function Base.setindex!(y::AbstractArray{T,N}, x, mask::Trues{N}) where {T,N}
-	@boundscheck size(x) == size(mask) == size(y) || throw(DimensionMismatch())
-	@boundscheck checkbounds(x, mask)
-	@boundscheck axes(mask) == axes(x) || throw("axes mismatch")
+    @boundscheck size(x) == size(mask) == size(y) || throw(DimensionMismatch())
+    @boundscheck checkbounds(x, mask)
+#   @boundscheck axes(mask) == axes(x) || throw("axes mismatch")
     copyto!(y, x)
 end
 
-# x[mask] when mask isa Trues
+# x[mask] when mask isa Trues (cf x[trues(size(x))] or x[:])
 function Base.getindex(x::AbstractArray{T,D}, mask::Trues{D}) where {T,D}
-	@boundscheck size(x) == size(mask) || throw(DimensionMismatch())
-	@boundscheck checkbounds(x, mask)
-	return vec(x)
+    @boundscheck size(x) == size(mask) || throw(DimensionMismatch())
+    @boundscheck checkbounds(x, mask)
+    return vec(x)
 end

--- a/src/trues.jl
+++ b/src/trues.jl
@@ -31,8 +31,13 @@ function Base.setindex!(y::AbstractArray{T,N}, x, mask::Trues{N}) where {T,N}
 end
 
 # x[mask] when mask isa Trues (cf x[trues(size(x))] or x[:])
-function Base.getindex(x::AbstractArray{T,D}, mask::Trues{D}) where {T,D}
-    @boundscheck axes(x) == axes(mask) || throw(BoundsError(x, mask))
-    @boundscheck checkbounds(x, mask)
-    return vec(x)
+# Supported here only for a mask with standard OneTo axes.
+function Base.getindex(x::AbstractArray{T,N},
+    mask::Trues{N, NTuple{N,Base.OneTo{Int}}},
+) where {T,N}
+    if axes(x) isa NTuple{N,Base.OneTo{Int}} where N
+       @boundscheck size(x) == size(mask) || throw(BoundsError(x, mask))
+       return vec(x)
+    end
+    return x[trues(size(x))] # else revert to usual getindex method
 end

--- a/src/trues.jl
+++ b/src/trues.jl
@@ -23,16 +23,16 @@ const Falses = Zeros{Bool, N, Axes} where {N, Axes}
 
 # y[mask] = x when mask isa Trues (cf y[:] = x)
 function Base.setindex!(y::AbstractArray{T,N}, x, mask::Trues{N}) where {T,N}
-    @boundscheck axes(x) == axes(mask) == axes(y) ||
-        throw(BoundsError("axes must match for setindex!"))
+    @boundscheck axes(y) == axes(mask) || throw(BoundsError(y, mask))
+    @boundscheck axes(x) == axes(mask) || throw(ArgumentError(
+        "tried to assign $(length(x)) elements to $(length(y)) destinations"))
     @boundscheck checkbounds(y, mask)
     copyto!(y, x)
 end
 
 # x[mask] when mask isa Trues (cf x[trues(size(x))] or x[:])
 function Base.getindex(x::AbstractArray{T,D}, mask::Trues{D}) where {T,D}
-    @boundscheck axes(x) == axes(mask) ||
-        throw(BoundsError("axes must match for getindex"))
+    @boundscheck axes(x) == axes(mask) || throw(BoundsError(x, mask))
     @boundscheck checkbounds(x, mask)
     return vec(x)
 end

--- a/src/trues.jl
+++ b/src/trues.jl
@@ -24,7 +24,7 @@ const Falses = Zeros{Bool, N, Axes} where {N, Axes}
 # y[mask] = x when mask isa Trues (cf y[:] = x)
 function Base.setindex!(y::AbstractArray{T,N}, x, mask::Trues{N}) where {T,N}
     @boundscheck axes(y) == axes(mask) || throw(BoundsError(y, mask))
-    @boundscheck axes(x) == axes(mask) || throw(ArgumentError(
+    @boundscheck axes(x) == axes(mask) || throw(DimensionMismatch(
         "tried to assign $(length(x)) elements to $(length(y)) destinations"))
     @boundscheck checkbounds(y, mask)
     copyto!(y, x)

--- a/src/trues.jl
+++ b/src/trues.jl
@@ -1,0 +1,37 @@
+
+"""
+    Trues = Ones{Bool, N, Axes} where {N, Axes}
+
+Lazy version of `trues` with axes.
+Typically created using `Trues(dims)` or `Trues(dims...)`
+
+# Example
+```jldoctest
+julia> Trues(1,3)
+1×3 Ones{Bool,2,Tuple{Base.OneTo{Int64},Base.OneTo{Int64}}} = true
+
+julia> Trues((2,3))
+2×3 Ones{Bool,2,Tuple{Base.OneTo{Int64},Base.OneTo{Int64}}} = true
+```
+"""
+const Trues = Ones{Bool, N, Axes} where {N, Axes}
+
+
+""" `Falses = Zeros{Bool, N, Axes}` (see `Trues`) """
+const Falses = Zeros{Bool, N, Axes} where {N, Axes}
+
+
+# y[mask] = x when mask isa Trues
+function Base.setindex!(y::AbstractArray{T,N}, x, mask::Trues{N}) where {T,N}
+	@boundscheck size(x) == size(mask) == size(y) || throw(DimensionMismatch())
+	@boundscheck checkbounds(x, mask)
+	@boundscheck axes(mask) == axes(x) || throw("axes mismatch")
+    copyto!(y, x)
+end
+
+# x[mask] when mask isa Trues
+function Base.getindex(x::AbstractArray{T,D}, mask::Trues{D}) where {T,D}
+	@boundscheck size(x) == size(mask) || throw(DimensionMismatch())
+	@boundscheck checkbounds(x, mask)
+	return vec(x)
+end

--- a/src/trues.jl
+++ b/src/trues.jl
@@ -23,15 +23,16 @@ const Falses = Zeros{Bool, N, Axes} where {N, Axes}
 
 # y[mask] = x when mask isa Trues (cf y[:] = x)
 function Base.setindex!(y::AbstractArray{T,N}, x, mask::Trues{N}) where {T,N}
-    @boundscheck size(x) == size(mask) == size(y) || throw(DimensionMismatch())
-    @boundscheck checkbounds(x, mask)
-#   @boundscheck axes(mask) == axes(x) || throw("axes mismatch")
+    @boundscheck axes(x) == axes(mask) == axes(y) ||
+        throw(DimensionMismatch("axes must match for setindex!"))
+    @boundscheck checkbounds(y, mask)
     copyto!(y, x)
 end
 
 # x[mask] when mask isa Trues (cf x[trues(size(x))] or x[:])
 function Base.getindex(x::AbstractArray{T,D}, mask::Trues{D}) where {T,D}
-    @boundscheck size(x) == size(mask) || throw(DimensionMismatch())
+    @boundscheck axes(x) == axes(mask) ||
+        throw(DimensionMismatch("axes must match for getindex"))
     @boundscheck checkbounds(x, mask)
     return vec(x)
 end

--- a/src/trues.jl
+++ b/src/trues.jl
@@ -24,7 +24,7 @@ const Falses = Zeros{Bool, N, Axes} where {N, Axes}
 # y[mask] = x when mask isa Trues (cf y[:] = x)
 function Base.setindex!(y::AbstractArray{T,N}, x, mask::Trues{N}) where {T,N}
     @boundscheck axes(x) == axes(mask) == axes(y) ||
-        throw(DimensionMismatch("axes must match for setindex!"))
+        throw(BoundsError("axes must match for setindex!"))
     @boundscheck checkbounds(y, mask)
     copyto!(y, x)
 end
@@ -32,7 +32,7 @@ end
 # x[mask] when mask isa Trues (cf x[trues(size(x))] or x[:])
 function Base.getindex(x::AbstractArray{T,D}, mask::Trues{D}) where {T,D}
     @boundscheck axes(x) == axes(mask) ||
-        throw(DimensionMismatch("axes must match for getindex"))
+        throw(BoundsError("axes must match for getindex"))
     @boundscheck checkbounds(x, mask)
     return vec(x)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1013,3 +1013,15 @@ end
         @test axes(U) == (Base.OneTo(3),Base.OneTo(3))
     end
 end
+
+@testset "Trues" begin
+    @test Trues(2,3) == Trues((2,3)) == trues(2,3)
+    @test Falses(2,3) == Falses((2,3)) == falses(2,3)
+    dim = (4,5)
+    mask = Trues(dim)
+    x = randn(dim)
+    @test x[mask] == vec(x) # getindex
+    y = similar(x)
+    y[mask] = x # setindex!
+    @test y == x
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1024,4 +1024,7 @@ end
     y = similar(x)
     y[mask] = x # setindex!
     @test y == x
+    @test_throws BoundsError ones(3)[Trues(2)]
+    @test_throws BoundsError setindex!(ones(3), zeros(3), Trues(2))
+    @test_throws DimensionMismatch setindex!(ones(2), zeros(3), Trues(2))
 end


### PR DESCRIPTION
The "show business" (pun intended) at #109 was just a warm-up.  This PR is the one that matters.
Here's a bit of background.  Unaware of `FillArrays.jl`, I created a somewhat similar package [ConstantArrays.jl](https://github.com/JeffFessler/ConstantArrays.jl), and only later learned about the duplication.
One of my main motivations for writing `ConstantArrays` was to have very efficient versions of `getindex` and `setindex!` for "masks" that are `trues(dim)`.
I have timing tests that show the methods for `getindex` and `setindex!` in this PR reduce the time from 1.6ms to 28ns for `getindex` and from 2.3ms to 0.6ms for `setindex!` using `Trues`:
https://github.com/JeffFessler/ConstantArrays.jl/blob/master/test/time.jl
If this PR goes through then I can delete the otherwise redundant `ConstantArrays` and use `FillArrays` hereafter.
BTW, I don't have a use case for `Falses` right now, but I included it for symmetry with `Trues`.
There is one possible test for matching `axes` that I included but left commented out because I don't think it is relevant when indexing using `Bool` arrays, but I am not that familiar with `axes` so I left it there in case one of you experts says it is needed.