### PR TITLE
`_fill_dot` support general vectors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FillArrays"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "0.13.9"
+version = "0.13.10"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -247,10 +247,14 @@ for TYPE in (:Array, :AbstractRange)
         -(a::AbstractFill, b::$TYPE) = a + (-b)
     end
 end
-+(a::AbstractFill, b::AbstractFill) = fill_add(a, b)
++(a::AbstractFill, b::AbstractFill) = Fill(getindex_value(a) + getindex_value(b), promote_shape(a,b))
 -(a::AbstractFill, b::AbstractFill) = a + (-b)
 
-@inline function fill_add(a, b::AbstractFill)
+@inline function fill_add(a::AbstractArray, b::AbstractFill)
+    promote_shape(a, b)
+    a .+ [getindex_value(b)]
+end
+@inline function fill_add(a::AbstractArray{<:Number}, b::AbstractFill)
     promote_shape(a, b)
     a .+ getindex_value(b)
 end

--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -162,31 +162,31 @@ end
 
 # support types with fast sum
 
-function _fill_dot(a::AbstractVector{T}, b::AbstractFill{V}) where {T,V}
+function _fill_dot(a::AbstractFillVector{T}, b::AbstractVector{V}) where {T,V}
     axes(a) == axes(b) || throw(DimensionMismatch("dot product arguments have lengths $(length(a)) and $(length(b))"))
     S = promote_op(+, T, V)
     # treat zero separately to support ∞-vectors
     if iszero(b) || iszero(a)
         zero(S)
     else
-        dot(S(sum(a)), S(getindex_value(b)))
+        dot(getindex_value(a), S(sum(b)))
     end
 end
 
-function _fill_dot_conj(a::AbstractVector{T}, b::AbstractFill{V}) where {T,V}
+function _fill_dot_rev(a::AbstractVector{T}, b::AbstractFillVector{V}) where {T,V}
     axes(a) == axes(b) || throw(DimensionMismatch("dot product arguments have lengths $(length(a)) and $(length(b))"))
     S = promote_op(+, T, V)
     # treat zero separately to support ∞-vectors
     if iszero(b) || iszero(a)
         zero(S)
     else
-        dot(S(getindex_value(b)), S(sum(a)))
+        dot(S(sum(a)), getindex_value(b))
     end
 end
 
 dot(a::AbstractFillVector, b::AbstractFillVector) = _fill_dot(a, b)
-dot(a::AbstractFillVector, b::AbstractVector) = _fill_dot_conj(b, a)
-dot(a::AbstractVector, b::AbstractFillVector) = _fill_dot(a, b)
+dot(a::AbstractFillVector, b::AbstractVector) = _fill_dot(a, b)
+dot(a::AbstractVector, b::AbstractFillVector) = _fill_dot_rev(a, b)
 
 function dot(u::AbstractVector, E::Eye, v::AbstractVector)
     length(u) == size(E,1) && length(v) == size(E,2) ||

--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -161,6 +161,8 @@ end
 *(a::Transpose{T, <:AbstractMatrix{T}}, b::ZerosVector{T}) where T<:Real = mult_zeros(a, b)
 
 # support types with fast sum
+# infinite cases should be supported in InfiniteArrays.jl
+# type issues of Bool dot are ignored at present.
 function _fill_dot(a::AbstractFillVector{T}, b::AbstractVector{V}) where {T,V}
     axes(a) == axes(b) || throw(DimensionMismatch("dot product arguments have lengths $(length(a)) and $(length(b))"))
     dot(getindex_value(a), sum(b))

--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -175,9 +175,8 @@ dot(a::AbstractFillVector, b::AbstractFillVector) = _fill_dot(a, b)
 dot(a::AbstractFillVector, b::AbstractVector) = _fill_dot(a, b)
 dot(a::AbstractVector, b::AbstractFillVector) = _fill_dot_rev(a, b)
 
-if VERSION >= v"1.6.0" && VERSION < v"1.7"
-    dot(A::AbstractFill, J::UniformScaling) = dot(tr(A), J.λ) # borrowed from julia\stdlib\v1.8\LinearAlgebra\src\uniformscaling.jl:516
-end
+# for Julia 1.6
+dot(A::AbstractFill, J::UniformScaling) = dot(tr(A), J.λ) # borrowed from julia\stdlib\v1.8\LinearAlgebra\src\uniformscaling.jl:516
 
 function dot(u::AbstractVector, E::Eye, v::AbstractVector)
     length(u) == size(E,1) && length(v) == size(E,2) ||

--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -161,28 +161,14 @@ end
 *(a::Transpose{T, <:AbstractMatrix{T}}, b::ZerosVector{T}) where T<:Real = mult_zeros(a, b)
 
 # support types with fast sum
-_mul_maybe_zero(a, b) = ifelse(iszero(a), zero(promote_op(*, typeof(a), typeof(b))), a * b)
-
 function _fill_dot(a::AbstractFillVector{T}, b::AbstractVector{V}) where {T,V}
     axes(a) == axes(b) || throw(DimensionMismatch("dot product arguments have lengths $(length(a)) and $(length(b))"))
-    S = promote_op(+, T, V)
-    # treat zero separately to support ∞-vectors
-    if iszero(a)
-        zero(S)
-    else
-        _mul_maybe_zero(S(sum(b)), conj(getindex_value(a)))
-    end
+    dot(getindex_value(a), sum(b))
 end
 
 function _fill_dot_rev(a::AbstractVector{T}, b::AbstractFillVector{V}) where {T,V}
     axes(a) == axes(b) || throw(DimensionMismatch("dot product arguments have lengths $(length(a)) and $(length(b))"))
-    S = promote_op(+, T, V)
-    # treat zero separately to support ∞-vectors
-    if iszero(b)
-        zero(S)
-    else
-        _mul_maybe_zero(conj(S(sum(a))), getindex_value(b))
-    end
+    dot(sum(a), getindex_value(b))
 end
 
 dot(a::AbstractFillVector, b::AbstractFillVector) = _fill_dot(a, b)

--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -161,15 +161,16 @@ end
 *(a::Transpose{T, <:AbstractMatrix{T}}, b::ZerosVector{T}) where T<:Real = mult_zeros(a, b)
 
 # support types with fast sum
+_mul_maybe_zero(a, b) = ifelse(iszero(a), zero(promote_op(*, typeof(a), typeof(b))), a * b)
 
 function _fill_dot(a::AbstractFillVector{T}, b::AbstractVector{V}) where {T,V}
     axes(a) == axes(b) || throw(DimensionMismatch("dot product arguments have lengths $(length(a)) and $(length(b))"))
     S = promote_op(+, T, V)
     # treat zero separately to support ∞-vectors
-    if iszero(b) || iszero(a)
+    if iszero(a)
         zero(S)
     else
-        dot(getindex_value(a), S(sum(b)))
+        _mul_maybe_zero(S(sum(b)), conj(getindex_value(a)))
     end
 end
 
@@ -177,10 +178,10 @@ function _fill_dot_rev(a::AbstractVector{T}, b::AbstractFillVector{V}) where {T,
     axes(a) == axes(b) || throw(DimensionMismatch("dot product arguments have lengths $(length(a)) and $(length(b))"))
     S = promote_op(+, T, V)
     # treat zero separately to support ∞-vectors
-    if iszero(b) || iszero(a)
+    if iszero(b)
         zero(S)
     else
-        dot(S(sum(a)), getindex_value(b))
+        _mul_maybe_zero(conj(S(sum(a))), getindex_value(b))
     end
 end
 

--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -175,9 +175,6 @@ dot(a::AbstractFillVector, b::AbstractFillVector) = _fill_dot(a, b)
 dot(a::AbstractFillVector, b::AbstractVector) = _fill_dot(a, b)
 dot(a::AbstractVector, b::AbstractFillVector) = _fill_dot_rev(a, b)
 
-# for Julia 1.6
-dot(A::AbstractFill, J::UniformScaling) = dot(tr(A), J.λ) # borrowed from julia\stdlib\v1.8\LinearAlgebra\src\uniformscaling.jl:516
-
 function dot(u::AbstractVector, E::Eye, v::AbstractVector)
     length(u) == size(E,1) && length(v) == size(E,2) ||
         throw(DimensionMismatch("dot product arguments have dimensions $(length(u))×$(size(E))×$(length(v))"))

--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -166,7 +166,7 @@ function _fill_dot(a::AbstractVector, b::AbstractFill)
     axes(a) == axes(b) || throw(DimensionMismatch("dot product arguments have lengths $(length(a)) and $(length(b))"))
     # treat zero separately to support ∞-vectors
     if iszero(b) || iszero(a)
-        zero(promote_type(eltype(a), eltype(b)))
+        zero(promote_op(*, eltype(a), eltype(b)))
     else
         sum(a) * getindex_value(b)
     end

--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -175,7 +175,7 @@ dot(a::AbstractFillVector, b::AbstractFillVector) = _fill_dot(a, b)
 dot(a::AbstractFillVector, b::AbstractVector) = _fill_dot(a, b)
 dot(a::AbstractVector, b::AbstractFillVector) = _fill_dot_rev(a, b)
 
-if VERSION >= v"1.6" && VERSION < v"1.7"
+if VERSION >= v"1.6.0" && VERSION < v"1.7"
     dot(A::AbstractFill, J::UniformScaling) = dot(tr(A), J.λ) # borrowed from julia\stdlib\v1.8\LinearAlgebra\src\uniformscaling.jl:516
 end
 

--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -162,18 +162,30 @@ end
 
 # support types with fast sum
 
-function _fill_dot(a::AbstractVector, b::AbstractFill)
+function _fill_dot(a::AbstractVector{T}, b::AbstractFill{V}) where {T,V}
     axes(a) == axes(b) || throw(DimensionMismatch("dot product arguments have lengths $(length(a)) and $(length(b))"))
+    S = promote_op(+, T, V)
     # treat zero separately to support ∞-vectors
     if iszero(b) || iszero(a)
-        zero(promote_op(*, eltype(a), eltype(b)))
+        zero(S)
     else
-        sum(a) * getindex_value(b)
+        dot(S(sum(a)), S(getindex_value(b)))
+    end
+end
+
+function _fill_dot_conj(a::AbstractVector{T}, b::AbstractFill{V}) where {T,V}
+    axes(a) == axes(b) || throw(DimensionMismatch("dot product arguments have lengths $(length(a)) and $(length(b))"))
+    S = promote_op(+, T, V)
+    # treat zero separately to support ∞-vectors
+    if iszero(b) || iszero(a)
+        zero(S)
+    else
+        dot(S(getindex_value(b)), S(sum(a)))
     end
 end
 
 dot(a::AbstractFillVector, b::AbstractFillVector) = _fill_dot(a, b)
-dot(a::AbstractFillVector, b::AbstractVector) = _fill_dot(b, a)
+dot(a::AbstractFillVector, b::AbstractVector) = _fill_dot_conj(b, a)
 dot(a::AbstractVector, b::AbstractFillVector) = _fill_dot(a, b)
 
 function dot(u::AbstractVector, E::Eye, v::AbstractVector)

--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -175,6 +175,10 @@ dot(a::AbstractFillVector, b::AbstractFillVector) = _fill_dot(a, b)
 dot(a::AbstractFillVector, b::AbstractVector) = _fill_dot(a, b)
 dot(a::AbstractVector, b::AbstractFillVector) = _fill_dot_rev(a, b)
 
+if VERSION >= v"1.6" && VERSION < v"1.7"
+    dot(A::AbstractFill, J::UniformScaling) = dot(tr(A), J.λ) # borrowed from julia\stdlib\v1.8\LinearAlgebra\src\uniformscaling.jl:516
+end
+
 function dot(u::AbstractVector, E::Eye, v::AbstractVector)
     length(u) == size(E,1) && length(v) == size(E,2) ||
         throw(DimensionMismatch("dot product arguments have dimensions $(length(u))×$(size(E))×$(length(v))"))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -324,12 +324,14 @@ function test_addition_subtraction_dot(As, Bs, Tout::Type)
             @test B - A isa Tout{promote_type(eltype(B), eltype(A))}
             @test equal_or_undef(as_array(B - A), as_array(B) - as_array(A))
             
-            d1 = dot(A, B)
-            d2 = dot(as_array(A), as_array(B))
-            d3 = dot(B, A)
-            d4 = dot(as_array(B), as_array(A))
-            @test d1 ≈ d2 || d1 ≡ d2
-            @test d3 ≈ d4 || d3 ≡ d4
+            if VERSION < v"1.6.0" || VERSION >= v"1.8.0"
+                d1 = dot(A, B)
+                d2 = dot(as_array(A), as_array(B))
+                d3 = dot(B, A)
+                d4 = dot(as_array(B), as_array(A))
+                @test d1 ≈ d2 || d1 ≡ d2
+                @test d3 ≈ d4 || d3 ≡ d4
+            end
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -308,7 +308,7 @@ as_array(x::AbstractArray) = Array(x)
 as_array(x::UniformScaling) = x
 function test_addition_and_subtraction(As, Bs, Tout::Type)
     for A in As, B in Bs
-        @testset "$A ± $B" begin
+        @testset "$(typeof(A)) ± $(typeof(B))" begin
             @test A + B isa Tout{promote_type(eltype(A), eltype(B))}
             @test as_array(A + B) == as_array(A) + as_array(B)
 
@@ -326,7 +326,7 @@ end
 
 # Check that all permutations of + / - throw a `DimensionMismatch` exception.
 function test_addition_and_subtraction_dim_mismatch(a, b)
-    @testset "$a ± $b" begin
+    @testset "$(typeof(a)) ± $(typeof(b))" begin
         @test_throws DimensionMismatch a + b
         @test_throws DimensionMismatch a - b
         @test_throws DimensionMismatch b + a
@@ -375,6 +375,11 @@ end
     # FillArray + StaticArray should not have ambiguities
     A_svec, B_svec = SVector{5}(rand(5)), SVector(1, 2, 3, 4, 5)
     test_addition_and_subtraction((A_fill, B_fill, Zeros(5)), (A_svec, B_svec), SVector{5})
+
+    # Issue #224
+    A_matmat, B_matmat = Fill(rand(3,3),5), [rand(3,3) for n=1:5]
+    test_addition_and_subtraction((A_matmat,), (A_matmat,), Fill)
+    test_addition_and_subtraction((B_matmat,), (A_matmat,), Vector)
 
     # Optimizations for Zeros and RectOrDiagonal{<:Any, <:AbstractFill}
     As_special_square = (

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -311,8 +311,7 @@ equal_or_undef(a, b) = all(equal_or_undef.(a, b))
 function test_addition_subtraction_dot(As, Bs, Tout::Type)
     for A in As, B in Bs
         @testset "$(typeof(A)) and $(typeof(B))" begin
-            T = Tout{promote_type(eltype(A), eltype(B))}
-            @test A + B isa T
+            @test A + B isa Tout{promote_type(eltype(A), eltype(B))}
             @test equal_or_undef(as_array(A + B), as_array(A) + as_array(B))
 
             @test A - B isa Tout{promote_type(eltype(A), eltype(B))}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1305,6 +1305,7 @@ end
 
     @test dot(Fill(1,5), Fill(2.0,5)) ≡ 10.0
     @test dot(Fill(true,5), Fill(Int8(1),5)) isa Int8
+    @test dot([Fill(1, 2, 2)], [[1 2; 3 4]])
 
     let N = 2^big(1000) # fast dot for fast sum
         @test dot(Fill(2,N),1:N) == dot(Fill(2,N),1:N) == dot(1:N,Fill(2,N)) == 2*sum(1:N)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1309,12 +1309,12 @@ end
     @test dot(u, 2D, v) == 2dot(u, v)
     @test dot(u, Z, v) == 0
 
-    @test dot(Zeros(5), Zeros{ComplexF16}(5)) ≡ zero(ComplexF64)
+    @test @inferred(dot(Zeros(5), Zeros{ComplexF16}(5))) ≡ zero(ComplexF64)
     @test @inferred(dot(Zeros(5), Ones{ComplexF16}(5))) ≡ zero(ComplexF64)
-    @test abs(dot(Ones{ComplexF16}(5), Zeros(5))) ≡ abs(dot(randn(5), Zeros{ComplexF16}(5))) ≡ abs(dot(Zeros{ComplexF16}(5), randn(5))) ≡ zero(Float64) # 0.0 !≡ -0.0
-    @test dot(c, Fill(1 + im, 15)) ≡ dot(Fill(1 + im, 15), c)' ≈ dot(c, fill(1 + im, 15))
+    @test abs(@inferred(dot(Ones{ComplexF16}(5), Zeros(5)))) ≡ abs(@inferred(dot(randn(5), Zeros{ComplexF16}(5)))) ≡ abs(@inferred(dot(Zeros{ComplexF16}(5), randn(5)))) ≡ zero(Float64) # 0.0 !≡ -0.0
+    @test @inferred(dot(c, Fill(1 + im, 15))) ≡ (@inferred(dot(Fill(1 + im, 15), c)))' ≈ @inferred(dot(c, fill(1 + im, 15)))
 
-    @test dot(Fill(1,5), Fill(2.0,5)) ≡ 10.0
+    @test @inferred(dot(Fill(1,5), Fill(2.0,5))) ≡ 10.0
     @test_skip dot(Fill(true,5), Fill(Int8(1),5)) isa Int8 # not working at present
 
     let N = 2^big(1000) # fast dot for fast sum

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -324,6 +324,7 @@ function test_addition_subtraction_dot(As, Bs, Tout::Type)
             @test B - A isa Tout{promote_type(eltype(B), eltype(A))}
             @test equal_or_undef(as_array(B - A), as_array(B) - as_array(A))
             
+            # Julia 1.6 doesn't support dot(UniformScaling)
             if VERSION < v"1.6.0" || VERSION >= v"1.8.0"
                 d1 = dot(A, B)
                 d2 = dot(as_array(A), as_array(B))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1301,7 +1301,7 @@ end
     @test dot(Zeros(5), Ones{ComplexF16}(5)) ≡ zero(ComplexF64)
     @test dot(Ones{ComplexF16}(5), Zeros(5)) ≡ zero(ComplexF64)
     @test dot(randn(5), Zeros{ComplexF16}(5)) ≡ dot(Zeros{ComplexF16}(5), randn(5)) ≡ zero(ComplexF64)
-    @test dot(c, Fill(1 + im, 15)) ≡ dot(Fill(1 + im, 15), c)' ≡ dot(c, fill(1 + im, 15))
+    @test dot(c, Fill(1 + im, 15)) ≡ dot(Fill(1 + im, 15), c)' ≈ dot(c, fill(1 + im, 15))
 
     @test dot(Fill(1,5), Fill(2.0,5)) ≡ 10.0
     @test dot(Fill(true,5), Fill(Int8(1),5)) isa Int8

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1291,6 +1291,7 @@ end
     Random.seed!(5)
     u = rand(n)
     v = rand(n)
+    c = rand(ComplexF16, n)
 
     @test dot(u, D, v) == dot(u, v)
     @test dot(u, 2D, v) == 2dot(u, v)
@@ -1300,6 +1301,7 @@ end
     @test dot(Zeros(5), Ones{ComplexF16}(5)) ≡ zero(ComplexF64)
     @test dot(Ones{ComplexF16}(5), Zeros(5)) ≡ zero(ComplexF64)
     @test dot(randn(5), Zeros{ComplexF16}(5)) ≡ dot(Zeros{ComplexF16}(5), randn(5)) ≡ zero(ComplexF64)
+    @test dot(c, Fill(1 + im, 15)) ≡ dot(Fill(1 + im, 15), c) ≡ dot(c, fill(1 + im, 15))
 
     @test dot(Fill(1,5), Fill(2.0,5)) ≡ 10.0
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1301,9 +1301,10 @@ end
     @test dot(Zeros(5), Ones{ComplexF16}(5)) ≡ zero(ComplexF64)
     @test dot(Ones{ComplexF16}(5), Zeros(5)) ≡ zero(ComplexF64)
     @test dot(randn(5), Zeros{ComplexF16}(5)) ≡ dot(Zeros{ComplexF16}(5), randn(5)) ≡ zero(ComplexF64)
-    @test dot(c, Fill(1 + im, 15)) ≡ dot(Fill(1 + im, 15), c) ≡ dot(c, fill(1 + im, 15))
+    @test dot(c, Fill(1 + im, 15)) ≡ dot(Fill(1 + im, 15), c)' ≡ dot(c, fill(1 + im, 15))
 
     @test dot(Fill(1,5), Fill(2.0,5)) ≡ 10.0
+    @test dot(Fill(true,5), Fill(Int8(1),5)) isa Int8
 
     let N = 2^big(1000) # fast dot for fast sum
         @test dot(Fill(2,N),1:N) == dot(Fill(2,N),1:N) == dot(1:N,Fill(2,N)) == 2*sum(1:N)


### PR DESCRIPTION
including Inf, NaN and nested arrays. Infinite cases should be implemented in InfiniteArrays.jl

Original PR:

including `Fill(0,∞)` and potentially `0.0:0.0:+∞` in the future

also fix a type issue:
```julia
julia> dot(fill(true, 5), fill(Int8(1), 5)) |> typeof
Int8

julia> dot(sum(fill(true, 5)), Int8(1)) |> typeof
Int64
```