### PR TITLE
Set `IndexStyle` to `IndexLinear` for `AbstractFill`

### DIFF
--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -56,7 +56,7 @@ end
 end
 
 rank(F::AbstractFill) = iszero(getindex_value(F)) ? 0 : 1
-IndexStyle(::Type{<:AbstractFill{<:Any,N,<:NTuple{N,Base.OneTo{Int}}}}) where N = IndexLinear()
+IndexStyle(::Type{<:AbstractFill}) = IndexLinear()
 
 issymmetric(F::AbstractFill{<:Any, 2}) = axes(F,1) == axes(F,2)
 ishermitian(F::AbstractFill{<:Any, 2}) = issymmetric(F) && iszero(imag(getindex_value(F)))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -478,6 +478,17 @@ end
 
 @testset "IndexStyle" begin
     @test IndexStyle(Zeros(5,5)) == IndexStyle(typeof(Zeros(5,5))) == IndexLinear()
+    for ax in (Base.OneTo(2), SOneTo(2), Base.IdentityUnitRange(2:3))
+        for f in (Fill(1, (ax,)), Fill(1, (ax,ax)),
+                    Zeros{Int}((ax,)), Zeros{Int}((ax, ax)),
+                    Ones{Int}((ax,)), Ones{Int}((ax, ax)),
+                    )
+            @test IndexStyle(f) == IndexLinear()
+            for (CI, LI) in zip(CartesianIndices(f), LinearIndices(f))
+                @test f[CI] == f[LI]
+            end
+        end
+    end
 end
 
 @testset "Identities" begin


### PR DESCRIPTION
Closes #195 by setting the default `IndexStyle` to `IndexLinear` for all `AbstractFill`

Edit: Oddly, this makes certain benchmarks worse, so let's hold off on merging this for a bit
```julia
julia> f = Fill(1, (SOneTo(32),));

julia> fo = OffsetArray(f, 4);

julia> @btime sum($fo);
  3.353 ns (0 allocations: 0 bytes) # master
  17.115 ns (0 allocations: 0 bytes) # PR
```