### PR TITLE
Add cat, vcat and hcat

### DIFF
--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -589,6 +589,7 @@ end
 include("fillalgebra.jl")
 include("fillbroadcast.jl")
 include("trues.jl")
+include("fillcat.jl")
 
 ##
 # print

--- a/src/fillcat.jl
+++ b/src/fillcat.jl
@@ -5,7 +5,7 @@ function Base.cat_t(::Type{T}, fs::Fill...; dims) where T
 
     catdims = Base.dims2cat(dims)
 
-    # Note, when dims is a tuple the output gets zero padded and we can't use a Fill unless it is all zeros too
+    # Note, when dims is a tuple the output gets zero padded and we can't use a Fill unless it is all zeros
     allvals[] !== zero(T) && sum(catdims) > 1 && return Base._cat_t(dims, T, fs...)
 
     shape = Base.cat_shape(catdims, map(Base.cat_size, fs)::Tuple{Vararg{Union{Int,Dims}}})::Dims
@@ -14,3 +14,14 @@ end
 
 Base.vcat(vs::Fill...) = cat(vs...;dims=Val(1))
 Base.hcat(vs::Fill...) = cat(vs...;dims=Val(2))
+
+
+function Base.cat_t(::Type{T}, fs::Zeros...; dims) where T
+    catdims = Base.dims2cat(dims)
+    shape = Base.cat_shape(catdims, map(Base.cat_size, fs)::Tuple{Vararg{Union{Int,Dims}}})::Dims
+    return Zeros{T}(shape)
+end
+
+Base.vcat(vs::Zeros...) = cat(vs...;dims=Val(1))
+Base.hcat(vs::Zeros...) = cat(vs...;dims=Val(2))
+

--- a/src/fillcat.jl
+++ b/src/fillcat.jl
@@ -9,7 +9,7 @@ function Base.cat_t(::Type{T}, fs::Fill...; dims) where T
     # There might be some cases when it does not get padded which are not considered here
     allvals[] !== zero(T) && sum(catdims) > 1 && return Base._cat_t(dims, T, fs...)
 
-    shape = Base.cat_shape(catdims, map(Base.cat_size, fs)::Tuple{Vararg{Union{Int,Dims}}})::Dims
+    shape = cat_shape_fill(catdims, fs)
     return Fill(convert(T, fs[1].value), shape)
 end
 
@@ -19,7 +19,7 @@ Base.hcat(vs::Fill...) = cat(vs...;dims=Val(2))
 
 function Base.cat_t(::Type{T}, fs::Zeros...; dims) where T
     catdims = Base.dims2cat(dims)
-    shape = Base.cat_shape(catdims, map(Base.cat_size, fs)::Tuple{Vararg{Union{Int,Dims}}})::Dims
+    shape = cat_shape_fill(catdims, fs)
     return Zeros{T}(shape)
 end
 
@@ -34,10 +34,16 @@ function Base.cat_t(::Type{T}, fs::Ones...; dims) where T
     # There might be some cases when it does not get padded which are not considered here
     sum(catdims) > 1 && return Base._cat_t(dims, T, fs...)
 
-    shape = Base.cat_shape(catdims, map(Base.cat_size, fs)::Tuple{Vararg{Union{Int,Dims}}})::Dims
+    shape = cat_shape_fill(catdims, fs)
     return Ones{T}(shape)
 end
 
 Base.vcat(vs::Ones...) = cat(vs...;dims=Val(1))
 Base.hcat(vs::Ones...) = cat(vs...;dims=Val(2))
 
+
+if VERSION < v"1.6-"
+    cat_shape_fill(catdims, fs) = Base.cat_shape(catdims, (), map(Base.cat_size, fs)...)
+else
+    cat_shape_fill(catdims, fs) = Base.cat_shape(catdims, map(Base.cat_size, fs)::Tuple{Vararg{Union{Int,Dims}}})::Dims
+end

--- a/src/fillcat.jl
+++ b/src/fillcat.jl
@@ -7,7 +7,11 @@ function Base.cat_t(::Type{T}, fs::Fill...; dims) where T
 
     # When dims is a tuple the output gets zero padded and we can't use a Fill unless it is all zeros
     # There might be some cases when it does not get padded which are not considered here
-    allvals[] !== zero(T) && sum(catdims) > 1 && return Base._cat_t(dims, T, fs...)
+    
+    if sum(catdims) > 1 
+        allvals[] isa Number || return Base._cat_t(dims, T, fs...)
+        allvals[] !== zero(T) && return Base._cat_t(dims, T, fs...)
+    end
 
     shape = cat_shape_fill(catdims, fs)
     return Fill(convert(T, fs[1].value), shape)

--- a/src/fillcat.jl
+++ b/src/fillcat.jl
@@ -5,7 +5,8 @@ function Base.cat_t(::Type{T}, fs::Fill...; dims) where T
 
     catdims = Base.dims2cat(dims)
 
-    # Note, when dims is a tuple the output gets zero padded and we can't use a Fill unless it is all zeros
+    # When dims is a tuple the output gets zero padded and we can't use a Fill unless it is all zeros
+    # There might be some cases when it does not get padded which are not considered here
     allvals[] !== zero(T) && sum(catdims) > 1 && return Base._cat_t(dims, T, fs...)
 
     shape = Base.cat_shape(catdims, map(Base.cat_size, fs)::Tuple{Vararg{Union{Int,Dims}}})::Dims
@@ -24,4 +25,19 @@ end
 
 Base.vcat(vs::Zeros...) = cat(vs...;dims=Val(1))
 Base.hcat(vs::Zeros...) = cat(vs...;dims=Val(2))
+
+
+function Base.cat_t(::Type{T}, fs::Ones...; dims) where T
+    catdims = Base.dims2cat(dims)
+
+    # When dims is a tuple the output gets zero padded so we can't return a Ones
+    # There might be some cases when it does not get padded which are not considered here
+    sum(catdims) > 1 && return Base._cat_t(dims, T, fs...)
+
+    shape = Base.cat_shape(catdims, map(Base.cat_size, fs)::Tuple{Vararg{Union{Int,Dims}}})::Dims
+    return Ones{T}(shape)
+end
+
+Base.vcat(vs::Ones...) = cat(vs...;dims=Val(1))
+Base.hcat(vs::Ones...) = cat(vs...;dims=Val(2))
 

--- a/src/fillcat.jl
+++ b/src/fillcat.jl
@@ -1,0 +1,16 @@
+
+function Base.cat_t(::Type{T}, fs::Fill...; dims) where T
+    allvals = unique([f.value for f in fs])
+    length(allvals) > 1 && return Base._cat_t(dims, T,  fs...)
+
+    catdims = Base.dims2cat(dims)
+
+    # Note, when dims is a tuple the output gets zero padded and we can't use a Fill unless it is all zeros too
+    allvals[] !== zero(T) && sum(catdims) > 1 && return Base._cat_t(dims, T, fs...)
+
+    shape = Base.cat_shape(catdims, map(Base.cat_size, fs)::Tuple{Vararg{Union{Int,Dims}}})::Dims
+    return Fill(convert(T, fs[1].value), shape)
+end
+
+Base.vcat(vs::Fill...) = cat(vs...;dims=Val(1))
+Base.hcat(vs::Fill...) = cat(vs...;dims=Val(2))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1259,7 +1259,8 @@ end
             @testset "Dim $dims" for dims in (
                 (1,2),
                 (2,3),
-                (1,3,4)
+                (1,3,4),
+                Iterators.take(3:5, 2)
             )
                 # This inserts a bunch of zeros so we can no longer assume the answer is a Fill
                 @test cat(Fill(1, s), Fill(1, s); dims=dims) == cat(fill(1, s), fill(1,s); dims=dims)
@@ -1300,7 +1301,8 @@ end
                 2,
                 Val(3),
                 (1,2),
-                (2,3)
+                (2,3),
+                Iterators.take(3:5, 2)
             )
                 res = cat(Zeros(s), Zeros(s); dims=dims) 
                 @test res isa Zeros
@@ -1349,7 +1351,8 @@ end
             @testset "Dim $dims" for dims in (
                 (1,2),
                 (2,3),
-                (1,3,4)
+                (1,3,4),
+                Iterators.take(3:5, 2)
             )
                 # This inserts a bunch of zeros so we can no longer assume the answer is a Fill
                 @test cat(Ones(s), Ones(s); dims=dims) == cat(ones(s), ones(s); dims=dims)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1327,4 +1327,47 @@ end
         end
     end
     
+    @testset "Ones" begin
+        @testset "cat shape $s" for s in
+            (
+                0,
+                1,
+                (2, 0),
+                (0, 2),
+                (2,3,4)
+            )
+
+            @testset "Dim $dims" for dims in (1,2,3, Val(4)) 
+                res = cat(Ones(s), Ones(s); dims=dims)
+                @test res isa Ones
+                @test res == cat(ones(s), ones(s); dims=dims)
+
+                res = cat(Ones{Float64}(s), Ones{Int}(s); dims=dims)
+                @test res isa Ones
+                @test res == cat(ones(Float64, s), ones(Int, s); dims=dims)
+            end
+            @testset "Dim $dims" for dims in (
+                (1,2),
+                (2,3),
+                (1,3,4)
+            )
+                # This inserts a bunch of zeros so we can no longer assume the answer is a Fill
+                @test cat(Ones(s), Ones(s); dims=dims) == cat(ones(s), ones(s); dims=dims)
+            end
+        end
+        
+        @testset "vcat" begin
+            # vcat just delegates to cat, so we basically just test that here
+            res = vcat(Ones(3), Ones(4))
+            @test res isa Ones
+            @test res == vcat(ones(3), fill(1,4)) 
+        end
+
+        @testset "hcat" begin
+            # hcat just delegates to cat, so we basically just test that here
+            res = hcat(Ones(2), Ones(2))
+            @test res isa Ones
+            @test res == hcat(ones(2), fill(1,2)) 
+        end
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1254,6 +1254,10 @@ end
                 @test res isa Fill
                 @test res == cat(fill(1.0, s), fill(1, s); dims=dims)
 
+                res = cat(Fill(:a, s), Fill(:a, s); dims=dims)
+                @test res isa Fill
+                @test res == cat(fill(:a, s), fill(:a, s);dims=dims)
+
                 @test cat(Fill(1, s), Fill(2, s);dims=dims) == cat(fill(1, s), fill(2, s);dims=dims)
             end
             @testset "Dim $dims" for dims in (

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1241,19 +1241,16 @@ end
                 0,
                 1,
                 (2, 0),
-                (2, 3),
                 (0, 2),
                 (2,3,4)
             )
 
             @testset "Dim $dims" for dims in (1,2,3, Val(4)) 
                 res = cat(Fill(1, s), Fill(1, s); dims=dims)
-
                 @test res isa Fill
                 @test res == cat(fill(1, s), fill(1, s); dims=dims)
 
                 res = cat(Fill(1.0, s), Fill(1, s); dims=dims)
-
                 @test res isa Fill
                 @test res == cat(fill(1.0, s), fill(1, s); dims=dims)
 
@@ -1274,17 +1271,60 @@ end
         end
         
         @testset "vcat" begin
-            # Vcat just delegates to cat, so we basically just test that here
+            # vcat just delegates to cat, so we basically just test that here
             res = vcat(Fill(1, 3), Fill(1, 4))
             @test res isa Fill
             @test res == vcat(fill(1, 3), fill(1,4)) 
         end
 
         @testset "hcat" begin
-            # Vcat just delegates to cat, so we basically just test that here
+            # hcat just delegates to cat, so we basically just test that here
             res = hcat(Fill(1, 2), Fill(1, 2))
             @test res isa Fill
             @test res == hcat(fill(1, 2), fill(1,2)) 
         end
     end
+
+    @testset "Zeros" begin
+        @testset "cat shape $s" for s in 
+            (
+                0,
+                1,
+                (2, 0),
+                (0, 2),
+                (2,3,4)
+            )
+
+            @testset "Dim $dims" for dims in (
+                1,
+                2,
+                Val(3),
+                (1,2),
+                (2,3)
+            )
+                res = cat(Zeros(s), Zeros(s); dims=dims) 
+                @test res isa Zeros
+                @test res == cat(zeros(s), zeros(s); dims=dims)
+
+                res = cat(Zeros{Float64}(s), Zeros{Int}(s); dims=dims) 
+                @test res isa Zeros
+                @test res == cat(zeros(Float64, s), zeros(Int, s); dims=dims)
+            end
+        end
+
+        @testset "vcat" begin
+            # vcat just delegates to cat, so we basically just test that here
+            res = vcat(Zeros(3), Zeros(4))
+            @test res isa Zeros
+            @test res == vcat(zeros(3), zeros(4)) 
+        end
+
+        @testset "hcat" begin
+            # hcat just delegates to cat, so we basically just test that here
+            res = vcat(Zeros(2), Zeros(2))
+            @test res isa Zeros
+            @test res == vcat(zeros(2), zeros(2)) 
+        end
+    end
+    
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1232,3 +1232,59 @@ end
         @test convert(Fill, transpose(a)) ≡ Fill(2.0,1,5)
     end
 end
+
+@testset "Concatenation" begin
+
+    @testset "Fill" begin
+        @testset "cat shape $s" for s in
+            (
+                0,
+                1,
+                (2, 0),
+                (2, 3),
+                (0, 2),
+                (2,3,4)
+            )
+
+            @testset "Dim $dims" for dims in (1,2,3, Val(4)) 
+                res = cat(Fill(1, s), Fill(1, s); dims=dims)
+
+                @test res isa Fill
+                @test res == cat(fill(1, s), fill(1, s); dims=dims)
+
+                res = cat(Fill(1.0, s), Fill(1, s); dims=dims)
+
+                @test res isa Fill
+                @test res == cat(fill(1.0, s), fill(1, s); dims=dims)
+
+                @test cat(Fill(1, s), Fill(2, s);dims=dims) == cat(fill(1, s), fill(2, s);dims=dims)
+            end
+            @testset "Dim $dims" for dims in (
+                (1,2),
+                (2,3),
+                (1,3,4)
+            )
+                # This inserts a bunch of zeros so we can no longer assume the answer is a Fill
+                @test cat(Fill(1, s), Fill(1, s); dims=dims) == cat(fill(1, s), fill(1,s); dims=dims)
+                @test cat(Fill(0, s), Fill(0, s); dims=dims) isa Fill
+                @test cat(Fill(0.0, s), Fill(0.0, s); dims=dims) isa Fill
+
+                @test cat(Fill(1, s), Fill(2, s);dims=dims) == cat(fill(1, s), fill(2, s);dims=dims)
+            end
+        end
+        
+        @testset "vcat" begin
+            # Vcat just delegates to cat, so we basically just test that here
+            res = vcat(Fill(1, 3), Fill(1, 4))
+            @test res isa Fill
+            @test res == vcat(fill(1, 3), fill(1,4)) 
+        end
+
+        @testset "hcat" begin
+            # Vcat just delegates to cat, so we basically just test that here
+            res = hcat(Fill(1, 2), Fill(1, 2))
+            @test res isa Fill
+            @test res == hcat(fill(1, 2), fill(1,2)) 
+        end
+    end
+end


### PR DESCRIPTION
Fixes #23 in case the offer from 2018 still stands :)

There where a few more edge cases than I had first thought and I hope the testing covers them all. 

There are a couple of cases where it is not possible to return a `Fill` or `Ones` and then a normal `Array` is returned. Same goes for mixed types (e.g. `vcat(Fill(0, 3), Zeros(4))` as I don't think there exist a feasible way to handle those cases. 

Just close with prejudice if this is not wanted any more.

I guess this is kind of breaking as there might be code out there which (perhaps inadvertently) relies on concatenation returning an `Array`.