### PR TITLE
Methods for `issymmetric` & `ishermitian`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FillArrays"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "0.12.1"
+version = "0.12.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -9,7 +9,8 @@ import Base: size, getindex, setindex!, IndexStyle, checkbounds, convert,
     show, view, in, mapreduce
 
 import LinearAlgebra: rank, svdvals!, tril, triu, tril!, triu!, diag, transpose, adjoint, fill!,
-    dot, norm2, norm1, normInf, normMinusInf, normp, lmul!, rmul!, diagzero, AbstractTriangular, AdjointAbsVec
+    dot, norm2, norm1, normInf, normMinusInf, normp, lmul!, rmul!, diagzero, AbstractTriangular, AdjointAbsVec,
+    issymmetric, ishermitian
 
 import Base.Broadcast: broadcasted, DefaultArrayStyle, broadcast_shape
 
@@ -61,6 +62,8 @@ end
 rank(F::AbstractFill) = iszero(getindex_value(F)) ? 0 : 1
 IndexStyle(::Type{<:AbstractFill{<:Any,N,<:NTuple{N,Base.OneTo{Int}}}}) where N = IndexLinear()
 
+issymmetric(F::AbstractFill) = axes(F,1) == axes(F,2)
+ishermitian(F::AbstractFill) = issymmetric(F) & iszero(imag(getindex_value(F)))
 
 """
     Fill{T, N, Axes}

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -63,7 +63,7 @@ rank(F::AbstractFill) = iszero(getindex_value(F)) ? 0 : 1
 IndexStyle(::Type{<:AbstractFill{<:Any,N,<:NTuple{N,Base.OneTo{Int}}}}) where N = IndexLinear()
 
 issymmetric(F::AbstractFill{<:Any, 2}) = axes(F,1) == axes(F,2)
-ishermitian(F::AbstractFill{<:Any, 2}) = issymmetric(F) & iszero(imag(getindex_value(F)))
+ishermitian(F::AbstractFill{<:Any, 2}) = issymmetric(F) && iszero(imag(getindex_value(F)))
 
 """
     Fill{T, N, Axes}

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -62,8 +62,8 @@ end
 rank(F::AbstractFill) = iszero(getindex_value(F)) ? 0 : 1
 IndexStyle(::Type{<:AbstractFill{<:Any,N,<:NTuple{N,Base.OneTo{Int}}}}) where N = IndexLinear()
 
-issymmetric(F::AbstractFill) = axes(F,1) == axes(F,2)
-ishermitian(F::AbstractFill) = issymmetric(F) & iszero(imag(getindex_value(F)))
+issymmetric(F::AbstractFill{<:Any, 2}) = axes(F,1) == axes(F,2)
+ishermitian(F::AbstractFill{<:Any, 2}) = issymmetric(F) & iszero(imag(getindex_value(F)))
 
 """
     Fill{T, N, Axes}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -411,6 +411,13 @@ end
     @test rank(Eye(2)) == 2
 end
 
+@testset "ishermitian" begin
+    for el in (2, 3+0im, 4+5im), size in [(3,3), (3,4)]
+        @test issymmetric(Fill(el, size...)) == issymmetric(fill(el, size...))
+        @test ishermitian(Fill(el, size...)) == ishermitian(fill(el, size...))
+    end
+end
+
 @testset "BigInt indices" begin
     for A in (Zeros(BigInt(100)), Ones(BigInt(100)), Fill(2, BigInt(100)))
         @test length(A) isa BigInt


### PR DESCRIPTION
Right now these iterate through, needlessly:
```
julia> @btime ishermitian(Fill(1, 10, 10))
  33.911 ns (0 allocations: 0 bytes)
true

julia> @btime ishermitian(Fill(1, 1000, 1000))
  215.875 μs (0 allocations: 0 bytes)
true
```