### PR TITLE
Nested special broadcast, throw error when special broadcast fails

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FillArrays"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "0.9.2"
+version = "0.9.3"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/fillbroadcast.jl
+++ b/src/fillbroadcast.jl
@@ -27,21 +27,11 @@ function broadcasted(::DefaultArrayStyle, op, a::AbstractFill, b::AbstractFill)
     return Fill(val, broadcast_shape(axes(a), axes(b)))
 end
 
-function _broadcasted_zeros(a::AbstractArray{T}, b::AbstractArray{V}) where {T,V}
-    return Zeros{promote_type(T,V)}(broadcast_shape(axes(a), axes(b)))
-end
-function _broadcasted_ones(a::AbstractArray{T}, b::AbstractArray{V}) where {T,V}
-    return Ones{promote_type(T,V)}(broadcast_shape(axes(a), axes(b)))
-end
+_broadcasted_eltype(a) = eltype(a)
+_broadcasted_eltype(a::Base.Broadcast.Broadcasted) = Base.Broadcast.combine_eltypes(a.f, a.args)
 
-function _broadcasted_zeros(a::Base.Broadcast.Broadcasted, b::AbstractArray{V}) where V
-    return Zeros{promote_type(Base.Broadcast.combine_eltypes(a.f, a.args),V)}(broadcast_shape(axes(a), axes(b)))
-end
-function _broadcasted_ones(a::AbstractArray{T}, b::Base.Broadcast.Broadcasted) where T
-    return Ones{promote_type(T,Base.Broadcast.combine_eltypes(b.f, b.args))}(broadcast_shape(axes(a), axes(b)))
-end
-
-
+_broadcasted_zeros(a, b) = Zeros{promote_type(_broadcasted_eltype(a), _broadcasted_eltype(b))}(broadcast_shape(axes(a), axes(b)))
+_broadcasted_ones(a, b) = Ones{promote_type(_broadcasted_eltype(a), _broadcasted_eltype(b))}(broadcast_shape(axes(a), axes(b)))
 
 broadcasted(::DefaultArrayStyle, ::typeof(+), a::Zeros, b::Zeros) = _broadcasted_zeros(a, b)
 broadcasted(::DefaultArrayStyle, ::typeof(+), a::Ones, b::Zeros) = _broadcasted_ones(a, b)

--- a/src/fillbroadcast.jl
+++ b/src/fillbroadcast.jl
@@ -27,12 +27,21 @@ function broadcasted(::DefaultArrayStyle, op, a::AbstractFill, b::AbstractFill)
     return Fill(val, broadcast_shape(axes(a), axes(b)))
 end
 
-function _broadcasted_zeros(a, b)
-    return Zeros{promote_type(eltype(a), eltype(b))}(broadcast_shape(axes(a), axes(b)))
+function _broadcasted_zeros(a::AbstractArray{T}, b::AbstractArray{V}) where {T,V}
+    return Zeros{promote_type(T,V)}(broadcast_shape(axes(a), axes(b)))
 end
-function _broadcasted_ones(a, b)
-    return Ones{promote_type(eltype(a), eltype(b))}(broadcast_shape(axes(a), axes(b)))
+function _broadcasted_ones(a::AbstractArray{T}, b::AbstractArray{V}) where {T,V}
+    return Ones{promote_type(T,V)}(broadcast_shape(axes(a), axes(b)))
 end
+
+function _broadcasted_zeros(a::Base.Broadcast.Broadcasted, b::AbstractArray{V}) where V
+    return Zeros{promote_type(Base.Broadcast.combine_eltypes(a.f, a.args),V)}(broadcast_shape(axes(a), axes(b)))
+end
+function _broadcasted_ones(a::AbstractArray{T}, b::Base.Broadcast.Broadcasted) where T
+    return Ones{promote_type(T,Base.Broadcast.combine_eltypes(b.f, b.args))}(broadcast_shape(axes(a), axes(b)))
+end
+
+
 
 broadcasted(::DefaultArrayStyle, ::typeof(+), a::Zeros, b::Zeros) = _broadcasted_zeros(a, b)
 broadcasted(::DefaultArrayStyle, ::typeof(+), a::Ones, b::Zeros) = _broadcasted_ones(a, b)
@@ -51,6 +60,7 @@ for op in (:*, :/)
         broadcasted(::DefaultArrayStyle, ::typeof($op), a::Zeros, b::Number) = _broadcasted_zeros(a, b)
         broadcasted(::DefaultArrayStyle, ::typeof($op), a::Zeros, b::AbstractRange) = _broadcasted_zeros(a, b)
         broadcasted(::DefaultArrayStyle, ::typeof($op), a::Zeros, b::AbstractArray) = _broadcasted_zeros(a, b)
+        broadcasted(::DefaultArrayStyle, ::typeof($op), a::Zeros, b::Base.Broadcast.Broadcasted) = _broadcasted_zeros(a, b)
         broadcasted(::DefaultArrayStyle{1}, ::typeof($op), a::Zeros, b::AbstractRange) = _broadcasted_zeros(a, b)
     end
 end
@@ -62,6 +72,7 @@ for op in (:*, :\)
         broadcasted(::DefaultArrayStyle, ::typeof($op), a::Number, b::Zeros) = _broadcasted_zeros(a, b)
         broadcasted(::DefaultArrayStyle, ::typeof($op), a::AbstractRange, b::Zeros) = _broadcasted_zeros(a, b)
         broadcasted(::DefaultArrayStyle, ::typeof($op), a::AbstractArray, b::Zeros) = _broadcasted_zeros(a, b)
+        broadcasted(::DefaultArrayStyle, ::typeof($op), a::Base.Broadcast.Broadcasted, b::Zeros) = _broadcasted_zeros(a, b)
         broadcasted(::DefaultArrayStyle{1}, ::typeof($op), a::AbstractRange, b::Zeros) = _broadcasted_zeros(a, b)
     end
 end

--- a/src/fillbroadcast.jl
+++ b/src/fillbroadcast.jl
@@ -86,6 +86,17 @@ function broadcasted(::DefaultArrayStyle{1}, ::typeof(*), a::AbstractRange{V}, b
     return _range_convert(AbstractVector{promote_type(T,V)}, a)
 end
 
+function broadcasted(::DefaultArrayStyle{2}, ::typeof(*), a::Ones{T}, b::AbstractMatrix{V}) where {T,V}
+    broadcast_shape(axes(a), axes(b)) # Check sizes are compatible.
+    return convert(AbstractMatrix{promote_type(T,V)}, b)
+end
+
+function broadcasted(::DefaultArrayStyle{2}, ::typeof(*), a::AbstractMatrix{V}, b::Ones{T}) where {T,V}
+    broadcast_shape(axes(a), axes(b)) # Check sizes are compatible.
+    return convert(AbstractMatrix{promote_type(T,V)}, a)
+end
+
+
 
 function broadcasted(::DefaultArrayStyle{1}, ::typeof(*), a::AbstractFill, b::AbstractRange)
     broadcast_shape(axes(a), axes(b)) # Check sizes are compatible.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -537,13 +537,20 @@ end
     @test imag(Ones{ComplexF64}(10)) isa Zeros{Float64}
     @test imag(Ones{ComplexF64}(10,10)) isa Zeros{Float64}
 
-    rnge = range(-5.0, step=1.0, length=10)
-    @test broadcast(*, Fill(5.0, 10), rnge) == broadcast(*, 5.0, rnge)
-    @test broadcast(*, Zeros(10, 10), rnge) == zeros(10, 10)
-    @test broadcast(*, rnge, Zeros(10, 10)) == zeros(10, 10)
-    @test_throws DimensionMismatch broadcast(*, Fill(5.0, 11), rnge)
-    @test broadcast(*, rnge, Fill(5.0, 10)) == broadcast(*, rnge, 5.0)
-    @test_throws DimensionMismatch broadcast(*, rnge, Fill(5.0, 11))
+    @testset "range broadcast" begin
+        rnge = range(-5.0, step=1.0, length=10)
+        @test broadcast(*, Fill(5.0, 10), rnge) == broadcast(*, 5.0, rnge)
+        @test broadcast(*, Zeros(10, 10), rnge) == zeros(10, 10)
+        @test broadcast(*, rnge, Zeros(10, 10)) == zeros(10, 10)
+        @test_throws DimensionMismatch broadcast(*, Fill(5.0, 11), rnge)
+        @test broadcast(*, rnge, Fill(5.0, 10)) == broadcast(*, rnge, 5.0)
+        @test_throws DimensionMismatch broadcast(*, rnge, Fill(5.0, 11))
+
+        # following should pass using alternative implementation in code
+        deg = 5:5
+        @test_throws ArgumentError @inferred(broadcast(*, Fill(5.0, 10), deg)) == broadcast(*, fill(5.0,10), deg)
+        @test_throws ArgumentError @inferred(broadcast(*, deg, Fill(5.0, 10))) == broadcast(*, deg, fill(5.0,10))
+    end
 
     @testset "Special Zeros/Ones" begin
         @test broadcast(+,Zeros(5)) ≡ broadcast(-,Zeros(5)) ≡ Zeros(5)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -578,7 +578,7 @@ end
 
         @testset "Nested" begin
             @test randn(5) .\ rand(5) .* Zeros(5) ≡ Zeros(5)
-            @test broadcast(*, Zeros(5), Base.broadcasted(\, randn(5), rand(5))) ≡ Zeros(5)
+            @test broadcast(*, Zeros(5), Base.Broadcast.broadcasted(\, randn(5), rand(5))) ≡ Zeros(5)
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -542,6 +542,8 @@ end
         @test broadcast(*, Fill(5.0, 10), rnge) == broadcast(*, 5.0, rnge)
         @test broadcast(*, Zeros(10, 10), rnge) == zeros(10, 10)
         @test broadcast(*, rnge, Zeros(10, 10)) == zeros(10, 10)
+        @test broadcast(*, Ones{Int}(10), rnge) ≡ rnge
+        @test broadcast(*, rnge, Ones{Int}(10)) ≡ rnge
         @test_throws DimensionMismatch broadcast(*, Fill(5.0, 11), rnge)
         @test broadcast(*, rnge, Fill(5.0, 10)) == broadcast(*, rnge, 5.0)
         @test_throws DimensionMismatch broadcast(*, rnge, Fill(5.0, 11))
@@ -573,6 +575,11 @@ end
         @test_throws DimensionMismatch broadcast(*, 1:6, Ones(3))
         @test_throws DimensionMismatch broadcast(*, Fill(1,3), 1:6)
         @test_throws DimensionMismatch broadcast(*, 1:6, Fill(1,3))
+
+        @testset "Nested" begin
+            @test randn(5) .\ rand(5) .* Zeros(5) ≡ Zeros(5)
+            @test broadcast(*, Zeros(5), Base.broadcasted(\, randn(5), rand(5))) ≡ Zeros(5)
+        end
     end
 
     @testset "support Ref" begin


### PR DESCRIPTION
There was a bug where `broadcast(*, x::AbstractFill, r::AbstractRange)` and friends would return a wrong result for the special case where `length(r) == 1`. This now throws an error.

I added in comments a type-stable fix using `StepRangeLen`, which allows the production of an abstract fill via `step = 0`. I decided not to roll that out right now as it might produce issues down stream, and I didn't want to deal with that right now.