### PR TITLE
Add methods for `mean`, `std`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.12.0"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 julia = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FillArrays"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "0.12.0"
+version = "0.12.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -601,14 +601,10 @@ function mean(f::Union{Function, Type}, A::AbstractFill; dims=(:))
         Fill(val, ntuple(d -> d in dims ? 1 : size(A,d), ndims(A))...)
 end
 
-for fun in (:std, :var)
-    @eval function $fun(A::AbstractFill{T}; corrected::Bool=true, mean=nothing, dims=(:)) where {T<:Number}
-        if mean !== nothing
-            mean ≈ Statistics.mean(A; dims=dims) || throw(ArgumentError("pre-computed mean is incorrect"))
-        end
-        dims isa Colon ? zero(float(T)) : 
-            Zeros{float(T)}(ntuple(d -> d in dims ? 1 : size(A,d), ndims(A))...)
-    end
+
+function var(A::AbstractFill{T}; corrected::Bool=true, mean=nothing, dims=(:)) where {T<:Number}
+    dims isa Colon ? zero(float(T)) : 
+        Zeros{float(T)}(ntuple(d -> d in dims ? 1 : size(A,d), ndims(A))...)
 end
 
 cov(A::AbstractFill{T,1}; corrected::Bool=true) where {T<:Number} = zero(float(T))

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -595,7 +595,7 @@ end
 #########
 
 mean(A::AbstractFill; dims=(:)) = mean(identity, A; dims=dims)
-function mean(f, A::AbstractFill; dims=(:))
+function mean(f::Union{Function, Type}, A::AbstractFill; dims=(:))
     val = float(f(getindex_value(A)))
     dims isa Colon ? val : 
         Fill(val, ntuple(d -> d in dims ? 1 : size(A,d), ndims(A)))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using FillArrays, LinearAlgebra, SparseArrays, StaticArrays, Random, Base64, Test
+using FillArrays, LinearAlgebra, SparseArrays, StaticArrays, Random, Base64, Test, Statistics
 import FillArrays: AbstractFill, RectDiagonal, SquareEye
 
 @testset "fill array constructors and convert" begin
@@ -1302,4 +1302,16 @@ end
         @test FillArrays.getindex_value(transpose(a)) == FillArrays.unique_value(transpose(a)) == 2.0 + im
         @test convert(Fill, transpose(a)) ≡ Fill(2.0+im,1,5)
     end
+end
+
+@testset "Statistics" begin
+    @test mean(Fill(3,4,5)) === mean(fill(3,4,5))
+    @test std(Fill(3,4,5)) === std(fill(3,4,5))
+    @test var(Trues(5)) === var(trues(5))
+    @test mean(Trues(5)) === mean(trues(5))
+
+    @test mean(sqrt, Fill(3,4,5)) ≈ mean(sqrt, fill(3,4,5))
+
+    @test mean(Fill(3,4,5), dims=2) == mean(fill(3,4,5), dims=2)
+    @test std(Fill(3,4,5), corrected=true, mean=3) == std(fill(3,4,5), corrected=true, mean=3)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1319,7 +1319,7 @@ end
     @test cov(Fill(3,4,5)) == cov(fill(3,4,5))
     @test cov(Fill(3,4,5), dims=2) == cov(fill(3,4,5), dims=2)
 
-    @test cor(Fill(3,4)) === cor(fill(3,4))
+    @test cor(Fill(3,4)) == cor(fill(3,4))
     @test cor(Fill(3, 4, 5)) ≈ cor(fill(3, 4, 5)) nans=true
     @test cor(Fill(3, 4, 5), dims=2) ≈ cor(fill(3, 4, 5), dims=2) nans=true
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1314,4 +1314,12 @@ end
 
     @test mean(Fill(3,4,5), dims=2) == mean(fill(3,4,5), dims=2)
     @test std(Fill(3,4,5), corrected=true, mean=3) == std(fill(3,4,5), corrected=true, mean=3)
+
+    @test cov(Fill(3,4)) === cov(fill(3,4))
+    @test cov(Fill(3,4,5)) == cov(fill(3,4,5))
+    @test cov(Fill(3,4,5), dims=2) == cov(fill(3,4,5), dims=2)
+
+    @test cor(Fill(3,4)) === cor(fill(3,4))
+    @test cor(Fill(3, 4, 5)) ≈ cor(fill(3, 4, 5)) nans=true
+    @test cor(Fill(3, 4, 5), dims=2) ≈ cor(fill(3, 4, 5), dims=2) nans=true
 end


### PR DESCRIPTION
This solves the following problem:
```julia
julia> using FillArrays, Statistics

julia> mean(Fill(3,4,5))
3.0

julia> mean(Fill(3,4,5), dims=1)
ERROR: ArgumentError: Cannot setindex! to 3.0 for an AbstractFill with value 12.0.

julia> cor(Fill(3, 4))
1.0

julia> cor(Fill(3, 4, 5))
ERROR: ArgumentError: Cannot setindex! to 1.0 for an AbstractFill with value 0.0.
```
Adds dependence on one more standard lib, which I hope is OK.