### PR TITLE
`replace_in_print_matrix` for `OneElement` vector

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FillArrays"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "1.0"
+version = "1.1.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/oneelement.jl
+++ b/src/oneelement.jl
@@ -42,6 +42,9 @@ function Base.getindex(A::OneElement{T,N}, kj::Vararg{Int,N}) where {T,N}
     ifelse(kj == A.ind, A.val, zero(T))
 end
 
+Base.replace_in_print_matrix(o::OneElement{<:Any,1}, k::Integer, j::Integer, s::AbstractString) =
+    o.ind == (k,) ? s : Base.replace_with_centered_mark(s)
+
 Base.replace_in_print_matrix(o::OneElement{<:Any,2}, k::Integer, j::Integer, s::AbstractString) =
     o.ind == (k,j) ? s : Base.replace_with_centered_mark(s)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1558,6 +1558,8 @@ end
     @test e₁ == [0,1,0,0,0]
     @test_throws BoundsError e₁[6]
 
+    @test stringmime("text/plain", e₁) == "5-element OneElement{$Int, 1, Tuple{$Int}, Tuple{Base.OneTo{$Int}}}:\n ⋅\n 1\n ⋅\n ⋅\n ⋅"
+
     e₁ = OneElement{Float64}(2, 5)
     @test e₁ == [0,1,0,0,0]
 


### PR DESCRIPTION
After this,
```julia
julia> OneElement(3, 4)
4-element OneElement{Int64, 1, Tuple{Int64}, Tuple{Base.OneTo{Int64}}}:
 ⋅
 ⋅
 1
 ⋅
```