### PR TITLE
size -> axes in broadcast_shape

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FillArrays"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "0.9.1"
+version = "0.9.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -593,12 +593,15 @@ Base.show(io::IO, x::AbstractFill) =
     print(io, "$(summary(x)): entries equal to $(getindex_value(x))")
 Base.show(io::IO, x::Union{Zeros,Ones}) =
     print(io, "$(summary(x))")
-Base.array_summary(io::IO, ::Zeros{T}, inds::Tuple{Vararg{Base.OneTo}}) where T =
-    print(io, Base.dims2string(length.(inds)), " Zeros{$T}")
-Base.array_summary(io::IO, ::Ones{T}, inds::Tuple{Vararg{Base.OneTo}}) where T =
-    print(io, Base.dims2string(length.(inds)), " Ones{$T}")
-Base.array_summary(io::IO, a::Fill{T}, inds::Tuple{Vararg{Base.OneTo}}) where T =
-    print(io, Base.dims2string(length.(inds)), " Fill{$T}")
+
+if VERSION ≥ v"1.5"
+    Base.array_summary(io::IO, ::Zeros{T}, inds::Tuple{Vararg{Base.OneTo}}) where T =
+        print(io, Base.dims2string(length.(inds)), " Zeros{$T}")
+    Base.array_summary(io::IO, ::Ones{T}, inds::Tuple{Vararg{Base.OneTo}}) where T =
+        print(io, Base.dims2string(length.(inds)), " Ones{$T}")
+    Base.array_summary(io::IO, a::Fill{T}, inds::Tuple{Vararg{Base.OneTo}}) where T =
+        print(io, Base.dims2string(length.(inds)), " Fill{$T}")
+end
 
 function Base.show(io::IO, ::MIME"text/plain", x::AbstractFill)
     show(io, x)

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -590,7 +590,15 @@ Base.print_matrix_row(io::IO,
 
 # Display concise description of a Fill.
 Base.show(io::IO, x::AbstractFill) =
-    print(io, "$(summary(x)) = $(getindex_value(x))")
+    print(io, "$(summary(x)) with entries equal to $(getindex_value(x))")
+Base.show(io::IO, x::Union{Zeros,Ones}) =
+    print(io, "$(summary(x))")
+Base.array_summary(io::IO, ::Zeros{T}, inds::Tuple{Vararg{Base.OneTo}}) where T =
+    print(io, Base.dims2string(length.(inds)), " Zeros{$T}")
+Base.array_summary(io::IO, ::Ones{T}, inds::Tuple{Vararg{Base.OneTo}}) where T =
+    print(io, Base.dims2string(length.(inds)), " Ones{$T}")
+Base.array_summary(io::IO, a::Fill{T}, inds::Tuple{Vararg{Base.OneTo}}) where T =
+    print(io, Base.dims2string(length.(inds)), " Fill")
 
 function Base.show(io::IO, ::MIME"text/plain", x::AbstractFill)
     show(io, x)

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -590,7 +590,7 @@ Base.print_matrix_row(io::IO,
 
 # Display concise description of a Fill.
 Base.show(io::IO, x::AbstractFill) =
-    print(io, "$(summary(x)) with entries equal to $(getindex_value(x))")
+    print(io, "$(summary(x)): entries equal to $(getindex_value(x))")
 Base.show(io::IO, x::Union{Zeros,Ones}) =
     print(io, "$(summary(x))")
 Base.array_summary(io::IO, ::Zeros{T}, inds::Tuple{Vararg{Base.OneTo}}) where T =

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -598,7 +598,7 @@ Base.array_summary(io::IO, ::Zeros{T}, inds::Tuple{Vararg{Base.OneTo}}) where T 
 Base.array_summary(io::IO, ::Ones{T}, inds::Tuple{Vararg{Base.OneTo}}) where T =
     print(io, Base.dims2string(length.(inds)), " Ones{$T}")
 Base.array_summary(io::IO, a::Fill{T}, inds::Tuple{Vararg{Base.OneTo}}) where T =
-    print(io, Base.dims2string(length.(inds)), " Fill")
+    print(io, Base.dims2string(length.(inds)), " Fill{$T}")
 
 function Base.show(io::IO, ::MIME"text/plain", x::AbstractFill)
     show(io, x)

--- a/src/fillbroadcast.jl
+++ b/src/fillbroadcast.jl
@@ -24,14 +24,14 @@ broadcasted(::DefaultArrayStyle{N}, ::typeof(imag), r::Ones{T,N}) where {T,N} = 
 
 function broadcasted(::DefaultArrayStyle, op, a::AbstractFill, b::AbstractFill)
     val = op(getindex_value(a), getindex_value(b))
-    return Fill(val, broadcast_shape(size(a), size(b)))
+    return Fill(val, broadcast_shape(axes(a), axes(b)))
 end
 
 function _broadcasted_zeros(a, b)
-    return Zeros{promote_type(eltype(a), eltype(b))}(broadcast_shape(size(a), size(b)))
+    return Zeros{promote_type(eltype(a), eltype(b))}(broadcast_shape(axes(a), axes(b)))
 end
 function _broadcasted_ones(a, b)
-    return Ones{promote_type(eltype(a), eltype(b))}(broadcast_shape(size(a), size(b)))
+    return Ones{promote_type(eltype(a), eltype(b))}(broadcast_shape(axes(a), axes(b)))
 end
 
 broadcasted(::DefaultArrayStyle, ::typeof(+), a::Zeros, b::Zeros) = _broadcasted_zeros(a, b)
@@ -77,23 +77,23 @@ _range_convert(::Type{AbstractVector{T}}, a::AbstractUnitRange) where T = conver
 _range_convert(::Type{AbstractVector{T}}, a::AbstractRange) where T = convert(T,first(a)):step(a):convert(T,last(a))
 
 function broadcasted(::DefaultArrayStyle{1}, ::typeof(*), a::Ones{T}, b::AbstractRange{V}) where {T,V}
-    broadcast_shape(size(a), size(b)) # Check sizes are compatible.
+    broadcast_shape(axes(a), axes(b)) # Check sizes are compatible.
     return _range_convert(AbstractVector{promote_type(T,V)}, b)
 end
 
 function broadcasted(::DefaultArrayStyle{1}, ::typeof(*), a::AbstractRange{V}, b::Ones{T}) where {T,V}
-    broadcast_shape(size(a), size(b)) # Check sizes are compatible.
+    broadcast_shape(axes(a), axes(b)) # Check sizes are compatible.
     return _range_convert(AbstractVector{promote_type(T,V)}, a)
 end
 
 
 function broadcasted(::DefaultArrayStyle{1}, ::typeof(*), a::AbstractFill, b::AbstractRange)
-    broadcast_shape(size(a), size(b)) # Check sizes are compatible.
+    broadcast_shape(axes(a), axes(b)) # Check sizes are compatible.
     return broadcasted(*, getindex_value(a), b)
 end
 
 function broadcasted(::DefaultArrayStyle{1}, ::typeof(*), a::AbstractRange, b::AbstractFill)
-    broadcast_shape(size(a), size(b)) # Check sizes are compatible.
+    broadcast_shape(axes(a), axes(b)) # Check sizes are compatible.
     return broadcasted(*, a, getindex_value(b))
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -976,8 +976,15 @@ end
     end
 end
 
-@testset "print" begin
-    @test stringmime("text/plain", Zeros(3)) == "3-element Zeros{Float64}"
+if VERSION ≥ v"1.5"
+    @testset "print" begin
+        @test stringmime("text/plain", Zeros(3)) == "3-element Zeros{Float64}"
+        @test stringmime("text/plain", Ones(3)) == "3-element Ones{Float64}"
+        @test stringmime("text/plain", Fill(7,2)) == "2-element Fill{Int64}: entries equal to 7"
+        @test stringmime("text/plain", Zeros(3,2)) == "3×2 Zeros{Float64}"
+        @test stringmime("text/plain", Ones(3,2)) == "3×2 Ones{Float64}"
+        @test stringmime("text/plain", Fill(7,2,3)) == "2×3 Fill{Int64}: entries equal to 7"
+    end
 end
 
 @testset "reshape" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -561,6 +561,11 @@ end
 
         @test conj.(Zeros(5)) ≡ Zeros(5)
         @test conj.(Zeros{ComplexF64}(5)) ≡ Zeros{ComplexF64}(5)
+
+        @test_throws DimensionMismatch broadcast(*, Ones(3), 1:6)
+        @test_throws DimensionMismatch broadcast(*, 1:6, Ones(3))
+        @test_throws DimensionMismatch broadcast(*, Fill(1,3), 1:6)
+        @test_throws DimensionMismatch broadcast(*, 1:6, Fill(1,3))
     end
 
     @testset "support Ref" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -977,7 +977,7 @@ end
 end
 
 @testset "print" begin
-    @test stringmime("text/plain", Zeros(3)) == "3-element Zeros{Float64,1,Tuple{Base.OneTo{$Int}}} = 0.0"
+    @test stringmime("text/plain", Zeros(3)) == "3-element Zeros{Float64}"
 end
 
 @testset "reshape" begin


### PR DESCRIPTION
This calls `axes` instead of `size` in broadcasting to work better with BlockArrays.jl.

I've also improved the printing to be more descriptive and less verbose, @JeffFessler are you happy with this change?