### PR TITLE
Combine transpose/adjoint methods for Ones/Zeros

### DIFF
--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -8,10 +8,8 @@ vec(a::Fill{T}) where T = Fill{T}(a.value,length(a))
 # cannot do this for vectors since that would destroy scalar dot product
 
 
-transpose(a::OnesMatrix{T}) where T = Ones{T}(reverse(a.axes))
-adjoint(a::OnesMatrix{T}) where T = Ones{T}(reverse(a.axes))
-transpose(a::ZerosMatrix{T}) where T = Zeros{T}(reverse(a.axes))
-adjoint(a::ZerosMatrix{T}) where T = Zeros{T}(reverse(a.axes))
+transpose(a::Union{<:OnesMatrix, <:ZerosMatrix}) = fillsimilar(a, reverse(axes(a)))
+adjoint(a::Union{<:OnesMatrix, <:ZerosMatrix}) = fillsimilar(a, reverse(axes(a)))
 transpose(a::FillMatrix{T}) where T = Fill{T}(transpose(a.value), reverse(a.axes))
 adjoint(a::FillMatrix{T}) where T = Fill{T}(adjoint(a.value), reverse(a.axes))
 


### PR DESCRIPTION
These may be implemented using `fillsimilar`