### PR TITLE
Fix compatibility with StaticArrays

### DIFF
--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -238,11 +238,11 @@ end
 
 # necessary for AbstractRange, Diagonal, etc
 +(a::AbstractFill, b::AbstractFill) = fill_add(a, b)
-+(a::AbstractFill, b::AbstractRange) = fill_add(b, a)
-+(a::AbstractRange, b::AbstractFill) = fill_add(a, b)
++(a::Union{Zero,AbstractFill}, b::AbstractRange) = fill_add(b, a)
++(a::AbstractRange, b::Union{Zero,AbstractFill}) = fill_add(a, b)
 -(a::AbstractFill, b::AbstractFill) = a + (-b)
--(a::AbstractFill, b::AbstractRange) = a + (-b)
--(a::AbstractRange, b::AbstractFill) = a + (-b)
+-(a::Union{Zero,AbstractFill}, b::AbstractRange) = a + (-b)
+-(a::AbstractRange, b::Union{Zero,AbstractFill}) = a + (-b)
 
 @inline function fill_add(a, b::AbstractFill)
     promote_shape(a, b)

--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -238,11 +238,11 @@ end
 
 # necessary for AbstractRange, Diagonal, etc
 +(a::AbstractFill, b::AbstractFill) = fill_add(a, b)
-+(a::AbstractFill, b::AbstractArray) = fill_add(b, a)
-+(a::AbstractArray, b::AbstractFill) = fill_add(a, b)
++(a::AbstractFill, b::AbstractRange) = fill_add(b, a)
++(a::AbstractRange, b::AbstractFill) = fill_add(a, b)
 -(a::AbstractFill, b::AbstractFill) = a + (-b)
--(a::AbstractFill, b::AbstractArray) = a + (-b)
--(a::AbstractArray, b::AbstractFill) = a + (-b)
+-(a::AbstractFill, b::AbstractRange) = a + (-b)
+-(a::AbstractRange, b::AbstractFill) = a + (-b)
 
 @inline function fill_add(a, b::AbstractFill)
     promote_shape(a, b)

--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -238,11 +238,11 @@ end
 
 # necessary for AbstractRange, Diagonal, etc
 +(a::AbstractFill, b::AbstractFill) = fill_add(a, b)
-+(a::Union{Zero,AbstractFill}, b::AbstractRange) = fill_add(b, a)
-+(a::AbstractRange, b::Union{Zero,AbstractFill}) = fill_add(a, b)
++(a::Union{Zeros,AbstractFill}, b::AbstractRange) = fill_add(b, a)
++(a::AbstractRange, b::Union{Zeros,AbstractFill}) = fill_add(a, b)
 -(a::AbstractFill, b::AbstractFill) = a + (-b)
--(a::Union{Zero,AbstractFill}, b::AbstractRange) = a + (-b)
--(a::AbstractRange, b::Union{Zero,AbstractFill}) = a + (-b)
+-(a::Union{Zeros,AbstractFill}, b::AbstractRange) = a + (-b)
+-(a::AbstractRange, b::Union{Zeros,AbstractFill}) = a + (-b)
 
 @inline function fill_add(a, b::AbstractFill)
     promote_shape(a, b)

--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -238,11 +238,15 @@ end
 
 # necessary for AbstractRange, Diagonal, etc
 +(a::AbstractFill, b::AbstractFill) = fill_add(a, b)
-+(a::Union{Zeros,AbstractFill}, b::AbstractRange) = fill_add(b, a)
-+(a::AbstractRange, b::Union{Zeros,AbstractFill}) = fill_add(a, b)
++(a::AbstractFill, b::AbstractRange) = fill_add(b, a)
++(a::AbstractRange, b::AbstractFill) = fill_add(a, b)
++(a::Zeros, b::AbstractRange) = fill_add(b, a)
++(a::AbstractRange, b::Zeros) = fill_add(a, b)
 -(a::AbstractFill, b::AbstractFill) = a + (-b)
--(a::Union{Zeros,AbstractFill}, b::AbstractRange) = a + (-b)
--(a::AbstractRange, b::Union{Zeros,AbstractFill}) = a + (-b)
+-(a::AbstractFill, b::AbstractRange) = a + (-b)
+-(a::AbstractRange, b::AbstractFill) = a + (-b)
+-(a::Zeros, b::AbstractRange) = a + (-b)
+-(a::AbstractRange, b::Zeros) = a + (-b)
 
 @inline function fill_add(a, b::AbstractFill)
     promote_shape(a, b)


### PR DESCRIPTION
https://github.com/JuliaArrays/FillArrays.jl/pull/219 broke compatibility with static arrays and thus downstream tests:

```julia
  Got exception outside of a @test
  LoadError: MethodError: +(::StaticArraysCore.SVector{2, Float64}, ::FillArrays.Fill{Float64, 1, Tuple{Base.OneTo{Int64}}}) is ambiguous. Candidates:
    +(a::AbstractArray, b::FillArrays.AbstractFill) in FillArrays at /home/runner/.julia/packages/FillArrays/VUZcr/src/fillalgebra.jl:242
    +(a::StaticArraysCore.StaticArray, b::AbstractArray) in StaticArrays at /home/runner/.julia/packages/StaticArrays/4WE4t/src/linalg.jl:14
  Possible fix, define
    +(::StaticArraysCore.StaticArray, ::FillArrays.AbstractFill)
```

https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/4444632992/jobs/7803006749?pr=1908#step:6:920

But it's not clear that the change to these operators was even necessary for anything.