### PR TITLE
remove allocation in oneelement mul

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FillArrays"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "1.1.0"
+version = "1.1.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1659,7 +1659,7 @@ end
     @test_throws BoundsError Base.setindex(Zeros(5), 2, 6)
 
     @testset "matmul" begin
-        A = rand(3,3)
+        A = reshape(Float64[1:9;], 3, 3)
         @testset "vector" begin
             w = zeros(size(A,1))
             w2 = MVector{length(w)}(w)


### PR DESCRIPTION
Removes an inadvertent allocation in the 5-el `mul!` with a `OneElement`, in the `beta != 0` case

On master
```julia
julia> A = Fill(2, 4, 4);

julia> B = OneElement(1, (1,2), (4,4));

julia> @btime mul!($(zero(B)), $A, $B, 1.0, 1.0);
  87.987 ns (1 allocation: 96 bytes)
```
This PR
```julia
julia> @btime mul!($(zero(B)), $A, $B, 1.0, 1.0);
  20.579 ns (0 allocations: 0 bytes)
```