### PR TITLE
Handle changed `copy_oftype`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,6 @@
 name: CI
-push:
+on:
+  push:
     branches:
       - master
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,8 @@
 name: CI
-on:
-  - push
-  - pull_request
+push:
+    branches:
+      - master
+  pull_request:
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
@@ -12,7 +13,7 @@ jobs:
         version:
           - '1.6'
           - '1'
-          - '^1.7.0-0'
+          - '^1.8.0-0'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FillArrays"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "0.14.0"
+version = "0.13.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FillArrays"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "0.13.1"
+version = "0.14.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FillArrays"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "0.13.0"
+version = "0.14.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/fillbroadcast.jl
+++ b/src/fillbroadcast.jl
@@ -197,14 +197,11 @@ function broadcasted(::DefaultArrayStyle{1}, ::typeof(*), a::AbstractRange{V}, b
     return _range_convert(AbstractVector{promote_type(T,V)}, a)
 end
 
-copy_oftype(A::AbstractArray{T}, ::Type{T}) where {T} = copy(A)
-copy_oftype(A::AbstractArray{T,N}, ::Type{S}) where {T,N,S} = convert(AbstractArray{S,N}, A)
-
 for op in (:+, -)
     @eval begin
         function broadcasted(::DefaultArrayStyle{1}, ::typeof($op), a::AbstractVector{T}, b::Zeros{V,1}) where {T,V}
             broadcast_shape(axes(a), axes(b)) == axes(a) || throw(ArgumentError("Cannot broadcast $a and $b. Convert $b to a Vector first."))
-            copy_oftype(a, promote_type(T,V))
+            map(promote_type(T, V), a)
         end
 
         broadcasted(::DefaultArrayStyle{1}, ::typeof($op), a::AbstractFill{T,1}, b::Zeros{V,1}) where {T,V} =
@@ -214,7 +211,7 @@ end
 
 function broadcasted(::DefaultArrayStyle{1}, ::typeof(+), a::Zeros{T,1}, b::AbstractVector{V}) where {T,V}
     broadcast_shape(axes(a), axes(b))
-    copy_oftype(b, promote_type(T,V))
+    map(promote_type(T, V), b)
 end
 
 broadcasted(::DefaultArrayStyle{1}, ::typeof(+), a::Zeros{V,1}, b::AbstractFill{T,1}) where {T,V} = 

--- a/src/fillbroadcast.jl
+++ b/src/fillbroadcast.jl
@@ -197,21 +197,24 @@ function broadcasted(::DefaultArrayStyle{1}, ::typeof(*), a::AbstractRange{V}, b
     return _range_convert(AbstractVector{promote_type(T,V)}, a)
 end
 
+copy_oftype(A::AbstractArray{T}, ::Type{T}) where {T} = copy(A)
+copy_oftype(A::AbstractArray{T,N}, ::Type{S}) where {T,N,S} = convert(AbstractArray{S,N}, A)
+
 for op in (:+, -)
     @eval begin
         function broadcasted(::DefaultArrayStyle{1}, ::typeof($op), a::AbstractVector{T}, b::Zeros{V,1}) where {T,V}
             broadcast_shape(axes(a), axes(b)) == axes(a) || throw(ArgumentError("Cannot broadcast $a and $b. Convert $b to a Vector first."))
-            copy(a)
+            copy_oftype(a, promote_type(T,V))
         end
 
-        broadcasted(::DefaultArrayStyle{1}, ::typeof($op), a::AbstractFill{T,1}, b::Zeros{V,1}) where {T,V} = 
+        broadcasted(::DefaultArrayStyle{1}, ::typeof($op), a::AbstractFill{T,1}, b::Zeros{V,1}) where {T,V} =
             Base.invoke(broadcasted, Tuple{DefaultArrayStyle, typeof($op), AbstractFill, AbstractFill}, DefaultArrayStyle{1}(), $op, a, b)
     end
 end
 
 function broadcasted(::DefaultArrayStyle{1}, ::typeof(+), a::Zeros{T,1}, b::AbstractVector{V}) where {T,V}
     broadcast_shape(axes(a), axes(b))
-    copy(b)
+    copy_oftype(b, promote_type(T,V))
 end
 
 broadcasted(::DefaultArrayStyle{1}, ::typeof(+), a::Zeros{V,1}, b::AbstractFill{T,1}) where {T,V} = 

--- a/src/fillbroadcast.jl
+++ b/src/fillbroadcast.jl
@@ -201,7 +201,7 @@ for op in (:+, -)
     @eval begin
         function broadcasted(::DefaultArrayStyle{1}, ::typeof($op), a::AbstractVector{T}, b::Zeros{V,1}) where {T,V}
             broadcast_shape(axes(a), axes(b)) == axes(a) || throw(ArgumentError("Cannot broadcast $a and $b. Convert $b to a Vector first."))
-            LinearAlgebra.copy_oftype(a, promote_type(T,V))
+            copy(a)
         end
 
         broadcasted(::DefaultArrayStyle{1}, ::typeof($op), a::AbstractFill{T,1}, b::Zeros{V,1}) where {T,V} = 
@@ -211,7 +211,7 @@ end
 
 function broadcasted(::DefaultArrayStyle{1}, ::typeof(+), a::Zeros{T,1}, b::AbstractVector{V}) where {T,V}
     broadcast_shape(axes(a), axes(b))
-    LinearAlgebra.copy_oftype(b, promote_type(T,V))
+    copy(b)
 end
 
 broadcasted(::DefaultArrayStyle{1}, ::typeof(+), a::Zeros{V,1}, b::AbstractFill{T,1}) where {T,V} = 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1053,8 +1053,6 @@ end
 
     @test copy(m) ≡ m
     @test copy(D) ≡ D
-    @test FillArrays.copy_oftype(m, Int) ≡ Eye{Int}(10)
-    @test FillArrays.copy_oftype(D, Float64) ≡ Diagonal(Fill(2.0,10))
 end
 
 @testset "Issue #31" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1053,6 +1053,8 @@ end
 
     @test copy(m) ≡ m
     @test copy(D) ≡ D
+    @test FillArrays.copy_oftype(m, Int) ≡ Eye{Int}(10)
+    @test FillArrays.copy_oftype(D, Float64) ≡ Diagonal(Fill(2.0,10))
 end
 
 @testset "Issue #31" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1053,6 +1053,8 @@ end
 
     @test copy(m) ≡ m
     @test copy(D) ≡ D
+    @test FillArrays._copy_oftype(m, Int) ≡ Eye{Int}(10)
+    @test FillArrays._copy_oftype(D, Float64) ≡ Diagonal(Fill(2.0,10))
 end
 
 @testset "Issue #31" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1053,8 +1053,6 @@ end
 
     @test copy(m) ≡ m
     @test copy(D) ≡ D
-    @test LinearAlgebra.copy_oftype(m, Int) ≡ Eye{Int}(10)
-    @test LinearAlgebra.copy_oftype(D, Float64) ≡ Diagonal(Fill(2.0,10))
 end
 
 @testset "Issue #31" begin


### PR DESCRIPTION
This fixes the tests on Julia 1.8-beta1. This fixes the underlying problem of https://github.com/JuliaArrays/LazyArrays.jl/pull/205:

For example, on Julia 1.8:
```julia
julia> Base.broadcasted(-, 1:5, Zeros{Int}(5))
5-element Vector{Int64}:
 1
 2
 3
 4
 5
```
which used to be
```julia
julia> Base.broadcasted(-, 1:5, Zeros{Int}(5))
1:5
```

This was caused in changes to `LinearAlgebra.copy_oftype` in https://github.com/JuliaLang/julia/pull/40831. As far as I understand, the meaning of `copy_oftype` used to be wrong and is now correct. I've solved the problem here by calling `copy` directly instead of `copy_oftype`.