### PR TITLE
Propagate inbounds correctly in `getindex`

### DIFF
--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -195,8 +195,8 @@ Base.@propagate_inbounds @inline Base._unsafe_getindex(::IndexStyle, F::Abstract
 
 
 
-getindex(A::AbstractFill, kr::AbstractVector{Bool}) = _fill_getindex(A, kr)
-getindex(A::AbstractFill, kr::AbstractArray{Bool}) = _fill_getindex(A, kr)
+Base.@propagate_inbounds getindex(A::AbstractFill, kr::AbstractVector{Bool}) = _fill_getindex(A, kr)
+Base.@propagate_inbounds getindex(A::AbstractFill, kr::AbstractArray{Bool}) = _fill_getindex(A, kr)
 
 @inline Base.iterate(F::AbstractFill) = length(F) == 0 ? nothing : (v = getindex_value(F); (v, (v, 1)))
 @inline function Base.iterate(F::AbstractFill, (v, n))


### PR DESCRIPTION
`@inbounds` was not being propagated in `getindex`, and this PR fixes that.

On master
```julia
julia> using FillArrays, BenchmarkTools

julia> A = ones(4000,4000); B = fill(oneunit(eltype(A)), size(A)); C = Fill(oneunit(eltype(A)), size(A));

julia> @btime $A .* $B;
  52.469 ms (2 allocations: 122.07 MiB)

julia> @btime $A .* $C;
  63.234 ms (2 allocations: 122.07 MiB)
```
This PR
```julia
julia> @btime $A .* $C;
  47.491 ms (2 allocations: 122.07 MiB)
```
Broadcasting a `Fill` should be faster, as we see in this PR.