### PR TITLE
Generalise Zeros +/-

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FillArrays"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "0.13.8"
+version = "0.13.9"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -249,6 +249,7 @@ end
     a .+ getindex_value(b)
 end
 
+# following needed since as of Julia v1.8 convert(AbstractArray{T}, ::AbstractRange) might return a Vector
 @inline elconvert(::Type{T}, A::AbstractRange) where T = T(first(A)):T(step(A)):T(last(A))
 @inline elconvert(::Type{T}, A::AbstractUnitRange) where T<:Integer = AbstractUnitRange{T}(A)
 @inline elconvert(::Type{T}, A::AbstractArray) where T = AbstractArray{T}(A)

--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -223,9 +223,11 @@ for TYPE in (:AbstractArray, :AbstractFill) # AbstractFill for disambiguity
     end
     @eval +(a::Zeros, b::$TYPE) = b + a
 end
-function +(a::ZerosMatrix{T}, b::UniformScaling) where {T}
+
+# for VERSION other than 1.6, could use ZerosMatrix only
+function +(a::AbstractFillMatrix{T}, b::UniformScaling) where {T}
     n = checksquare(a)
-    return Diagonal(Fill(zero(T) + b.λ, n))
+    return a + Diagonal(Fill(zero(T) + b.λ, n))
 end
 
 # LinearAlgebra defines `-(a::AbstractMatrix, b::UniformScaling) = a + (-b)`,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -146,9 +146,9 @@ include("infinitearrays.jl")
         y = x + x
         @test y isa Fill{Int,1}
         @test y[1] == 2
-        @test x + Zeros{Bool}(5) ≡ x
-        @test x - Zeros{Bool}(5) ≡ x
-        @test Zeros{Bool}(5) + x ≡ x
+        @test x + Zeros{Bool}(5) ≡ Ones{Int}(5)
+        @test x - Zeros{Bool}(5) ≡ Ones{Int}(5)
+        @test Zeros{Bool}(5) + x ≡ Ones{Int}(5)
         @test -x ≡ Fill(-1,5)
     end
 


### PR DESCRIPTION
- Include a method `elconvert` which could be overloaded by custom types to resolve, etc, `Zeros(∞)+(1:∞)`.

- Some other +/- methods in `FillArrays.jl` are moved to `fillalgebra.jl`

- Resolve #209 