### PR TITLE
Fix some Base.@propagate_inbounds annotations

### DIFF
--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -33,21 +33,21 @@ abstract type AbstractFill{T, N, Axes} <: AbstractArray{T, N} end
 
 ==(a::AbstractFill, b::AbstractFill) = axes(a) == axes(b) && getindex_value(a) == getindex_value(b)
 
-Base.@propagate_inbounds @inline function _fill_getindex(F::AbstractFill, kj::Integer...)
+Base.@propagate_inbounds function _fill_getindex(F::AbstractFill, kj::Integer...)
     @boundscheck checkbounds(F, kj...)
     getindex_value(F)
 end
 
-getindex(F::AbstractFill, k::Integer) = _fill_getindex(F, k)
-getindex(F::AbstractFill{T, N}, kj::Vararg{<:Integer, N}) where {T, N} = _fill_getindex(F, kj...)
+Base.@propagate_inbounds getindex(F::AbstractFill, k::Integer) = _fill_getindex(F, k)
+Base.@propagate_inbounds getindex(F::AbstractFill{T, N}, kj::Vararg{<:Integer, N}) where {T, N} = _fill_getindex(F, kj...)
 
-@inline function setindex!(F::AbstractFill, v, k::Integer)
+Base.@propagate_inbounds function setindex!(F::AbstractFill, v, k::Integer)
     @boundscheck checkbounds(F, k)
     v == getindex_value(F) || throw(ArgumentError("Cannot setindex! to $v for an AbstractFill with value $(getindex_value(F))."))
     F
 end
 
-@inline function setindex!(F::AbstractFill{T, N}, v, kj::Vararg{<:Integer, N}) where {T, N}
+Base.@propagate_inbounds function setindex!(F::AbstractFill{T, N}, v, kj::Vararg{<:Integer, N}) where {T, N}
     @boundscheck checkbounds(F, kj...)
     v == getindex_value(F) || throw(ArgumentError("Cannot setindex! to $v for an AbstractFill with value $(getindex_value(F))."))
     F
@@ -163,26 +163,26 @@ convert(::Type{T}, F::T) where T<:Fill = F
 
 
 
-getindex(F::Fill{<:Any,0}) = getindex_value(F)
+Base.@propagate_inbounds getindex(F::Fill{<:Any,0}) = getindex_value(F)
 
-Base.@propagate_inbounds @inline function _fill_getindex(A::AbstractFill, I::Vararg{Union{Real, AbstractArray}, N}) where N
+Base.@propagate_inbounds function _fill_getindex(A::AbstractFill, I::Vararg{Union{Real, AbstractArray}, N}) where N
     @boundscheck checkbounds(A, I...)
     shape = Base.index_shape(I...)
     fillsimilar(A, shape)
 end
 
-Base.@propagate_inbounds @inline function _fill_getindex(A::AbstractFill, kr::AbstractArray{Bool})
+Base.@propagate_inbounds function _fill_getindex(A::AbstractFill, kr::AbstractArray{Bool})
    @boundscheck checkbounds(A, kr)
    fillsimilar(A, count(kr))
 end
 
-Base.@propagate_inbounds @inline Base._unsafe_getindex(::IndexStyle, F::AbstractFill, I::Vararg{Union{Real, AbstractArray}, N}) where N =
+Base._unsafe_getindex(::IndexStyle, F::AbstractFill, I::Vararg{Union{Real, AbstractArray}, N}) where N =
     @inbounds(return _fill_getindex(F, I...))
 
 
 
-getindex(A::AbstractFill, kr::AbstractVector{Bool}) = _fill_getindex(A, kr)
-getindex(A::AbstractFill, kr::AbstractArray{Bool}) = _fill_getindex(A, kr)
+Base.@propagate_inbounds getindex(A::AbstractFill, kr::AbstractVector{Bool}) = _fill_getindex(A, kr)
+Base.@propagate_inbounds getindex(A::AbstractFill, kr::AbstractArray{Bool}) = _fill_getindex(A, kr)
 
 sort(a::AbstractFill; kwds...) = a
 sort!(a::AbstractFill; kwds...) = a
@@ -329,7 +329,7 @@ axes(T::AbstractTriangular{<:Any,<:AbstractFill}) = axes(parent(T))
 axes(rd::RectDiagonal) = rd.axes
 size(rd::RectDiagonal) = length.(rd.axes)
 
-@inline function getindex(rd::RectDiagonal{T}, i::Integer, j::Integer) where T
+Base.@propagate_inbounds function getindex(rd::RectDiagonal{T}, i::Integer, j::Integer) where T
     @boundscheck checkbounds(rd, i, j)
     if i == j
         @inbounds r = rd.diag[i]
@@ -339,7 +339,7 @@ size(rd::RectDiagonal) = length.(rd.axes)
     return r
 end
 
-function setindex!(rd::RectDiagonal, v, i::Integer, j::Integer)
+Base.@propagate_inbounds function setindex!(rd::RectDiagonal, v, i::Integer, j::Integer)
     @boundscheck checkbounds(rd, i, j)
     if i == j
         @inbounds rd.diag[i] = v


### PR DESCRIPTION
I noticed the compiler wasn't quite reducing things as it should, so here are some edits to (hopefully) improve performance. Thanks to @mbauman and @YingboMa for Slack discussion.

Suppose we have
```julia
julia> Z = Zeros(10)
10-element Zeros{Float64}

julia> f(z,j) = @inbounds z[j]
f (generic function with 1 method)
```

Then

# Before

```julia
julia> @code_llvm f(Z,3)
;  @ REPL[5]:1 within `f`
define double @julia_f_2043([1 x [1 x [1 x i64]]]* nocapture nonnull readonly align 8 dereferenceable(8) %0, i64 signext %1) #0 {
top:
  %2 = alloca [1 x i64], align 8
; ┌ @ /home/chad/git/FillArrays.jl/src/FillArrays.jl:42 within `getindex`
; │┌ @ /home/chad/git/FillArrays.jl/src/FillArrays.jl:37 within `_fill_getindex`
    %3 = getelementptr inbounds [1 x i64], [1 x i64]* %2, i64 0, i64 0
    store i64 %1, i64* %3, align 8
; ││┌ @ abstractarray.jl:659 within `checkbounds` @ abstractarray.jl:644
; │││┌ @ abstractarray.jl:718 within `checkindex`
; ││││┌ @ int.jl:471 within `<=`
       %4 = icmp slt i64 %1, 1
; ││││└
; ││││┌ @ range.jl:686 within `last`
; │││││┌ @ Base.jl:42 within `getproperty`
        %5 = getelementptr inbounds [1 x [1 x [1 x i64]]], [1 x [1 x [1 x i64]]]* %0, i64 0, i64 0, i64 0, i64 0
; ││││└└
; ││││┌ @ int.jl:471 within `<=`
       %6 = load i64, i64* %5, align 8
       %7 = icmp slt i64 %6, %1
; │││└└
; │││ @ abstractarray.jl:659 within `checkbounds`
     %8 = or i1 %4, %7
     br i1 %8, label %L12, label %L17

L12:                                              ; preds = %top
     %9 = call nonnull {}* @j_throw_boundserror_2045([1 x [1 x [1 x i64]]]* nocapture nonnull readonly %0, [1 x i64]* nocapture readonly %2) #0
     call void @llvm.trap()
     unreachable

L17:                                              ; preds = %top
; └└└
  ret double 0.000000e+00
}
```

# After

```julia
julia> @code_llvm f(Z,3)
;  @ REPL[5]:1 within `f`
define double @julia_f_1017([1 x [1 x [1 x i64]]]* nocapture nonnull readonly align 8 dereferenceable(8) %0, i64 signext %1) #0 {
top:
  ret double 0.000000e+00
}
```