### PR TITLE
Fix getindex of Fill with Trues in N-D

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FillArrays"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "0.11.8"
+version = "0.11.9"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/trues.jl
+++ b/src/trues.jl
@@ -47,7 +47,7 @@ end
 # https://github.com/JuliaArrays/FillArrays.jl/issues/148 and 150
 function Base.getindex(
     a::AbstractFill{T, N, Tuple{Vararg{Base.OneTo{Int}, N}}},
-    b::Trues{N, Tuple{Vararg{Base.OneTo{Int64}, N}}},
+    b::Trues{N, Tuple{Vararg{Base.OneTo{Int}, N}}},
 ) where {T, N}
     @boundscheck size(a) == size(b) || throw(BoundsError(a, b))
     return Fill(getindex_value(a), length(a))

--- a/src/trues.jl
+++ b/src/trues.jl
@@ -44,10 +44,19 @@ function Base.getindex(x::AbstractArray{T,N}, mask::Trues{N, NTuple{N,Base.OneTo
     return x[trues(size(x))] # else revert to usual getindex method
 end
 
-# https://github.com/JuliaArrays/FillArrays.jl/issues/148
+# https://github.com/JuliaArrays/FillArrays.jl/issues/148 and 150
+#=
 function Base.getindex(
     a::AbstractFill{T, 1, Tuple{Base.OneTo{Int}}},
     b::Trues{1, Tuple{Base.OneTo{Int}}}) where T
     @boundscheck length(a) == length(b) || throw(BoundsError(a, b))
+    return Fill(getindex_value(a), length(a))
+end
+=#
+function Base.getindex(
+    a::AbstractFill{T, N, Tuple{Vararg{Base.OneTo{Int64}, N}}},
+    b::Trues{N, Tuple{Vararg{Base.OneTo{Int64}, N}}},
+) where {T, N}
+    @boundscheck size(a) == size(b) || throw(BoundsError(a, b))
     return Fill(getindex_value(a), length(a))
 end

--- a/src/trues.jl
+++ b/src/trues.jl
@@ -45,14 +45,6 @@ function Base.getindex(x::AbstractArray{T,N}, mask::Trues{N, NTuple{N,Base.OneTo
 end
 
 # https://github.com/JuliaArrays/FillArrays.jl/issues/148 and 150
-#=
-function Base.getindex(
-    a::AbstractFill{T, 1, Tuple{Base.OneTo{Int}}},
-    b::Trues{1, Tuple{Base.OneTo{Int}}}) where T
-    @boundscheck length(a) == length(b) || throw(BoundsError(a, b))
-    return Fill(getindex_value(a), length(a))
-end
-=#
 function Base.getindex(
     a::AbstractFill{T, N, Tuple{Vararg{Base.OneTo{Int64}, N}}},
     b::Trues{N, Tuple{Vararg{Base.OneTo{Int64}, N}}},

--- a/src/trues.jl
+++ b/src/trues.jl
@@ -46,7 +46,7 @@ end
 
 # https://github.com/JuliaArrays/FillArrays.jl/issues/148 and 150
 function Base.getindex(
-    a::AbstractFill{T, N, Tuple{Vararg{Base.OneTo{Int64}, N}}},
+    a::AbstractFill{T, N, Tuple{Vararg{Base.OneTo{Int}, N}}},
     b::Trues{N, Tuple{Vararg{Base.OneTo{Int64}, N}}},
 ) where {T, N}
     @boundscheck size(a) == size(b) || throw(BoundsError(a, b))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1206,6 +1206,9 @@ end
     @test_throws DimensionMismatch setindex!(ones(2), zeros(3), Trues(2))
     @test Ones(3)[Trues(3)] == Ones(3)
     @test_throws BoundsError Ones(3)[Trues(2)]
+    @test Ones(2,3)[Trues(2,3)] == Ones(6)
+    @test Ones(2,3)[Trues(6)] == Ones(6)
+    @test_throws BoundsError Ones(2,3)[Trues(3,2)]
 end
 
 @testset "FillArray interface" begin


### PR DESCRIPTION
Fixes #150 in a more general way that also covers #148.

Limited to `OneTo` axes for simplicity and reasons discussed in #149.
Someone could perhaps generalize in the future if they have a need.