### PR TITLE
Avoid allocation in FillArrays.Zero addition

### DIFF
--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -162,11 +162,11 @@ end
 # Zeros +/- Array and Array +/- Zeros
 function +(a::Zeros{T, N}, b::AbstractArray{V, N}) where {T, V, N}
     size(a) ≠ size(b) && throw(DimensionMismatch("dimensions must match."))
-    return AbstractArray{promote_type(T,V),N}(b)
+    return T == V ? b : AbstractArray{promote_type(T,V),N}(b)
 end
 function +(a::Array{T, N}, b::Zeros{V, N}) where {T, V, N}
     size(a) ≠ size(b) && throw(DimensionMismatch("dimensions must match."))
-    return AbstractArray{promote_type(T,V),N}(a)
+    return T == V ? a : AbstractArray{promote_type(T,V),N}(a)
 end
 
 function -(a::Zeros{T, N}, b::AbstractArray{V, N}) where {T, V, N}


### PR DESCRIPTION
`X` is a dense matrix, `Z` is a `FillArrays.Zero`.

Before this PR:

```Julia
julia> @btime $X+$Z
  70.028 ns (1 allocation: 896 bytes)
```

Afterwards:
```julia
julia> @btime $X+$Z
  4.327 ns (0 allocations: 0 bytes)
```

(Here `X` is a `Matrix{Float64}` and `Z` is a `FillArrays.Zero{Float64}` but the PR addresses all cases where the type parameters are equal.)