### PR TITLE
`map` and `mapreduce`

### DIFF
--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -6,7 +6,7 @@ import Base: size, getindex, setindex!, IndexStyle, checkbounds, convert,
     +, -, *, /, \, diff, sum, cumsum, maximum, minimum, sort, sort!,
     any, all, axes, isone, iterate, unique, allunique, permutedims, inv,
     copy, vec, setindex!, count, ==, reshape, _throw_dmrs, map, zero,
-    show, view, in
+    show, view, in, mapreduce
 
 import LinearAlgebra: rank, svdvals!, tril, triu, tril!, triu!, diag, transpose, adjoint, fill!,
     dot, norm2, norm1, normInf, normMinusInf, normp, lmul!, rmul!, diagzero, AbstractTriangular, AdjointAbsVec

--- a/src/fillbroadcast.jl
+++ b/src/fillbroadcast.jl
@@ -32,7 +32,11 @@ end
 
 ### mapreduce
 
-# mapreduce(f, op, A::AbstractFill; kw...) = reduce(op, map(f, A); kw...)
+# Apply f, then take the same path as Base -- calling reduce would cause an infinite loop,
+# as there is no special reduce(op, ::Fill) method.
+
+mapreduce(f, op, A::AbstractFill; dims=:, init=Base._InitialValue()) =
+    Base._mapreduce_dim(identity, op, init, map(f, A), dims)
 
 function mapreduce(f, op, A::AbstractFill, B::AbstractFill; kw...)
     val(_...) = f(getindex_value(A), getindex_value(B))

--- a/src/fillbroadcast.jl
+++ b/src/fillbroadcast.jl
@@ -32,7 +32,7 @@ end
 
 ### mapreduce
 
-mapreduce(f, op, A::AbstractFill; kw...) = reduce(op, map(f, A); kw...)
+# mapreduce(f, op, A::AbstractFill; kw...) = reduce(op, map(f, A); kw...)
 
 function mapreduce(f, op, A::AbstractFill, B::AbstractFill; kw...)
     val(_...) = f(getindex_value(A), getindex_value(B))

--- a/src/fillbroadcast.jl
+++ b/src/fillbroadcast.jl
@@ -69,7 +69,7 @@ function mapreduce(f, op, A::AbstractArray, B::AbstractFill, Cs::AbstractArray..
 end
 function mapreduce(f, op, A::AbstractFill, B::AbstractFill, Cs::AbstractArray...; kw...)
     gh(cs...) = f(getindex_value(A), getindex_value(B), cs...)
-    mapreduce(gh, op, A, Cs...; kw...)
+    mapreduce(gh, op, Cs...; kw...)
 end
 
 ### Unary broadcasting

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -782,9 +782,12 @@ end
 
     @test mapreduce(exp, +, Y) == mapreduce(exp, +, y)
     @test mapreduce(exp, +, Y; dims=2) == mapreduce(exp, +, y; dims=2)
-    @test mapreduce(exp, +, Y; dims=(1,), init=5.0) == mapreduce(exp, +, y; dims=(1,), init=5.0)
     @test mapreduce(identity, +, Y) == sum(y) == sum(Y)
     @test mapreduce(identity, +, Y, dims=1) == sum(y, dims=1) == sum(Y, dims=1)
+
+    if VERSION >= v"1.5"
+        @test mapreduce(exp, +, Y; dims=(1,), init=5.0) == mapreduce(exp, +, y; dims=(1,), init=5.0)
+    end
 
     # Two arrays
     @test mapreduce(*, +, x, Y) == mapreduce(*, +, x, y)
@@ -796,10 +799,12 @@ end
     op2(x,y) = x^2 + 3y
     @test mapreduce(f2, op2, x, Y) == mapreduce(f2, op2, x, y)
 
-    @test mapreduce(f2, op2, x, Y, dims=1, init=5.0) == mapreduce(f2, op2, x, y, dims=1, init=5.0)
-    @test mapreduce(f2, op2, Y, x, dims=1, init=5.0) == mapreduce(f2, op2, y, x, dims=1, init=5.0)
-    @test mapreduce(f2, op2, x, O, dims=1, init=5.0) == mapreduce(f2, op2, x, y, dims=1, init=5.0)
-    @test mapreduce(f2, op2, Y, O, dims=1, init=5.0) == mapreduce(f2, op2, y, y, dims=1, init=5.0)
+    if VERSION >= v"1.5"
+        @test mapreduce(f2, op2, x, Y, dims=1, init=5.0) == mapreduce(f2, op2, x, y, dims=1, init=5.0)
+        @test mapreduce(f2, op2, Y, x, dims=1, init=5.0) == mapreduce(f2, op2, y, x, dims=1, init=5.0)
+        @test mapreduce(f2, op2, x, O, dims=1, init=5.0) == mapreduce(f2, op2, x, y, dims=1, init=5.0)
+        @test mapreduce(f2, op2, Y, O, dims=1, init=5.0) == mapreduce(f2, op2, y, y, dims=1, init=5.0)
+    end
 
     # More than two
     @test mapreduce(+, +, x, Y, x) == mapreduce(+, +, x, y, x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -785,33 +785,37 @@ end
     @test mapreduce(identity, +, Y) == sum(y) == sum(Y)
     @test mapreduce(identity, +, Y, dims=1) == sum(y, dims=1) == sum(Y, dims=1)
 
-    if VERSION >= v"1.5"
+    if VERSION >= v"1.4"
         @test mapreduce(exp, +, Y; dims=(1,), init=5.0) == mapreduce(exp, +, y; dims=(1,), init=5.0)
     end
 
-    # Two arrays
-    @test mapreduce(*, +, x, Y) == mapreduce(*, +, x, y)
-    @test mapreduce(*, +, Y, x) == mapreduce(*, +, y, x)
-    @test mapreduce(*, +, x, O) == mapreduce(*, +, x, y)
-    @test mapreduce(*, +, Y, O) == mapreduce(*, +, y, y)
+    if VERSION >= v"1.2" # Vararg mapreduce was added in Julia 1.2
 
-    f2(x,y) = 1 + x/y
-    op2(x,y) = x^2 + 3y
-    @test mapreduce(f2, op2, x, Y) == mapreduce(f2, op2, x, y)
+        # Two arrays
+        @test mapreduce(*, +, x, Y) == mapreduce(*, +, x, y)
+        @test mapreduce(*, +, Y, x) == mapreduce(*, +, y, x)
+        @test mapreduce(*, +, x, O) == mapreduce(*, +, x, y)
+        @test mapreduce(*, +, Y, O) == mapreduce(*, +, y, y)
 
-    if VERSION >= v"1.5"
-        @test mapreduce(f2, op2, x, Y, dims=1, init=5.0) == mapreduce(f2, op2, x, y, dims=1, init=5.0)
-        @test mapreduce(f2, op2, Y, x, dims=1, init=5.0) == mapreduce(f2, op2, y, x, dims=1, init=5.0)
-        @test mapreduce(f2, op2, x, O, dims=1, init=5.0) == mapreduce(f2, op2, x, y, dims=1, init=5.0)
-        @test mapreduce(f2, op2, Y, O, dims=1, init=5.0) == mapreduce(f2, op2, y, y, dims=1, init=5.0)
+        f2(x,y) = 1 + x/y
+        op2(x,y) = x^2 + 3y
+        @test mapreduce(f2, op2, x, Y) == mapreduce(f2, op2, x, y)
+
+        if VERSION >= v"1.4"
+            @test mapreduce(f2, op2, x, Y, dims=1, init=5.0) == mapreduce(f2, op2, x, y, dims=1, init=5.0)
+            @test mapreduce(f2, op2, Y, x, dims=1, init=5.0) == mapreduce(f2, op2, y, x, dims=1, init=5.0)
+            @test mapreduce(f2, op2, x, O, dims=1, init=5.0) == mapreduce(f2, op2, x, y, dims=1, init=5.0)
+            @test mapreduce(f2, op2, Y, O, dims=1, init=5.0) == mapreduce(f2, op2, y, y, dims=1, init=5.0)
+        end
+
+        # More than two
+        @test mapreduce(+, +, x, Y, x) == mapreduce(+, +, x, y, x)
+        @test mapreduce(+, +, Y, x, x) == mapreduce(+, +, y, x, x)
+        @test mapreduce(+, +, x, O, Y) == mapreduce(+, +, x, y, y)
+        @test mapreduce(+, +, Y, O, Y) == mapreduce(+, +, y, y, y)
+        @test mapreduce(+, +, Y, O, Y, x) == mapreduce(+, +, y, y, y, x)
+
     end
-
-    # More than two
-    @test mapreduce(+, +, x, Y, x) == mapreduce(+, +, x, y, x)
-    @test mapreduce(+, +, Y, x, x) == mapreduce(+, +, y, x, x)
-    @test mapreduce(+, +, x, O, Y) == mapreduce(+, +, x, y, y)
-    @test mapreduce(+, +, Y, O, Y) == mapreduce(+, +, y, y, y)
-    @test mapreduce(+, +, Y, O, Y, x) == mapreduce(+, +, y, y, y, x)
 end
 
 @testset "Offset indexing" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -772,6 +772,32 @@ end
     @test map(+, x2, x2) === x2 .+ x2
     @test_throws DimensionMismatch map(+, x2', x2)
 end
+
+@testset "mapreduce" begin
+    x = rand(3, 4)
+    y = fill(1.0, 3, 4)
+    Y = Fill(1.0, 3, 4)
+    O = Ones(3, 4)
+
+    @test_broken mapreduce(exp, +, Y) == mapreduce(exp, +, y)
+
+    # Two arrays
+    @test mapreduce(*, +, x, Y) == mapreduce(*, +, x, y)
+    @test mapreduce(*, +, Y, x) == mapreduce(*, +, y, x)
+    @test mapreduce(*, +, x, O) == mapreduce(*, +, x, y)
+    @test mapreduce(*, +, Y, O) == mapreduce(*, +, y, y)
+
+    @test mapreduce(*, +, x, Y, dims=1, init=5.0) == mapreduce(*, +, x, y, dims=1, init=5.0)
+    @test mapreduce(*, +, Y, x, dims=1, init=5.0) == mapreduce(*, +, y, x, dims=1, init=5.0)
+    @test mapreduce(*, +, x, O, dims=1, init=5.0) == mapreduce(*, +, x, y, dims=1, init=5.0)
+    @test mapreduce(*, +, Y, O, dims=1, init=5.0) == mapreduce(*, +, y, y, dims=1, init=5.0)
+
+    # More than two
+    @test mapreduce(*, +, x, Y, x) == mapreduce(*, +, x, y, x)
+    @test mapreduce(*, +, Y, x, x) == mapreduce(*, +, y, x, x)
+    @test mapreduce(*, +, x, O, Y) == mapreduce(*, +, x, y, y)
+    @test mapreduce(*, +, Y, O, Y) == mapreduce(*, +, y, y, y)
+    @test mapreduce(*, +, Y, O, Y, x) == mapreduce(*, +, y, y, y, x)
 end
 
 @testset "Offset indexing" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -536,6 +536,7 @@ end
 
 @testset "Cumsum and diff" begin
     @test sum(Fill(3,10)) ≡ 30
+    @test reduce(+, Fill(3,10)) ≡ 30
     @test sum(x -> x + 1, Fill(3,10)) ≡ 40
     @test cumsum(Fill(3,10)) ≡ 3:3:30
 
@@ -782,8 +783,8 @@ end
     @test mapreduce(exp, +, Y) == mapreduce(exp, +, y)
     @test mapreduce(exp, +, Y; dims=2) == mapreduce(exp, +, y; dims=2)
     @test mapreduce(exp, +, Y; dims=(1,), init=5.0) == mapreduce(exp, +, y; dims=(1,), init=5.0)
-    @test mapreduce(identity, +, Y) == sum(y)
-    @test mapreduce(identity, +, Y, dims=1) == sum(y, dims=1)
+    @test mapreduce(identity, +, Y) == sum(y) == sum(Y)
+    @test mapreduce(identity, +, Y, dims=1) == sum(y, dims=1) == sum(Y, dims=1)
 
     # Two arrays
     @test mapreduce(*, +, x, Y) == mapreduce(*, +, x, y)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -792,10 +792,14 @@ end
     @test mapreduce(*, +, x, O) == mapreduce(*, +, x, y)
     @test mapreduce(*, +, Y, O) == mapreduce(*, +, y, y)
 
-    @test mapreduce(*, +, x, Y, dims=1, init=5.0) == mapreduce(*, +, x, y, dims=1, init=5.0)
-    @test mapreduce(*, +, Y, x, dims=1, init=5.0) == mapreduce(*, +, y, x, dims=1, init=5.0)
-    @test mapreduce(*, +, x, O, dims=1, init=5.0) == mapreduce(*, +, x, y, dims=1, init=5.0)
-    @test mapreduce(*, +, Y, O, dims=1, init=5.0) == mapreduce(*, +, y, y, dims=1, init=5.0)
+    f2(x,y) = 1 + x/y
+    op2(x,y) = x^2 + 3y
+    @test mapreduce(f2, op2, x, Y) == mapreduce(f2, op2, x, y)
+
+    @test mapreduce(f2, op2, x, Y, dims=1, init=5.0) == mapreduce(f2, op2, x, y, dims=1, init=5.0)
+    @test mapreduce(f2, op2, Y, x, dims=1, init=5.0) == mapreduce(f2, op2, y, x, dims=1, init=5.0)
+    @test mapreduce(f2, op2, x, O, dims=1, init=5.0) == mapreduce(f2, op2, x, y, dims=1, init=5.0)
+    @test mapreduce(f2, op2, Y, O, dims=1, init=5.0) == mapreduce(f2, op2, y, y, dims=1, init=5.0)
 
     # More than two
     @test mapreduce(*, +, x, Y, x) == mapreduce(*, +, x, y, x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -758,15 +758,20 @@ end
 end
 
 @testset "map" begin
-    x = Ones(5)
-    @test map(exp,x) === Fill(exp(1.0),5)
-    @test map(isone,x) === Fill(true,5)
+    x1 = Ones(5)
+    @test map(exp,x1) === Fill(exp(1.0),5)
+    @test map(isone,x1) === Fill(true,5)
 
-    x = Zeros(5)
-    @test map(exp,x) === exp.(x)
+    x0 = Zeros(5)
+    @test map(exp,x0) === exp.(x0)
 
-    x = Fill(2,5,3)
-    @test map(exp,x) === Fill(exp(2),5,3)
+    x2 = Fill(2,5,3)
+    @test map(exp,x2) === Fill(exp(2),5,3)
+
+    @test map(+, x1, x2) === Fill(3.0, 5)
+    @test map(+, x2, x2) === x2 .+ x2
+    @test_throws DimensionMismatch map(+, x2', x2)
+end
 end
 
 @testset "Offset indexing" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -779,7 +779,11 @@ end
     Y = Fill(1.0, 3, 4)
     O = Ones(3, 4)
 
-    @test mapreduce(exp, +, Y) == mapreduce(exp, +, y)  # no special method right now
+    @test mapreduce(exp, +, Y) == mapreduce(exp, +, y)
+    @test mapreduce(exp, +, Y; dims=2) == mapreduce(exp, +, y; dims=2)
+    @test mapreduce(exp, +, Y; dims=(1,), init=5.0) == mapreduce(exp, +, y; dims=(1,), init=5.0)
+    @test mapreduce(identity, +, Y) == sum(y)
+    @test mapreduce(identity, +, Y, dims=1) == sum(y, dims=1)
 
     # Two arrays
     @test mapreduce(*, +, x, Y) == mapreduce(*, +, x, y)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -802,11 +802,11 @@ end
     @test mapreduce(f2, op2, Y, O, dims=1, init=5.0) == mapreduce(f2, op2, y, y, dims=1, init=5.0)
 
     # More than two
-    @test mapreduce(*, +, x, Y, x) == mapreduce(*, +, x, y, x)
-    @test mapreduce(*, +, Y, x, x) == mapreduce(*, +, y, x, x)
-    @test mapreduce(*, +, x, O, Y) == mapreduce(*, +, x, y, y)
-    @test mapreduce(*, +, Y, O, Y) == mapreduce(*, +, y, y, y)
-    @test mapreduce(*, +, Y, O, Y, x) == mapreduce(*, +, y, y, y, x)
+    @test mapreduce(+, +, x, Y, x) == mapreduce(+, +, x, y, x)
+    @test mapreduce(+, +, Y, x, x) == mapreduce(+, +, y, x, x)
+    @test mapreduce(+, +, x, O, Y) == mapreduce(+, +, x, y, y)
+    @test mapreduce(+, +, Y, O, Y) == mapreduce(+, +, y, y, y)
+    @test mapreduce(+, +, Y, O, Y, x) == mapreduce(+, +, y, y, y, x)
 end
 
 @testset "Offset indexing" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -779,7 +779,7 @@ end
     Y = Fill(1.0, 3, 4)
     O = Ones(3, 4)
 
-    @test_broken mapreduce(exp, +, Y) == mapreduce(exp, +, y)
+    @test mapreduce(exp, +, Y) == mapreduce(exp, +, y)  # no special method right now
 
     # Two arrays
     @test mapreduce(*, +, x, Y) == mapreduce(*, +, x, y)


### PR DESCRIPTION
This should make `map(f, A, B, C)`, and `mapreduce(f, op, A, B, C)` work for FillArrays.

One motivation is that Base's `mapreduce` isn't fast for multiple arrays, but if we peel off the ones which are `Fill` then we can go the fast path. The other is that a mix of CuArrays & Fill seems to give errors:
```
julia> mapreduce((x,y) -> x*conj(y), +, Fill(1.0, 3), cu(ones(3)))
ERROR: scalar getindex is disallowed
```
Edit -- scope has crept a little, it now also handles `reduce`, which has this result:
```
julia> sum(Fill(3,4,5), dims=1)
1×5 Matrix{Int64}:  # master
 12  12  12  12  12

1×5 Fill{Int64}: entries equal to 12  # this PR
```
Happy to remove / separate that if you prefer. 