### PR TITLE
specialize sum for FillArrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,9 +13,8 @@ julia = "1.6"
 
 [extras]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
-InfiniteArrays = "4858937d-0d70-526a-a4dd-2d5cb5dd786c"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Base64", "InfiniteArrays", "StaticArrays"]
+test = ["Test", "Base64", "StaticArrays"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FillArrays"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "0.13.3"
+version = "0.13.4"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -13,8 +13,9 @@ julia = "1.6"
 
 [extras]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+InfiniteArrays = "4858937d-0d70-526a-a4dd-2d5cb5dd786c"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Base64", "StaticArrays"]
+test = ["Test", "Base64", "InfiniteArrays", "StaticArrays"]

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -515,6 +515,9 @@ end
 # Cumsum
 #########
 
+# These methods are necessary to deal with infinite arrays
+sum(x::AbstractFill) = getindex_value(x)*length(x)
+sum(f, x::AbstractFill) = length(x) * f(getindex_value(x))
 sum(x::Zeros) = getindex_value(x)
 
 cumsum(x::AbstractFill{<:Any,1}) = range(getindex_value(x); step=getindex_value(x),

--- a/test/infinitearrays.jl
+++ b/test/infinitearrays.jl
@@ -1,0 +1,65 @@
+# Infinite Arrays implementation from
+# https://github.com/JuliaLang/julia/blob/master/test/testhelpers/InfiniteArrays.jl
+module InfiniteArrays
+    export OneToInf, Infinity
+
+    """
+       Infinity()
+    Represents infinite cardinality. Note that `Infinity <: Integer` to support
+    being treated as an index.
+    """
+    struct Infinity <: Integer end
+
+    Base.:(==)(::Infinity, ::Int) = false
+    Base.:(==)(::Int, ::Infinity) = false
+    Base.:(<)(::Int, ::Infinity) = true
+    Base.:(<)(::Infinity, ::Int) = false
+    Base.:(≤)(::Int, ::Infinity) = true
+    Base.:(≤)(::Infinity, ::Int) = false
+    Base.:(≤)(::Infinity, ::Infinity) = true
+    Base.:(-)(::Infinity, ::Int) = Infinity()
+    Base.:(+)(::Infinity, ::Int) = Infinity()
+    Base.:(:)(::Infinity, ::Infinity) = 1:0
+
+    Base.:(+)(::Integer, ::Infinity) = Infinity()
+    Base.:(+)(::Infinity, ::Integer) = Infinity()
+    Base.:(*)(::Integer, ::Infinity) = Infinity()
+    Base.:(*)(::Infinity, ::Integer) = Infinity()
+
+    Base.isinf(::Infinity) = true
+
+    abstract type AbstractInfUnitRange{T<:Real} <: AbstractUnitRange{T} end
+    Base.length(r::AbstractInfUnitRange) = Infinity()
+    Base.size(r::AbstractInfUnitRange) = (Infinity(),)
+    Base.unitrange(r::AbstractInfUnitRange) = InfUnitRange(r)
+    Base.last(r::AbstractInfUnitRange) = Infinity()
+    Base.axes(r::AbstractInfUnitRange) = (OneToInf(),)
+
+    """
+        OneToInf(n)
+    Define an `AbstractInfUnitRange` that behaves like `1:∞`, with the added
+    distinction that the limits are guaranteed (by the type system) to
+    be 1 and ∞.
+    """
+    struct OneToInf{T<:Integer} <: AbstractInfUnitRange{T} end
+
+    OneToInf() = OneToInf{Int}()
+
+    Base.axes(r::OneToInf) = (r,)
+    Base.first(r::OneToInf{T}) where {T} = oneunit(T)
+    Base.oneto(::Infinity) = OneToInf()
+
+    struct InfUnitRange{T<:Real} <: AbstractInfUnitRange{T}
+        start::T
+    end
+    Base.first(r::InfUnitRange) = r.start
+    InfUnitRange(a::InfUnitRange) = a
+    InfUnitRange{T}(a::AbstractInfUnitRange) where T<:Real = InfUnitRange{T}(first(a))
+    InfUnitRange(a::AbstractInfUnitRange{T}) where T<:Real = InfUnitRange{T}(first(a))
+    unitrange(a::AbstractInfUnitRange) = InfUnitRange(a)
+    Base.:(:)(start::T, stop::Infinity) where {T<:Integer} = InfUnitRange{T}(start)
+    function getindex(v::InfUnitRange{T}, i::Integer) where T
+        @boundscheck i > 0 || Base.throw_boundserror(v, i)
+        convert(T, first(v) + i - 1)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,71 @@
 using FillArrays, LinearAlgebra, SparseArrays, StaticArrays, Random, Base64, Test, Statistics
 import FillArrays: AbstractFill, RectDiagonal, SquareEye
-import InfiniteArrays: OneToInf
+
+# Infinite Arrays implementation from
+# https://github.com/JuliaLang/julia/blob/master/test/testhelpers/InfiniteArrays.jl
+module InfiniteArrays
+    export OneToInf, Infinity
+
+    """
+       Infinity()
+    Represents infinite cardinality. Note that `Infinity <: Integer` to support
+    being treated as an index.
+    """
+    struct Infinity <: Integer end
+
+    Base.:(==)(::Infinity, ::Int) = false
+    Base.:(==)(::Int, ::Infinity) = false
+    Base.:(<)(::Int, ::Infinity) = true
+    Base.:(<)(::Infinity, ::Int) = false
+    Base.:(≤)(::Int, ::Infinity) = true
+    Base.:(≤)(::Infinity, ::Int) = false
+    Base.:(≤)(::Infinity, ::Infinity) = true
+    Base.:(-)(::Infinity, ::Int) = Infinity()
+    Base.:(+)(::Infinity, ::Int) = Infinity()
+    Base.:(:)(::Infinity, ::Infinity) = 1:0
+
+    Base.:(+)(::Integer, ::Infinity) = Infinity()
+    Base.:(+)(::Infinity, ::Integer) = Infinity()
+    Base.:(*)(::Integer, ::Infinity) = Infinity()
+    Base.:(*)(::Infinity, ::Integer) = Infinity()
+
+    Base.isinf(::Infinity) = true
+
+    abstract type AbstractInfUnitRange{T<:Real} <: AbstractUnitRange{T} end
+    Base.length(r::AbstractInfUnitRange) = Infinity()
+    Base.size(r::AbstractInfUnitRange) = (Infinity(),)
+    Base.unitrange(r::AbstractInfUnitRange) = InfUnitRange(r)
+    Base.last(r::AbstractInfUnitRange) = Infinity()
+    Base.axes(r::AbstractInfUnitRange) = (OneToInf(),)
+
+    """
+        OneToInf(n)
+    Define an `AbstractInfUnitRange` that behaves like `1:∞`, with the added
+    distinction that the limits are guaranteed (by the type system) to
+    be 1 and ∞.
+    """
+    struct OneToInf{T<:Integer} <: AbstractInfUnitRange{T} end
+
+    OneToInf() = OneToInf{Int}()
+
+    Base.axes(r::OneToInf) = (r,)
+    Base.first(r::OneToInf{T}) where {T} = oneunit(T)
+    Base.oneto(::Infinity) = OneToInf()
+
+    struct InfUnitRange{T<:Real} <: AbstractInfUnitRange{T}
+        start::T
+    end
+    Base.first(r::InfUnitRange) = r.start
+    InfUnitRange(a::InfUnitRange) = a
+    InfUnitRange{T}(a::AbstractInfUnitRange) where T<:Real = InfUnitRange{T}(first(a))
+    InfUnitRange(a::AbstractInfUnitRange{T}) where T<:Real = InfUnitRange{T}(first(a))
+    unitrange(a::AbstractInfUnitRange) = InfUnitRange(a)
+    Base.:(:)(start::T, stop::Infinity) where {T<:Integer} = InfUnitRange{T}(start)
+    function getindex(v::InfUnitRange{T}, i::Integer) where T
+        @boundscheck i > 0 || Base.throw_boundserror(v, i)
+        convert(T, first(v) + i - 1)
+    end
+end
 
 @testset "fill array constructors and convert" begin
     for (Typ, funcs) in ((:Zeros, :zeros), (:Ones, :ones))
@@ -623,7 +688,7 @@ end
     @test_throws UndefKeywordError cumsum(Fill(1,1,5))
 
     @testset "infinite arrays" begin
-        A = Ones((OneToInf(),))
+        A = Ones{Int}((InfiniteArrays.OneToInf(),))
         @test isinf(sum(A))
         @test sum(A) == length(A)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -627,7 +627,7 @@ end
         A = Ones{Int}((InfiniteArrays.OneToInf(),))
         @test isinf(sum(A))
         @test sum(A) == length(A)
-        @test sum(x->x^2, A) == length(A)
+        @test sum(x->x^2, A) == sum(A.^2)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,71 +1,7 @@
 using FillArrays, LinearAlgebra, SparseArrays, StaticArrays, Random, Base64, Test, Statistics
 import FillArrays: AbstractFill, RectDiagonal, SquareEye
 
-# Infinite Arrays implementation from
-# https://github.com/JuliaLang/julia/blob/master/test/testhelpers/InfiniteArrays.jl
-module InfiniteArrays
-    export OneToInf, Infinity
-
-    """
-       Infinity()
-    Represents infinite cardinality. Note that `Infinity <: Integer` to support
-    being treated as an index.
-    """
-    struct Infinity <: Integer end
-
-    Base.:(==)(::Infinity, ::Int) = false
-    Base.:(==)(::Int, ::Infinity) = false
-    Base.:(<)(::Int, ::Infinity) = true
-    Base.:(<)(::Infinity, ::Int) = false
-    Base.:(≤)(::Int, ::Infinity) = true
-    Base.:(≤)(::Infinity, ::Int) = false
-    Base.:(≤)(::Infinity, ::Infinity) = true
-    Base.:(-)(::Infinity, ::Int) = Infinity()
-    Base.:(+)(::Infinity, ::Int) = Infinity()
-    Base.:(:)(::Infinity, ::Infinity) = 1:0
-
-    Base.:(+)(::Integer, ::Infinity) = Infinity()
-    Base.:(+)(::Infinity, ::Integer) = Infinity()
-    Base.:(*)(::Integer, ::Infinity) = Infinity()
-    Base.:(*)(::Infinity, ::Integer) = Infinity()
-
-    Base.isinf(::Infinity) = true
-
-    abstract type AbstractInfUnitRange{T<:Real} <: AbstractUnitRange{T} end
-    Base.length(r::AbstractInfUnitRange) = Infinity()
-    Base.size(r::AbstractInfUnitRange) = (Infinity(),)
-    Base.unitrange(r::AbstractInfUnitRange) = InfUnitRange(r)
-    Base.last(r::AbstractInfUnitRange) = Infinity()
-    Base.axes(r::AbstractInfUnitRange) = (OneToInf(),)
-
-    """
-        OneToInf(n)
-    Define an `AbstractInfUnitRange` that behaves like `1:∞`, with the added
-    distinction that the limits are guaranteed (by the type system) to
-    be 1 and ∞.
-    """
-    struct OneToInf{T<:Integer} <: AbstractInfUnitRange{T} end
-
-    OneToInf() = OneToInf{Int}()
-
-    Base.axes(r::OneToInf) = (r,)
-    Base.first(r::OneToInf{T}) where {T} = oneunit(T)
-    Base.oneto(::Infinity) = OneToInf()
-
-    struct InfUnitRange{T<:Real} <: AbstractInfUnitRange{T}
-        start::T
-    end
-    Base.first(r::InfUnitRange) = r.start
-    InfUnitRange(a::InfUnitRange) = a
-    InfUnitRange{T}(a::AbstractInfUnitRange) where T<:Real = InfUnitRange{T}(first(a))
-    InfUnitRange(a::AbstractInfUnitRange{T}) where T<:Real = InfUnitRange{T}(first(a))
-    unitrange(a::AbstractInfUnitRange) = InfUnitRange(a)
-    Base.:(:)(start::T, stop::Infinity) where {T<:Integer} = InfUnitRange{T}(start)
-    function getindex(v::InfUnitRange{T}, i::Integer) where T
-        @boundscheck i > 0 || Base.throw_boundserror(v, i)
-        convert(T, first(v) + i - 1)
-    end
-end
+include("infinitearrays.jl")
 
 @testset "fill array constructors and convert" begin
     for (Typ, funcs) in ((:Zeros, :zeros), (:Ones, :ones))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -627,6 +627,7 @@ end
         A = Ones{Int}((InfiniteArrays.OneToInf(),))
         @test isinf(sum(A))
         @test sum(A) == length(A)
+        @test sum(x->x^2, A) == length(A)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using FillArrays, LinearAlgebra, SparseArrays, StaticArrays, Random, Base64, Test, Statistics
 import FillArrays: AbstractFill, RectDiagonal, SquareEye
+import InfiniteArrays: OneToInf
 
 @testset "fill array constructors and convert" begin
     for (Typ, funcs) in ((:Zeros, :zeros), (:Ones, :ones))
@@ -620,6 +621,12 @@ end
     @test diff(Fill(1,10)) ≡ Zeros{Int}(9)
     @test diff(Ones{Float64}(10)) ≡ Zeros{Float64}(9)
     @test_throws UndefKeywordError cumsum(Fill(1,1,5))
+
+    @testset "infinite arrays" begin
+        A = Ones((InfiniteArrays.OneToInf(),))
+        @test isinf(sum(A))
+        @test sum(A) == length(A)
+    end
 end
 
 @testset "Broadcast" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -623,7 +623,7 @@ end
     @test_throws UndefKeywordError cumsum(Fill(1,1,5))
 
     @testset "infinite arrays" begin
-        A = Ones((InfiniteArrays.OneToInf(),))
+        A = Ones((OneToInf(),))
         @test isinf(sum(A))
         @test sum(A) == length(A)
     end


### PR DESCRIPTION
The specialized `sum` was removed in #181, relying on the specialized `mapreduce` instead. While this is fine for finite-sized arrays, it doesn't seem to work for infinite arrays. This PR reverts that change. With `sum` specialized, the following works in `O(1)` time again:
```julia
julia> using FillArrays, InfiniteArrays

julia> A = Ones((InfiniteArrays.OneToInf(),))
ℵ₀-element Ones{Float64, 1, Tuple{InfiniteArrays.OneToInf{Int64}}} with indices OneToInf()

julia> @time sum(A)
  0.000006 seconds
+∞
```
Ideally, we would be able to get `mapreduce` to work for infinite arrays, but this should avoid breaking code meanwhile.