### PR TITLE
Check if a value is present in an AbstractFill without iterating over it

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FillArrays"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "0.11.1"
+version = "0.11.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -6,7 +6,7 @@ import Base: size, getindex, setindex!, IndexStyle, checkbounds, convert,
     +, -, *, /, \, diff, sum, cumsum, maximum, minimum, sort, sort!,
     any, all, axes, isone, iterate, unique, allunique, permutedims, inv,
     copy, vec, setindex!, count, ==, reshape, _throw_dmrs, map, zero,
-    show, view
+    show, view, in
 
 import LinearAlgebra: rank, svdvals!, tril, triu, tril!, triu!, diag, transpose, adjoint, fill!,
     norm2, norm1, normInf, normMinusInf, normp, lmul!, rmul!, diagzero, AbstractTriangular, AdjointAbsVec
@@ -571,6 +571,12 @@ all(x::AbstractFill) = all(getindex_value(x))
 count(x::Ones{Bool}) = length(x)
 count(x::Zeros{Bool}) = 0
 count(f, x::AbstractFill) = f(getindex_value(x)) ? length(x) : 0
+
+#########
+# in
+#########
+in(x, A::Union{Ones, Zeros, Fill}) = x == getindex_value(A)
+in(x, A::RectDiagonal) = iszero(x) || x in A.diag
 
 include("fillalgebra.jl")
 include("fillbroadcast.jl")

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -575,7 +575,7 @@ count(f, x::AbstractFill) = f(getindex_value(x)) ? length(x) : 0
 #########
 # in
 #########
-in(x, A::Union{Ones, Zeros, Fill}) = x == getindex_value(A)
+in(x, A::AbstractFill) = x == getindex_value(A)
 in(x, A::RectDiagonal) = iszero(x) || x in A.diag
 
 include("fillalgebra.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -163,6 +163,17 @@ import FillArrays: AbstractFill, RectDiagonal, SquareEye
         @test vec(Zeros{Int}(5,10,20)) ≡ Zeros{Int}(1000)
         @test vec(Fill(1,5,10)) ≡ Fill(1,50)
     end
+
+    @testset "in" begin
+        for T in [Zeros, Ones, Fill, Trues, Falses]
+            A = T(4, 4)
+            @test FillArrays.getindex_value(A) in A
+            @test !(FillArrays.getindex_value(A) + 1 in A)
+        end
+        A = FillArrays.RectDiagonal([1, 2, 3])
+        @test 3 in A
+        @test !(4 in A)
+    end
 end
 
 @testset "indexing" begin


### PR DESCRIPTION
There's often no need to iterate over these special arrays to check if a value is contained in them.

Now 

```julia
julia> A = Ones(10_000, 10_000);

julia> @btime 4000 in $(Ref(A))[]
  2.670 ns (0 allocations: 0 bytes)
false

julia> @btime 1 in $(Ref(A))[]
  2.670 ns (0 allocations: 0 bytes)
true
```