### PR TITLE
broadcasting with literal powers returns fills

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FillArrays"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "0.12.2"
+version = "0.12.3"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/fillbroadcast.jl
+++ b/src/fillbroadcast.jl
@@ -244,3 +244,9 @@ broadcasted(::DefaultArrayStyle{N}, op, r::AbstractFill{T,N}, x::Number) where {
 broadcasted(::DefaultArrayStyle{N}, op, x::Number, r::AbstractFill{T,N}) where {T,N} = Fill(op(x, getindex_value(r)), axes(r))
 broadcasted(::DefaultArrayStyle{N}, op, r::AbstractFill{T,N}, x::Ref) where {T,N} = Fill(op(getindex_value(r),x[]), axes(r))
 broadcasted(::DefaultArrayStyle{N}, op, x::Ref, r::AbstractFill{T,N}) where {T,N} = Fill(op(x[], getindex_value(r)), axes(r))
+
+# support AbstractFill .^ k
+broadcasted(::DefaultArrayStyle{N}, ::typeof(Base.literal_pow), ::Base.RefValue{typeof(^)}, r::AbstractFill{T,N}, ::Base.RefValue{Val{k}}) where {T,N,k} = Fill(getindex_value(r)^k, axes(r))
+broadcasted(::DefaultArrayStyle{N}, ::typeof(Base.literal_pow), ::Base.RefValue{typeof(^)}, r::Ones{T,N}, ::Base.RefValue{Val{k}}) where {T,N,k} = Ones{T}(axes(r))
+broadcasted(::DefaultArrayStyle{N}, ::typeof(Base.literal_pow), ::Base.RefValue{typeof(^)}, r::Zeros{T,N}, ::Base.RefValue{Val{0}}) where {T,N} = Ones{T}(axes(r))
+broadcasted(::DefaultArrayStyle{N}, ::typeof(Base.literal_pow), ::Base.RefValue{typeof(^)}, r::Zeros{T,N}, ::Base.RefValue{Val{k}}) where {T,N,k} = Zeros{T}(axes(r))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -585,6 +585,7 @@ end
     @test x .+ Ones(5) ≡ Fill(6.0,5)
     f = (x,y) -> cos(x*y)
     @test f.(x, Ones(5)) ≡ Fill(f(5,1.0),5)
+    @test x .^ 1 ≡ Fill(5,5)
 
     y = Ones(5,5)
     @test (.+)(y) ≡ Ones(5,5)
@@ -593,6 +594,7 @@ end
     @test y .+ 1 ≡ Fill(2.0,5,5)
     @test y .+ y ≡ Fill(2.0,5,5)
     @test y .* y ≡ y ./ y ≡ y .\ y ≡ y
+    @test y .^ 1 ≡ y .^ 0 ≡ Ones(5,5)
 
     rng = MersenneTwister(123456)
     sizes = [(5, 4), (5, 1), (1, 4), (1, 1), (5,)]
@@ -620,6 +622,8 @@ end
         end
     end
 
+    @test Zeros{Int}(5) .^ 0 ≡ Ones{Int}(5)
+    @test Zeros{Int}(5) .^ 1 ≡ Zeros{Int}(5)
     @test Zeros{Int}(5) .+ Zeros(5) isa Zeros{Float64}
 
     # Test for conj, real and imag with complex element types


### PR DESCRIPTION
This is useful in Julia v1.7 where Diagonal matrices raised to powers lower to broadcasting of the diagonal.