### PR TITLE
Short form printing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FillArrays"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "0.11.10"
+version = "0.12.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FillArrays"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "0.11.7"
+version = "0.11.8"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -634,7 +634,11 @@ end
 
 function Base.show(io::IO, x::AbstractFill)  # for example (Fill(π,3),)
     print(io, nameof(typeof(x)), "(")
-    x isa Union{Zeros, Ones} || print(io, getindex_value(x), ", ")
+    if x isa Union{Zeros, Ones}
+    else
+        show(io, getindex_value(x))  # show not print to handle (Fill(1f0,2),)
+        print(io, ", ")
+    end
     join(io, size(x), ", ")
     print(io, ")")
 end

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -618,12 +618,13 @@ Base.print_matrix_row(io::IO,
 
 # Display concise description of a Fill.
 
-function Base.show(io::IO, ::MIME"text/plain", x::AbstractFill)
+function Base.show(io::IO, ::MIME"text/plain", x::Union{Eye, AbstractFill})
     if get(IOContext(io), :compact, false)  # for example [Fill(i==j,2,2) for i in 1:3, j in 1:4]
         return show(io, x)
     end
     summary(io, x)
-    if x isa Union{Zeros,Ones}
+    if x isa Union{Zeros, Ones, Eye}
+        # then no need to print entries
     elseif length(x) > 1
         print(io, ", with entries equal to ", getindex_value(x))
     else
@@ -633,7 +634,7 @@ end
 
 function Base.show(io::IO, x::AbstractFill)  # for example (Fill(π,3),)
     print(io, nameof(typeof(x)), "(")
-    x isa Union{Zeros,Ones} || print(io, getindex_value(x), ", ")
+    x isa Union{Zeros, Ones} || print(io, getindex_value(x), ", ")
     join(io, size(x), ", ")
     print(io, ")")
 end

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -660,7 +660,8 @@ end
 # interface
 ##
 
-getindex_value(a::LinearAlgebra.AdjOrTrans) = getindex_value(parent(a)) # FillArrays.getindex_value(Adjoint(Fill(1+im,2,2)))
+getindex_value(a::LinearAlgebra.Adjoint) = adjoint(getindex_value(parent(a)))
+getindex_value(a::LinearAlgebra.Transpose) = transpose(getindex_value(parent(a)))
 getindex_value(a::SubArray) = getindex_value(parent(a))
 
 

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -637,7 +637,7 @@ function Base.show(io::IO, x::AbstractFill)  # for example (Fill(π,3),)
     if x isa Union{Zeros, Ones}
     else
         show(io, getindex_value(x))  # show not print to handle (Fill(1f0,2),)
-        print(io, ", ")
+        ndims(x) > 0 && print(io, ", ")
     end
     join(io, size(x), ", ")
     print(io, ")")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1151,7 +1151,7 @@ end
     @test repr(Fill(1f0,10)) == "Fill(1.0f0, 10)"  # Float32!
     @test repr(Eye(9)) == "Eye(9)"
     # also used for arrays of arrays:
-    @test contains(stringmime("text/plain", [Eye(2) for i in 1:2, j in 1:2]), "Eye(2) ")
+    @test occursin("Eye(2) ", stringmime("text/plain", [Eye(2) for i in 1:2, j in 1:2]))
 end
 
 @testset "reshape" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1134,6 +1134,7 @@ end
 
 @testset "print" begin
     if VERSION ≥ v"1.5"
+        # 3-arg show, full printing
         @test stringmime("text/plain", Zeros(3)) == "3-element Zeros{Float64}"
         @test stringmime("text/plain", Ones(3)) == "3-element Ones{Float64}"
         @test stringmime("text/plain", Fill(7,2)) == "2-element Fill{$Int}, with entries equal to 7"
@@ -1143,11 +1144,14 @@ end
         @test stringmime("text/plain", Fill(8.0,1)) == "1-element Fill{Float64}, with entry equal to 8.0"
         @test stringmime("text/plain", Eye(5)) == "5×5 Eye{Float64}"
     end
+    # 2-arg show, compact printing
     @test repr(Zeros(3)) == "Zeros(3)"
     @test repr(Ones(3,2)) == "Ones(3, 2)"
     @test repr(Fill(7,3,2)) == "Fill(7, 3, 2)"
     @test repr(Fill(1f0,10)) == "Fill(1.0f0, 10)"  # Float32!
     @test repr(Eye(9)) == "Eye(9)"
+    # also used for arrays of arrays:
+    @test contains(stringmime("text/plain", [Eye(2) for i in 1:2, j in 1:2]), "Eye(2) ")
 end
 
 @testset "reshape" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1132,16 +1132,21 @@ end
     @test_throws DimensionMismatch dot(u, Z, v[1:end-1])
 end
 
-if VERSION ≥ v"1.5"
-    @testset "print" begin
+@testset "print" begin
+    if VERSION ≥ v"1.5"
         @test stringmime("text/plain", Zeros(3)) == "3-element Zeros{Float64}"
         @test stringmime("text/plain", Ones(3)) == "3-element Ones{Float64}"
-        @test stringmime("text/plain", Fill(7,2)) == "2-element Fill{$Int}: entries equal to 7"
+        @test stringmime("text/plain", Fill(7,2)) == "2-element Fill{$Int}, with entries equal to 7"
         @test stringmime("text/plain", Zeros(3,2)) == "3×2 Zeros{Float64}"
         @test stringmime("text/plain", Ones(3,2)) == "3×2 Ones{Float64}"
-        @test stringmime("text/plain", Fill(7,2,3)) == "2×3 Fill{$Int}: entries equal to 7"
+        @test stringmime("text/plain", Fill(7,2,3)) == "2×3 Fill{$Int}, with entries equal to 7"
+        @test stringmime("text/plain", Fill(8.0,1)) == "1-element Fill{Float64}, with entry equal to 8.0"
         @test stringmime("text/plain", Eye(5)) == "5×5 Eye{Float64}"
     end
+    @test repr(Zeros(3)) == "Zeros(3)"
+    @test repr(Ones(3,2)) == "Ones(3, 2)"
+    @test repr(Fill(7,3,2)) == "Fill(7, 3, 2)"
+    @test repr(Eye(9)) == "Eye(9)"
 end
 
 @testset "reshape" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1149,6 +1149,7 @@ end
     @test repr(Ones(3,2)) == "Ones(3, 2)"
     @test repr(Fill(7,3,2)) == "Fill(7, 3, 2)"
     @test repr(Fill(1f0,10)) == "Fill(1.0f0, 10)"  # Float32!
+    @test repr(Fill(0)) == "Fill(0)"
     @test repr(Eye(9)) == "Eye(9)"
     # also used for arrays of arrays:
     @test occursin("Eye(2) ", stringmime("text/plain", [Eye(2) for i in 1:2, j in 1:2]))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1241,10 +1241,10 @@ end
     end
 
     @testset "adjtrans" begin
-        a = Fill(2.0,5)
-        @test FillArrays.getindex_value(a') == FillArrays.unique_value(a') == 2.0
-        @test convert(Fill, a') ≡ Fill(2.0,1,5)
-        @test FillArrays.getindex_value(transpose(a)) == FillArrays.unique_value(transpose(a)) == 2.0
-        @test convert(Fill, transpose(a)) ≡ Fill(2.0,1,5)
+        a = Fill(2.0+im, 5)
+        @test FillArrays.getindex_value(a') == FillArrays.unique_value(a') == 2.0 - im
+        @test convert(Fill, a') ≡ Fill(2.0-im,1,5)
+        @test FillArrays.getindex_value(transpose(a)) == FillArrays.unique_value(transpose(a)) == 2.0 + im
+        @test convert(Fill, transpose(a)) ≡ Fill(2.0+im,1,5)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1146,6 +1146,7 @@ end
     @test repr(Zeros(3)) == "Zeros(3)"
     @test repr(Ones(3,2)) == "Ones(3, 2)"
     @test repr(Fill(7,3,2)) == "Fill(7, 3, 2)"
+    @test repr(Fill(1f0,10)) == "Fill(1.0f0, 10)"  # Float32!
     @test repr(Eye(9)) == "Eye(9)"
 end
 


### PR DESCRIPTION
This adds a shorter printing for when a FillArray appears inside a tuple, or in an array.

Before:
```
julia> (1, Fill(ℯ,2), 3, Fill(π,4), 5)
(1, 2-element Fill{Irrational{:ℯ}}: entries equal to ℯ, 3, 4-element Fill{Irrational{:π}}: entries equal to π, 5)

julia> [Fill(i==j,2,2) for i in 1:3, j in 1:4]
3×4 Matrix{Fill{Bool, 2, Tuple{Base.OneTo{Int64}, Base.OneTo{Int64}}}}:
 2×2 Fill{Bool}: entries equal to true   2×2 Fill{Bool}: entries equal to false  2×2 Fill{Bool}: entries equal to false  2×2 Fill{Bool}: entries equal to false
 2×2 Fill{Bool}: entries equal to false  2×2 Fill{Bool}: entries equal to true   2×2 Fill{Bool}: entries equal to false  2×2 Fill{Bool}: entries equal to false
 2×2 Fill{Bool}: entries equal to false  2×2 Fill{Bool}: entries equal to false  2×2 Fill{Bool}: entries equal to true   2×2 Fill{Bool}: entries equal to false
 
julia> Fill(99,1)
1-element Fill{Int64}: entries equal to 99

julia> Fill(1.0, (3:4,))
2-element Fill{Float64, 1, Tuple{UnitRange{Int64}}} with indices 3:4: entries equal to 1.0
```
After:
```
julia> (1, Fill(ℯ,2), 3, Fill(π,4), 5)
(1, Fill(ℯ, 2), 3, Fill(π, 4), 5)

julia> [Fill(i==j,2,2) for i in 1:3, j in 1:4]
3×4 Matrix{Fill{Bool, 2, Tuple{Base.OneTo{Int64}, Base.OneTo{Int64}}}}:
 Fill(true, 2, 2)   Fill(false, 2, 2)  Fill(false, 2, 2)  Fill(false, 2, 2)
 Fill(false, 2, 2)  Fill(true, 2, 2)   Fill(false, 2, 2)  Fill(false, 2, 2)
 Fill(false, 2, 2)  Fill(false, 2, 2)  Fill(true, 2, 2)   Fill(false, 2, 2)

julia> Fill(99,1)
1-element Fill{Int64}, with entry equal to 99

julia> Fill(1.0, (3:4,))
2-element Fill{Float64, 1, Tuple{UnitRange{Int64}}} with indices 3:4, with entries equal to 1.0

julia> (Zeros{Int}(2), Ones{Bool}(3))  # should this print more?
(Zeros(2), Ones(3))

julia> Zygote.gradient((x,y) -> y * sum(x), ones(Float32, 3,3), pi)
(Fill(3.1415927f0, 3, 3), 9.0f0)
````