### PR TITLE
Apply ChainRulesCore.jl's projection operators

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,12 +3,14 @@ uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
 version = "0.12.1"
 
 [deps]
+ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
+ChainRulesCore = "1"
 julia = "1"
 
 [extras]

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -626,6 +626,7 @@ end
 include("fillalgebra.jl")
 include("fillbroadcast.jl")
 include("trues.jl")
+include("chainrules.jl")
 
 ##
 # print

--- a/src/chainrules.jl
+++ b/src/chainrules.jl
@@ -1,0 +1,30 @@
+import ChainRulesCore: ProjectTo, NoTangent
+
+"""
+    ProjectTo(::Fill) -> ProjectTo{Fill}
+    ProjectTo(::Ones) -> ProjectTo{NoTangent}
+
+Most FillArrays arrays store one number, and so their gradients under automatic
+differentiation represent the variation of this one number. 
+
+The exception is those like `Ones` and `Zeros` whose type fixes their value,
+which have no graidient.
+"""
+ProjectTo(x::Fill{<:Number}) = ProjectTo{Fill}(; element = ProjectTo(getindex_value(x)), axes = axes(x))
+
+ProjectTo(x::AbstractFill{Bool}) = ProjectTo{NoTangent}()  # Bool is always regarded as categorical
+
+ProjectTo(x::Zeros) = ProjectTo{NoTangent}()
+ProjectTo(x::Ones) = ProjectTo{NoTangent}()
+
+function (project::ProjectTo{Fill})(dx::AbstractArray)
+    for d in 1:max(ndims(dx), length(project.axes))
+        size(dx, d) == length(get(project.axes, d, 1)) || throw(_projection_mismatch(axes_x, size(dx)))
+    end
+    Fill(mean(dx), project.axes)  # Note that mean(dx::Fill) is optimised
+end
+
+function _projection_mismatch(axes_x::Tuple, size_dx::Tuple)
+    size_x = map(length, axes_x)
+    DimensionMismatch("variable with size(x) == $size_x cannot have a gradient with size(dx) == $size_dx")
+end

--- a/src/chainrules.jl
+++ b/src/chainrules.jl
@@ -1,4 +1,4 @@
-import ChainRulesCore: ProjectTo, NoTangent
+import ChainRulesCore: ProjectTo, NoTangent, Tangent
 
 """
     ProjectTo(::Fill) -> ProjectTo{Fill}
@@ -22,6 +22,14 @@ function (project::ProjectTo{Fill})(dx::AbstractArray)
         size(dx, d) == length(get(project.axes, d, 1)) || throw(_projection_mismatch(axes_x, size(dx)))
     end
     Fill(mean(dx), project.axes)  # Note that mean(dx::Fill) is optimised
+end
+
+function (project::ProjectTo{Fill})(dx::Tangent{<:Fill})
+    # This would need a definition for length(::NoTangent) to be safe:
+    # for d in 1:max(length(dx.axes), length(project.axes))
+    #     length(get(dx.axes, d, 1)) == length(get(project.axes, d, 1)) || throw(_projection_mismatch(dx.axes, size(dx)))
+    # end
+    Fill(dx.value / prod(length, project.axes), project.axes)
 end
 
 function _projection_mismatch(axes_x::Tuple, size_dx::Tuple)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,7 @@
-using FillArrays, LinearAlgebra, SparseArrays, StaticArrays, Random, Base64, Test, Statistics
+
+using FillArrays, StaticArrays, ChainRulesCore, Base64
+using LinearAlgebra, SparseArrays, Random, Statistics, Test  # standard libraries
+
 import FillArrays: AbstractFill, RectDiagonal, SquareEye
 
 @testset "fill array constructors and convert" begin
@@ -1322,4 +1325,13 @@ end
     @test cor(Fill(3,4)) == cor(fill(3,4))
     @test cor(Fill(3, 4, 5)) ≈ cor(fill(3, 4, 5)) nans=true
     @test cor(Fill(3, 4, 5), dims=2) ≈ cor(fill(3, 4, 5), dims=2) nans=true
+end
+
+@testset "ChainRules integration" begin
+    @test ProjectTo(Fill(1,2,3))(ones(2,3)) === Fill(1.0, 2, 3)
+    @test ProjectTo(Fill(1,2,3))(ones(2,3,1) .+ im) === Fill(1.0, 2, 3)
+    @test ProjectTo(Fill(1,2,3))(Fill(1+im, 2,3)) === Fill(1.0, 2, 3)
+
+    @test ProjectTo(Eye(3))(rand(3,3)) === NoTangent()
+    @test ProjectTo(Zeros(3))(rand(3)) === NoTangent()
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1328,9 +1328,11 @@ end
 end
 
 @testset "ChainRules integration" begin
-    @test ProjectTo(Fill(1,2,3))(ones(2,3)) === Fill(1.0, 2, 3)
-    @test ProjectTo(Fill(1,2,3))(ones(2,3,1) .+ im) === Fill(1.0, 2, 3)
-    @test ProjectTo(Fill(1,2,3))(Fill(1+im, 2,3)) === Fill(1.0, 2, 3)
+    x = Fill(1,2,3)
+    @test ProjectTo(x)(ones(2,3)) === Fill(1.0, 2, 3)
+    @test ProjectTo(x)(ones(2,3,1) .+ im) === Fill(1.0, 2, 3)
+    @test ProjectTo(x)(Fill(1+im, 2,3)) === Fill(1.0, 2, 3)
+    @test ProjectTo(x)(Tangent{typeof(x)}(; value=6)) === Fill(1.0, 2, 3)
 
     @test ProjectTo(Eye(3))(rand(3,3)) === NoTangent()
     @test ProjectTo(Zeros(3))(rand(3)) === NoTangent()


### PR DESCRIPTION
ChainRules now has a projection mechanism to preserve, among other things, the structure of structured arrays. This should probably apply to FillArrays. So this PR writes a few methods. 

However, I'm not sure where it should live. This package depends on nothing at all besides the standard library. My vote would be for it to live in ChainRules, which is already a bigger package. (And Zygote which loads ChainRules already loads FillArrays anyway). But I open the PR here just because I wrote the code on this fork, and to discuss.

CC @oxinabox, @mzgubic

Loading times, on 1.8-, before:
```
julia> @time using FillArrays
[ Info: Precompiling FillArrays [1a297f60-69ca-5386-bcde-b61e274b549b]
  1.058200 seconds (1.43 M allocations: 82.388 MiB, 0.42% gc time, 1.01% compilation time)

julia> @time using FillArrays  # fresh start
  0.217252 seconds (763.15 k allocations: 46.191 MiB, 64.89% compilation time)

julia> @time using ChainRulesCore
  0.242396 seconds (702.60 k allocations: 37.375 MiB, 4.25% gc time, 81.22% compilation time)
```
And after:
```
julia> @time using FillArrays
[ Info: Precompiling FillArrays [1a297f60-69ca-5386-bcde-b61e274b549b]
  1.703313 seconds (2.20 M allocations: 124.462 MiB, 0.26% gc time, 0.60% compilation time)

julia> @time using FillArrays  # fresh start
  0.341163 seconds (974.43 k allocations: 58.087 MiB, 9.82% gc time, 65.06% compilation time)
```