### PR TITLE
Add new types to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 [![Build Status](https://travis-ci.org/JuliaArrays/FillArrays.jl.svg?branch=master)](https://travis-ci.org/JuliaArrays/FillArrays.jl)
 [![codecov](https://codecov.io/gh/JuliaArrays/FillArrays.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaArrays/FillArrays.jl)
 
-Julia package to lazily representing matrices filled with a single entry,
-as well as identity matrices.  This package exports the following types: `Eye`,
-`Fill`, `Ones`, and `Zeros`.
+Julia package to lazily represent matrices filled with a single entry,
+as well as identity matrices.  This package exports the following types:
+`Eye`, `Fill`, `Ones`, `Zeros`, `Trues` and `Falses`.
 
 
 The primary purpose of this package is to present a unified way of constructing
@@ -21,7 +21,7 @@ julia> BandedMatrix(Zeros(5,5), (1, 2))
 
 ## Usage
 
-Here are the matrix type4s:
+Here are the matrix types:
 ```julia
 julia> Zeros(5, 6)
 5×6 Zeros{Float64,2,Tuple{Base.OneTo{Int64},Base.OneTo{Int64}}}:
@@ -60,6 +60,12 @@ julia> Fill(5.0f0, 3, 2)
  5.0  5.0
  5.0  5.0
  5.0  5.0
+
+julia> Trues(2, 3)
+2×3 Ones{Bool,2,Tuple{Base.OneTo{Int64},Base.OneTo{Int64}}} = true
+
+julia> Falses(2)
+2-element Zeros{Bool,1,Tuple{Base.OneTo{Int64}}} = false
 ```
 
 They support conversion to other matrix types like `Array`, `SparseVector`, `SparseMatrix`, and `Diagonal`:
@@ -87,3 +93,8 @@ Ones{Float64,2,Tuple{UnitRange{Int64},UnitRange{Int64}}} with indices -3:2×1:2:
  1.0  1.0
  1.0  1.0
 ```
+
+These types have methods that perform many operations efficiently,
+including elementary algebra operations like multiplication and addition,
+as well as linear algebra methods like
+`norm`, `adjoint`, `transpose` and `vec`.

--- a/README.md
+++ b/README.md
@@ -24,30 +24,18 @@ julia> BandedMatrix(Zeros(5,5), (1, 2))
 Here are the matrix types:
 ```julia
 julia> Zeros(5, 6)
-5×6 Zeros{Float64,2,Tuple{Base.OneTo{Int64},Base.OneTo{Int64}}}:
- 0.0  0.0  0.0  0.0  0.0  0.0
- 0.0  0.0  0.0  0.0  0.0  0.0
- 0.0  0.0  0.0  0.0  0.0  0.0
- 0.0  0.0  0.0  0.0  0.0  0.0
- 0.0  0.0  0.0  0.0  0.0  0.0
+5×6 Zeros{Float64}
 
- julia> Zeros{Int}(5, 6)
- 5×6 Zeros{Int64,2,Tuple{Base.OneTo{Int64},Base.OneTo{Int64}}}:
-  0  0  0  0  0  0
-  0  0  0  0  0  0
-  0  0  0  0  0  0
-  0  0  0  0  0  0
-  0  0  0  0  0  0
+julia> typeof(Zeros(5,6))
+Zeros{Float64,2,Tuple{Base.OneTo{Int64},Base.OneTo{Int64}}}
+
+julia> Zeros{Int}(2, 3)
+2×3 Zeros{Int64}
 
 julia> Ones{Int}(5)
-5-element Ones{Int64,1,Tuple{Base.OneTo{Int64}}}:
- 1
- 1
- 1
- 1
- 1
+5-element Ones{Int64}
 
- julia> Eye{Int}(5)
+julia> Eye{Int}(5)
  5×5 Diagonal{Int64,Ones{Int64,1,Tuple{Base.OneTo{Int64}}}}:
   1  ⋅  ⋅  ⋅  ⋅
   ⋅  1  ⋅  ⋅  ⋅
@@ -56,16 +44,13 @@ julia> Ones{Int}(5)
   ⋅  ⋅  ⋅  ⋅  1
 
 julia> Fill(5.0f0, 3, 2)
-3×2 Fill{Float32,2,Tuple{Base.OneTo{Int64},Base.OneTo{Int64}}}:
- 5.0  5.0
- 5.0  5.0
- 5.0  5.0
+3×2 Fill{Float32}: entries equal to 5.0
 
 julia> Trues(2, 3)
-2×3 Ones{Bool,2,Tuple{Base.OneTo{Int64},Base.OneTo{Int64}}} = true
+2×3 Ones{Bool}
 
 julia> Falses(2)
-2-element Zeros{Bool,1,Tuple{Base.OneTo{Int64}}} = false
+2-element Zeros{Bool}
 ```
 
 They support conversion to other matrix types like `Array`, `SparseVector`, `SparseMatrix`, and `Diagonal`:
@@ -85,13 +70,7 @@ julia> SparseMatrixCSC(Zeros(5, 5))
 There is also support for offset index ranges:
 ```julia
 julia> Ones((-3:2, 1:2))
-Ones{Float64,2,Tuple{UnitRange{Int64},UnitRange{Int64}}} with indices -3:2×1:2:
- 1.0  1.0
- 1.0  1.0
- 1.0  1.0
- 1.0  1.0
- 1.0  1.0
- 1.0  1.0
+6×2 Ones{Float64,2,Tuple{UnitRange{Int64},UnitRange{Int64}}} with indices -3:2×1:2
 ```
 
 These types have methods that perform many operations efficiently,

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ julia> Eye{Int}(5)
   ⋅  ⋅  ⋅  1  ⋅
   ⋅  ⋅  ⋅  ⋅  1
 
-julia> Fill(5.0f0, 3, 2)
-3×2 Fill{Float32}: entries equal to 5.0
+julia> Fill(7.0f0, 3, 2)
+3×2 Fill{Float32}: entries equal to 7.0
 
 julia> Trues(2, 3)
 2×3 Ones{Bool}
@@ -63,10 +63,10 @@ julia> Matrix(Zeros(5, 5))
 julia> SparseMatrixCSC(Zeros(5, 5))
 5×5 SparseMatrixCSC{Float64,Int64} with 0 stored entries
 
-julia> Array(Fill(5, (2,3)))
+julia> Array(Fill(7, (2,3)))
 2×3 Array{Int64,2}:
- 5  5  5
- 5  5  5
+ 7  7  7
+ 7  7  7
 ```
 
 There is also support for offset index ranges,
@@ -75,8 +75,8 @@ and the type includes the `axes`:
 julia> Ones((-3:2, 1:2))
 6×2 Ones{Float64,2,Tuple{UnitRange{Int64},UnitRange{Int64}}} with indices -3:2×1:2
 
-julia> Fill(5, ((0:2), (-1:0)))
-3×2 Fill{Int64,2,Tuple{UnitRange{Int64},UnitRange{Int64}}} with indices 0:2×-1:0: entries equal to 5
+julia> Fill(7, ((0:2), (-1:0)))
+3×2 Fill{Int64,2,Tuple{UnitRange{Int64},UnitRange{Int64}}} with indices 0:2×-1:0: entries equal to 7
 
 julia> typeof(Zeros(5,6))
 Zeros{Float64,2,Tuple{Base.OneTo{Int64},Base.OneTo{Int64}}}

--- a/README.md
+++ b/README.md
@@ -26,9 +26,6 @@ Here are the matrix types:
 julia> Zeros(5, 6)
 5×6 Zeros{Float64}
 
-julia> typeof(Zeros(5,6))
-Zeros{Float64,2,Tuple{Base.OneTo{Int64},Base.OneTo{Int64}}}
-
 julia> Zeros{Int}(2, 3)
 2×3 Zeros{Int64}
 
@@ -65,12 +62,24 @@ julia> Matrix(Zeros(5, 5))
 
 julia> SparseMatrixCSC(Zeros(5, 5))
 5×5 SparseMatrixCSC{Float64,Int64} with 0 stored entries
+
+julia> Array(Fill(5, (2,3)))
+2×3 Array{Int64,2}:
+ 5  5  5
+ 5  5  5
 ```
 
-There is also support for offset index ranges:
+There is also support for offset index ranges,
+and the type includes the `axes`:
 ```julia
 julia> Ones((-3:2, 1:2))
 6×2 Ones{Float64,2,Tuple{UnitRange{Int64},UnitRange{Int64}}} with indices -3:2×1:2
+
+julia> Fill(5, ((0:2), (-1:0)))
+3×2 Fill{Int64,2,Tuple{UnitRange{Int64},UnitRange{Int64}}} with indices 0:2×-1:0: entries equal to 5
+
+julia> typeof(Zeros(5,6))
+Zeros{Float64,2,Tuple{Base.OneTo{Int64},Base.OneTo{Int64}}}
 ```
 
 These types have methods that perform many operations efficiently,


### PR DESCRIPTION
I forgot to update the README with the new types.  Fixed a couple typos while in there, as a service :)

An unintended consequence of the new `show` is that the examples in the README don't quite match the actual code output because they show the older more verbose output.  I used the new output format for the `Trues` and `Falses` additions, but I left the other ones untouched.  if you want me to update the README to match the actual output of show in the current code I can.  Personally I think it may be more intuitive in the README the way it is, but your call.