### PR TITLE
Implement `sum(f, ::AbstractFill)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FillArrays"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "0.10.1"
+version = "0.10.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -489,7 +489,10 @@ end
 sum(x::AbstractFill) = getindex_value(x)*length(x)
 sum(x::Zeros) = getindex_value(x)
 
-sum(f, x::AbstractFill) = length(x) * f(getindex_value(x))
+# define `sum(::Callable, ::AbstractFill)` to avoid method ambiguity errors on Julia 1.0
+sum(f, x::AbstractFill) = _sum(f, x)
+sum(f::Base.Callable, x::AbstractFill) = _sum(f, x)
+_sum(f, x::AbstractFill) = length(x) * f(getindex_value(x))
 
 cumsum(x::AbstractFill{<:Any,1}) = range(getindex_value(x); step=getindex_value(x),
                                                     length=length(x))

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -489,6 +489,8 @@ end
 sum(x::AbstractFill) = getindex_value(x)*length(x)
 sum(x::Zeros) = getindex_value(x)
 
+sum(f, x::AbstractFill) = length(x) * f(getindex_value(x))
+
 cumsum(x::AbstractFill{<:Any,1}) = range(getindex_value(x); step=getindex_value(x),
                                                     length=length(x))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -508,18 +508,23 @@ end
 
 @testset "Cumsum and diff" begin
     @test sum(Fill(3,10)) ≡ 30
+    @test sum(x -> x + 1, Fill(3,10)) ≡ 40
     @test cumsum(Fill(3,10)) ≡ 3:3:30
 
     @test sum(Ones(10)) ≡ 10.0
+    @test sum(x -> x + 1, Ones(10)) ≡ 20.0
     @test cumsum(Ones(10)) ≡ 1.0:10.0
 
     @test sum(Ones{Int}(10)) ≡ 10
+    @test sum(x -> x + 1, Ones{Int}(10)) ≡ 20
     @test cumsum(Ones{Int}(10)) ≡ Base.OneTo(10)
 
     @test sum(Zeros(10)) ≡ 0.0
+    @test sum(x -> x + 1, Zeros(10)) ≡ 10.0
     @test cumsum(Zeros(10)) ≡ Zeros(10)
 
     @test sum(Zeros{Int}(10)) ≡ 0
+    @test sum(x -> x + 1, Zeros{Int}(10)) ≡ 10
     @test cumsum(Zeros{Int}(10)) ≡ Zeros{Int}(10)
 
     @test cumsum(Zeros{Bool}(10)) ≡ Zeros{Bool}(10)


### PR DESCRIPTION
I noticed that `sum(f, ::AbstractFill)` is currently not implemented and added it in this PR, together with some tests and a version bump.