### PR TITLE
`IteratorSize` for infinite `AbstractFill`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
         version:
           - '1.6'
           - '1'
+          - '~1.9.0-0'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FillArrays"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "0.13.6"
+version = "0.13.7"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -64,10 +64,18 @@ ishermitian(F::AbstractFill{<:Any, 2}) = issymmetric(F) && iszero(imag(getindex_
 Base.IteratorSize(::Type{<:AbstractFill{T,N,Axes}}) where {T,N,Axes} = _IteratorSize(Axes)
 _IteratorSize(::Type{Tuple{}}) = Base.HasShape{0}()
 _IteratorSize(::Type{Tuple{T}}) where {T} = Base.IteratorSize(T)
+# Julia Base has an optimized any for Tuples for versions >= v1.9
+# For lower versions, a recursive implementation might be easier for type-inference
+if VERSION >= v"1.9.0-beta3"
+    _any(f, t::Tuple) = any(f, t)
+else
+    _any(f, ::Tuple{}) = false
+    _any(f, t::Tuple) = f(t[1]) || _any(f, Base.tail(t))
+end
 function _IteratorSize(::Type{T}) where {T<:Tuple}
     N = fieldcount(T)
     s = ntuple(i-> Base.IteratorSize(fieldtype(T, i)), N)
-    any(x -> x isa Base.IsInfinite, s) ? Base.IsInfinite() : Base.HasShape{N}()
+    _any(x -> x isa Base.IsInfinite, s) ? Base.IsInfinite() : Base.HasShape{N}()
 end
 
 

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -61,6 +61,12 @@ IndexStyle(::Type{<:AbstractFill{<:Any,N,<:NTuple{N,Base.OneTo{Int}}}}) where N 
 issymmetric(F::AbstractFill{<:Any, 2}) = axes(F,1) == axes(F,2)
 ishermitian(F::AbstractFill{<:Any, 2}) = issymmetric(F) && iszero(imag(getindex_value(F)))
 
+axestype(::Type{<:AbstractFill{<:Any,<:Any,Axes}}) where {Axes} = Axes
+
+Base.IteratorSize(::Type{A}) where {A<:AbstractFill} =
+    Base.IteratorSize(Iterators.ProductIterator{axestype(A)})
+
+
 """
     Fill{T, N, Axes} where {T,N,Axes<:Tuple{Vararg{AbstractUnitRange,N}}}
 

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -61,10 +61,14 @@ IndexStyle(::Type{<:AbstractFill{<:Any,N,<:NTuple{N,Base.OneTo{Int}}}}) where N 
 issymmetric(F::AbstractFill{<:Any, 2}) = axes(F,1) == axes(F,2)
 ishermitian(F::AbstractFill{<:Any, 2}) = issymmetric(F) && iszero(imag(getindex_value(F)))
 
-axestype(::Type{<:AbstractFill{<:Any,<:Any,Axes}}) where {Axes} = Axes
-
-Base.IteratorSize(::Type{A}) where {A<:AbstractFill} =
-    Base.IteratorSize(Iterators.ProductIterator{axestype(A)})
+Base.IteratorSize(::Type{<:AbstractFill{T,N,Axes}}) where {T,N,Axes} = _IteratorSize(Axes)
+_IteratorSize(::Type{Tuple{}}) = Base.HasShape{0}()
+_IteratorSize(::Type{Tuple{T}}) where {T} = Base.IteratorSize(T)
+function _IteratorSize(::Type{T}) where {T<:Tuple}
+    N = fieldcount(T)
+    s = ntuple(i-> Base.IteratorSize(fieldtype(T, i)), N)
+    any(x -> x isa Base.IsInfinite, s) ? Base.IsInfinite() : Base.HasShape{N}()
+end
 
 
 """

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -64,8 +64,8 @@ ishermitian(F::AbstractFill{<:Any, 2}) = issymmetric(F) && iszero(imag(getindex_
 Base.IteratorSize(::Type{<:AbstractFill{T,N,Axes}}) where {T,N,Axes} = _IteratorSize(Axes)
 _IteratorSize(::Type{Tuple{}}) = Base.HasShape{0}()
 _IteratorSize(::Type{Tuple{T}}) where {T} = Base.IteratorSize(T)
-# Julia Base has an optimized any for Tuples for versions >= v1.9
-# For lower versions, a recursive implementation might be easier for type-inference
+# Julia Base has an optimized any for Tuples on versions >= v1.9
+# On lower versions, a recursive implementation helps with type-inference
 if VERSION >= v"1.9.0-beta3"
     _any(f, t::Tuple) = any(f, t)
 else

--- a/test/infinitearrays.jl
+++ b/test/infinitearrays.jl
@@ -35,6 +35,8 @@ module InfiniteArrays
     Base.last(r::AbstractInfUnitRange) = Infinity()
     Base.axes(r::AbstractInfUnitRange) = (OneToInf(),)
 
+    Base.IteratorSize(::Type{<:AbstractInfUnitRange}) = Base.IsInfinite()
+
     """
         OneToInf(n)
     Define an `AbstractInfUnitRange` that behaves like `1:∞`, with the added

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -644,13 +644,13 @@ end
         @test sum(A) == length(A)
         @test sum(x->x^2, A) == sum(A.^2)
         @testset "IteratorSize" begin
-            @test Base.IteratorSize(Ones()) == Base.IteratorSize(ones())
-            @test Base.IteratorSize(Ones(2)) == Base.IteratorSize(ones(2))
-            @test Base.IteratorSize(Ones(r)) == Base.IsInfinite()
-            @test Base.IteratorSize(Fill(2, (1:2, 1:2))) == Base.HasShape{2}()
-            @test Base.IteratorSize(Fill(2, (1:2, r))) == Base.IsInfinite()
-            @test Base.IteratorSize(Fill(2, (r, 1:2))) == Base.IsInfinite()
-            @test Base.IteratorSize(Fill(2, (r, r))) == Base.IsInfinite()
+            @test (@inferred Base.IteratorSize(Ones())) == Base.IteratorSize(ones())
+            @test (@inferred Base.IteratorSize(Ones(2))) == Base.IteratorSize(ones(2))
+            @test (@inferred Base.IteratorSize(Ones(r))) == Base.IsInfinite()
+            @test (@inferred Base.IteratorSize(Fill(2, (1:2, 1:2)))) == Base.HasShape{2}()
+            @test (@inferred Base.IteratorSize(Fill(2, (1:2, r)))) == Base.IsInfinite()
+            @test (@inferred Base.IteratorSize(Fill(2, (r, 1:2)))) == Base.IsInfinite()
+            @test (@inferred Base.IteratorSize(Fill(2, (r, r)))) == Base.IsInfinite()
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -638,10 +638,13 @@ end
     @test_throws UndefKeywordError cumsum(Fill(1,1,5))
 
     @testset "infinite arrays" begin
-        A = Ones{Int}((InfiniteArrays.OneToInf(),))
+        r = InfiniteArrays.OneToInf()
+        A = Ones{Int}((r,))
         @test isinf(sum(A))
         @test sum(A) == length(A)
         @test sum(x->x^2, A) == sum(A.^2)
+        @test Base.IteratorSize(A) == Base.IsInfinite()
+        @test Base.IteratorSize(Fill(2, (1:2, r))) == Base.IsInfinite()
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -643,8 +643,15 @@ end
         @test isinf(sum(A))
         @test sum(A) == length(A)
         @test sum(x->x^2, A) == sum(A.^2)
-        @test Base.IteratorSize(A) == Base.IsInfinite()
-        @test Base.IteratorSize(Fill(2, (1:2, r))) == Base.IsInfinite()
+        @testset "IteratorSize" begin
+            @test Base.IteratorSize(Ones()) == Base.IteratorSize(ones())
+            @test Base.IteratorSize(Ones(2)) == Base.IteratorSize(ones(2))
+            @test Base.IteratorSize(Ones(r)) == Base.IsInfinite()
+            @test Base.IteratorSize(Fill(2, (1:2, 1:2))) == Base.HasShape{2}()
+            @test Base.IteratorSize(Fill(2, (1:2, r))) == Base.IsInfinite()
+            @test Base.IteratorSize(Fill(2, (r, 1:2))) == Base.IsInfinite()
+            @test Base.IteratorSize(Fill(2, (r, r))) == Base.IsInfinite()
+        end
     end
 end
 


### PR DESCRIPTION
Implement `IteratorSize` by looping over the types of the axes, and checking if any of them is infinite. With this and https://github.com/JuliaArrays/InfiniteArrays.jl/pull/105, we obtain
```julia
julia> x = Ones(1:∞);

julia> Base.IteratorSize(x)
Base.IsInfinite()

julia> s = Iterators.Stateful(x)
Base.Iterators.Stateful{Ones{Int64, 1, Tuple{InfiniteArrays.OneToInf{Int64}}}, Tuple{Int64, Tuple{Int64, Int64}}, Int64}(Ones(ℵ₀), (1, (1, 1)), -1)

julia> first(s,2)
2-element Vector{Int64}:
 1
 1
```