### PR TITLE
Specialize `iterate`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FillArrays"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "0.13.2"
+version = "0.13.3"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -185,7 +185,7 @@ getindex(A::AbstractFill, kr::AbstractArray{Bool}) = _fill_getindex(A, kr)
 
 @inline Base.iterate(F::AbstractFill) = length(F) == 0 ? nothing : (v = getindex_value(F); (v, (v, 1)))
 @inline function Base.iterate(F::AbstractFill, (v, n))
-    n > length(F) && return nothing
+    n >= length(F) && return nothing
     v, (v, n+1)
 end
 


### PR DESCRIPTION
On master:
```julia
julia> @btime fill(2, 300, 300);
  61.167 μs (2 allocations: 703.17 KiB)

julia> x = Fill(2, 300, 300);

julia> @btime [i for i in $x];
  77.769 μs (2 allocations: 703.17 KiB)
```
This PR makes them both equally fast:
```julia
julia> @btime [i for i in $x];
  60.280 μs (2 allocations: 703.17 KiB)
```
I've also removed some specializations of `sum`, as the specialized `Base._mapreduce_dim` covers these. On this PR:
```julia
julia> @btime sum(x->x^2, $x);
  3.355 ns (0 allocations: 0 bytes)

julia> @btime sum($x);
  3.358 ns (0 allocations: 0 bytes)
```