### PR TITLE
Avoid StackOverflow in view

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FillArrays"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "0.11.5"
+version = "0.11.6"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -650,8 +650,12 @@ getindex_value(a::SubArray) = getindex_value(parent(a))
 Base.@propagate_inbounds view(A::AbstractFill{<:Any,N}, kr::AbstractArray{Bool,N}) where N = _fill_getindex(A, kr)
 Base.@propagate_inbounds view(A::AbstractFill{<:Any,1}, kr::AbstractVector{Bool}) = _fill_getindex(A, kr)
 Base.@propagate_inbounds view(A::AbstractFill{<:Any,N}, I::Vararg{Union{Real, AbstractArray}, N}) where N =
-    _fill_getindex(A, I...)
-Base.@propagate_inbounds view(A::AbstractFill{<:Any,N}, I::Vararg{Real, N}) where N =
-    Base.invoke(view, Tuple{AbstractArray,Vararg{Any,N}}, A, I...)
+    _fill_getindex(A, Base.to_indices(A,I)...)
+
+# not getindex since we need array-like indexing
+function Base.@propagate_inbounds view(A::AbstractFill{<:Any,N}, I::Vararg{Real, N}) where N
+    @boundscheck checkbounds(A, I...)
+    fillsimilar(A)
+end
 
 end # module

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -653,7 +653,7 @@ Base.@propagate_inbounds view(A::AbstractFill{<:Any,N}, I::Vararg{Union{Real, Ab
     _fill_getindex(A, Base.to_indices(A,I)...)
 
 # not getindex since we need array-like indexing
-function Base.@propagate_inbounds view(A::AbstractFill{<:Any,N}, I::Vararg{Real, N}) where N
+Base.@propagate_inbounds function view(A::AbstractFill{<:Any,N}, I::Vararg{Real, N}) where N
     @boundscheck checkbounds(A, I...)
     fillsimilar(A)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -198,7 +198,7 @@ end
     @test A[[true, false, true, false, false]] ≡ Fill(3.0, 2)
     A = Fill(3.0, 2, 2)
     @test A[[true true; true false]] ≡ Fill(3.0, 3)
-    @test_throws DimensionMismatch A[[true, false]]
+    @test_throws BoundsError A[[true, false]]
 
     A = Ones{Int}(5,5)
     @test A[1:3] ≡ Ones{Int}(3)
@@ -208,7 +208,7 @@ end
     A = Ones{Int}(2,2)
     @test A[[true false; true false]] ≡ Ones{Int}(2)
     @test A[[true, false, true, false]] ≡ Ones{Int}(2)
-    @test_throws DimensionMismatch A[[true false false; true false false]]
+    @test_throws BoundsError A[[true false false; true false false]]
 
     A = Zeros{Int}(5,5)
     @test A[1:3] ≡ Zeros{Int}(3)
@@ -218,7 +218,7 @@ end
     A = Zeros{Int}(2,2)
     @test A[[true false; true false]] ≡ Zeros{Int}(2)
     @test A[[true, false, true, false]] ≡ Zeros{Int}(2)
-    @test_throws DimensionMismatch A[[true false false; true false false]]
+    @test_throws BoundsError A[[true false false; true false false]]
 
     @testset "colon" begin
         @test Ones(2)[:] ≡ Ones(2)[Base.Slice(Base.OneTo(2))] ≡ Ones(2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1214,7 +1214,7 @@ end
         @test v isa Fill
         @test FillArrays.getindex_value(v) == FillArrays.unique_value(v) == 2.0
         @test convert(Fill, v) ≡ Fill(2.0,2)
-        @test view(a,1) isa SubArray
+        @test view(a,1) ≡ Fill(2.0)
     end
 
     @testset "view with bool" begin


### PR DESCRIPTION
In BlockArrays getindex may call view, so this redesigns `getindex` and `view` to both call `_fill_getindex` and avoid possible overflows.