### PR TITLE
Remove the explicit CI test on v1.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
         version:
           - '1.6'
           - '1'
-          - '~1.9.0-0'
         os:
           - ubuntu-latest
           - macOS-latest


### PR DESCRIPTION
Now that v1 points to v1.9, this is unnecessary