### PR TITLE
Reduce `mult_fill` methods

### DIFF
--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -35,8 +35,6 @@ reverse(A::AbstractFill; dims=:) = A
 
 ## Algebraic identities
 
-mult_axes(a_ax::Tuple, b_ax::Tuple) = (a_ax[1], b_ax[2:end]...)
-
 function _mult_fill(a::AbstractFill, b::AbstractFill, ax, ::Type{Fill})
     val = getindex_value(a)*getindex_value(b)*size(a,2)
     return Fill(val, ax)
@@ -51,8 +49,8 @@ function mult_fill(a, b, T::Type = Fill)
     Base.require_one_based_indexing(a, b)
     size(a, 2) ≠ size(b, 1) &&
         throw(DimensionMismatch("A has dimensions $(size(a)) but B has dimensions $(size(b))"))
-    ax = mult_axes(axes(a), axes(b))
-    _mult_fill(a, b, ax, T)
+    ax_result = (axes(a, 1), axes(b)[2:end]...)
+    _mult_fill(a, b, ax_result, T)
 end
 
 *(a::AbstractFillVector, b::AbstractFillMatrix) = mult_fill(a,b)

--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -52,37 +52,39 @@ function mult_fill(a, b, T::Type = Fill)
     ax_result = (axes(a, 1), axes(b)[2:end]...)
     _mult_fill(a, b, ax_result, T)
 end
+mult_zeros(a, b) = mult_fill(a, b, Zeros)
+mult_ones(a, b) = mult_fill(a, b, Ones)
 
 *(a::AbstractFillVector, b::AbstractFillMatrix) = mult_fill(a,b)
 *(a::AbstractFillMatrix, b::AbstractFillMatrix) = mult_fill(a,b)
 *(a::AbstractFillMatrix, b::AbstractFillVector) = mult_fill(a,b)
 
-*(a::OnesVector, b::OnesMatrix) = mult_fill(a, b, Ones)
+*(a::OnesVector, b::OnesMatrix) = mult_ones(a, b)
 
-*(a::ZerosVector, b::ZerosMatrix) = mult_fill(a, b, Zeros)
-*(a::ZerosMatrix, b::ZerosMatrix) = mult_fill(a, b, Zeros)
-*(a::ZerosMatrix, b::ZerosVector) = mult_fill(a, b, Zeros)
+*(a::ZerosVector, b::ZerosMatrix) = mult_zeros(a, b)
+*(a::ZerosMatrix, b::ZerosMatrix) = mult_zeros(a, b)
+*(a::ZerosMatrix, b::ZerosVector) = mult_zeros(a, b)
 
-*(a::ZerosVector, b::AbstractFillMatrix) = mult_fill(a, b, Zeros)
-*(a::ZerosMatrix, b::AbstractFillMatrix) = mult_fill(a, b, Zeros)
-*(a::ZerosMatrix, b::AbstractFillVector) = mult_fill(a, b, Zeros)
-*(a::AbstractFillVector, b::ZerosMatrix) = mult_fill(a, b, Zeros)
-*(a::AbstractFillMatrix, b::ZerosMatrix) = mult_fill(a, b, Zeros)
-*(a::AbstractFillMatrix, b::ZerosVector) = mult_fill(a, b, Zeros)
+*(a::ZerosVector, b::AbstractFillMatrix) = mult_zeros(a, b)
+*(a::ZerosMatrix, b::AbstractFillMatrix) = mult_zeros(a, b)
+*(a::ZerosMatrix, b::AbstractFillVector) = mult_zeros(a, b)
+*(a::AbstractFillVector, b::ZerosMatrix) = mult_zeros(a, b)
+*(a::AbstractFillMatrix, b::ZerosMatrix) = mult_zeros(a, b)
+*(a::AbstractFillMatrix, b::ZerosVector) = mult_zeros(a, b)
 
-*(a::ZerosVector, b::AbstractMatrix) = mult_fill(a, b, Zeros)
-*(a::ZerosMatrix, b::AbstractMatrix) = mult_fill(a, b, Zeros)
-*(a::AbstractMatrix, b::ZerosVector) = mult_fill(a, b, Zeros)
-*(a::AbstractMatrix, b::ZerosMatrix) = mult_fill(a, b, Zeros)
-*(a::ZerosMatrix, b::AbstractVector) = mult_fill(a, b, Zeros)
-*(a::AbstractVector, b::ZerosMatrix) = mult_fill(a, b, Zeros)
+*(a::ZerosVector, b::AbstractMatrix) = mult_zeros(a, b)
+*(a::ZerosMatrix, b::AbstractMatrix) = mult_zeros(a, b)
+*(a::AbstractMatrix, b::ZerosVector) = mult_zeros(a, b)
+*(a::AbstractMatrix, b::ZerosMatrix) = mult_zeros(a, b)
+*(a::ZerosMatrix, b::AbstractVector) = mult_zeros(a, b)
+*(a::AbstractVector, b::ZerosMatrix) = mult_zeros(a, b)
 
-*(a::ZerosVector, b::AdjOrTransAbsVec) = mult_fill(a, b, Zeros)
+*(a::ZerosVector, b::AdjOrTransAbsVec) = mult_zeros(a, b)
 
-*(a::ZerosVector, b::Diagonal) = mult_fill(a, b, Zeros)
-*(a::ZerosMatrix, b::Diagonal) = mult_fill(a, b, Zeros)
-*(a::Diagonal, b::ZerosVector) = mult_fill(a, b, Zeros)
-*(a::Diagonal, b::ZerosMatrix) = mult_fill(a, b, Zeros)
+*(a::ZerosVector, b::Diagonal) = mult_zeros(a, b)
+*(a::ZerosMatrix, b::Diagonal) = mult_zeros(a, b)
+*(a::Diagonal, b::ZerosVector) = mult_zeros(a, b)
+*(a::Diagonal, b::ZerosMatrix) = mult_zeros(a, b)
 function *(a::Diagonal, b::AbstractFillMatrix)
     size(a,2) == size(b,1) || throw(DimensionMismatch("A has dimensions $(size(a)) but B has dimensions $(size(b))"))
     parent(a) .* b # use special broadcast
@@ -136,7 +138,7 @@ end
 *(a::TransposeAbsVec, b::ZerosVector) = _adjvec_mul_zeros(a, b)
 *(a::TransposeAbsVec{<:Number}, b::ZerosVector{<:Number}) = _adjvec_mul_zeros(a, b)
 
-*(a::Adjoint{T, <:AbstractMatrix{T}} where T, b::Zeros{<:Any, 1}) = mult_fill(a, b, Zeros)
+*(a::Adjoint{T, <:AbstractMatrix{T}} where T, b::Zeros{<:Any, 1}) = mult_zeros(a, b)
 
 function *(a::Transpose{T, <:AbstractVector{T}}, b::ZerosVector{T}) where T<:Real
     la, lb = length(a), length(b)
@@ -145,7 +147,7 @@ function *(a::Transpose{T, <:AbstractVector{T}}, b::ZerosVector{T}) where T<:Rea
     end
     return zero(T)
 end
-*(a::Transpose{T, <:AbstractMatrix{T}}, b::ZerosVector{T}) where T<:Real = mult_fill(a, b, Zeros)
+*(a::Transpose{T, <:AbstractMatrix{T}}, b::ZerosVector{T}) where T<:Real = mult_zeros(a, b)
 
 # support types with fast sum
 # infinite cases should be supported in InfiniteArrays.jl

--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -35,20 +35,20 @@ reverse(A::AbstractFill; dims=:) = A
 
 ## Algebraic identities
 
-mult_axes(a, b) = (axes(a, 1), axes(b)[2:end]...)
+mult_axes(a_ax, b_ax) = (a_ax[1], b_ax[2:end]...)
 
 function mult_fill(a::AbstractFill, b::AbstractFill)
     axes(a, 2) ≠ axes(b, 1) &&
         throw(DimensionMismatch("Incompatible matrix multiplication dimensions"))
     val = getindex_value(a)*getindex_value(b)*size(a,2)
-    return Fill(val, mult_axes(a, b))
+    return Fill(val, mult_axes(axes(a), axes(b)))
 end
 
 function mult_fill(a, b, ::Type{OnesZeros}) where {OnesZeros}
     axes(a, 2) ≠ axes(b, 1) &&
         throw(DimensionMismatch("Incompatible matrix multiplication dimensions"))
     ElType = promote_type(eltype(a), eltype(b))
-    return OnesZeros{ElType}(mult_axes(a, b))
+    return OnesZeros{ElType}(mult_axes(axes(a), axes(b)))
 end
 
 *(a::AbstractFillVector, b::AbstractFillMatrix) = mult_fill(a,b)

--- a/src/fillbroadcast.jl
+++ b/src/fillbroadcast.jl
@@ -198,21 +198,28 @@ _copy_oftype(A::AbstractArray{T,N}, ::Type{S}) where {T,N,S} = convert(AbstractA
 _copy_oftype(A::AbstractRange{T}, ::Type{T}) where T = copy(A)
 _copy_oftype(A::AbstractRange{T}, ::Type{S}) where {T,S} = map(S, A)
 
-for op in (:+, -)
+for op in (:+, :-)
     @eval begin
-        function broadcasted(::DefaultArrayStyle{1}, ::typeof($op), a::AbstractVector{T}, b::ZerosVector{V}) where {T,V}
+        function broadcasted(::DefaultArrayStyle{1}, ::typeof($op), a::AbstractRange{T}, b::ZerosVector{V}) where {T,V}
             broadcast_shape(axes(a), axes(b)) == axes(a) || throw(ArgumentError("Cannot broadcast $a and $b. Convert $b to a Vector first."))
             _copy_oftype(a, promote_type(T,V))
         end
+        function broadcasted(::DefaultArrayStyle{1}, ::typeof($op), a::AbstractVector{T}, b::ZerosVector{V}) where {T,V}
+            broadcast_shape(axes(a), axes(b)) == axes(a) || throw(ArgumentError("Cannot broadcast $a and $b. Convert $b to a Vector first."))
+            TT = promote_type(T,V)
+            broadcasted(TT∘$op, a)
+        end
 
-        broadcasted(::DefaultArrayStyle{1}, ::typeof($op), a::AbstractFill{T,1}, b::ZerosVector) where T =
+        broadcasted(::DefaultArrayStyle{1}, ::typeof($op), a::AbstractFillVector{T}, b::ZerosVector) where T =
             Base.invoke(broadcasted, Tuple{DefaultArrayStyle, typeof($op), AbstractFill, AbstractFill}, DefaultArrayStyle{1}(), $op, a, b)
     end
 end
 
-function broadcasted(::DefaultArrayStyle{1}, ::typeof(+), a::ZerosVector{T}, b::AbstractVector{V}) where {T,V}
-    broadcast_shape(axes(a), axes(b))
-    _copy_oftype(b, promote_type(T,V))
+function broadcasted(S::DefaultArrayStyle{1}, ::typeof(+), a::ZerosVector, b::AbstractRange)
+    broadcasted(S, +, b, a)
+end
+function broadcasted(S::DefaultArrayStyle{1}, ::typeof(+), a::ZerosVector, b::AbstractVector)
+    broadcasted(S, +, b, a)
 end
 
 broadcasted(::DefaultArrayStyle{1}, ::typeof(+), a::ZerosVector, b::AbstractFillVector) =

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1235,6 +1235,12 @@ end
     @test_throws DimensionMismatch Fill(2,10)*Fill(3,2,12)
     @test_throws DimensionMismatch Fill(2,3,10)*Fill(3,2,12)
 
+    f = Fill(1, (Base.IdentityUnitRange(1:3), Base.IdentityUnitRange(1:3)))
+    @test f * f === Fill(size(f,2), axes(f))
+
+    f = Fill(2, (Base.IdentityUnitRange(2:3), Base.IdentityUnitRange(2:3)))
+    @test_throws ArgumentError f * f
+
     @test Ones(10)*Fill(3,1,12) ≡ Fill(3.0,10,12)
     @test Ones(10,3)*Fill(3,3,12) ≡ Fill(9.0,10,12)
     @test Ones(10,3)*Fill(3,3) ≡ Fill(9.0,10)
@@ -1258,6 +1264,12 @@ end
     @test Zeros(10)*Zeros(1,12) ≡ Zeros(10,12)
     @test Zeros(3,10)*Zeros(10,12) ≡ Zeros(3,12)
     @test Zeros(3,10)*Zeros(10) ≡ Zeros(3)
+
+    f = Zeros((Base.IdentityUnitRange(1:4), Base.IdentityUnitRange(1:4)))
+    @test f * f === f
+
+    f = Zeros((Base.IdentityUnitRange(3:4), Base.IdentityUnitRange(3:4)))
+    @test_throws ArgumentError f * f
 
     a = randn(3)
     A = randn(1,4)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -908,6 +908,15 @@ end
         @test Zeros(10) .- Zeros(1,9) ≡ Zeros(10,9)
         @test Ones(10) .- Zeros(1,9) ≡ Ones(10,9)
         @test Ones(10) .- Ones(1,9) ≡ Zeros(10,9)
+
+    end
+
+    @testset "issue #208" begin
+        u = rand(2); v = Zeros(2)
+        @test Broadcast.broadcasted(-, u, v) isa Broadcast.Broadcasted
+        @test Broadcast.broadcasted(+, u, v) isa Broadcast.Broadcasted
+        @test Broadcast.broadcasted(-, v, u) isa Broadcast.Broadcasted
+        @test Broadcast.broadcasted(+, v, u) isa Broadcast.Broadcasted
     end
 
     @testset "Zero .*" begin


### PR DESCRIPTION
Many of these methods may be combined, as they do similar things. This PR also disallows offset arrays in matrix multiplication, as there isn't a well-defined convention about what the result should be (and it's disallowed by `Base`).