### PR TITLE
`Eigen` for `AbstractFill` and `eigvals` for `Tridiagonal{<:Number,<:AbstractFillVector}`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FillArrays"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "1.1.0"
+version = "1.2.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -10,7 +10,7 @@ import Base: size, getindex, setindex!, IndexStyle, checkbounds, convert,
 
 import LinearAlgebra: rank, svdvals!, tril, triu, tril!, triu!, diag, transpose, adjoint, fill!,
     dot, norm2, norm1, normInf, normMinusInf, normp, lmul!, rmul!, diagzero, AdjointAbsVec, TransposeAbsVec,
-    issymmetric, ishermitian, AdjOrTransAbsVec, checksquare, mul!
+    issymmetric, ishermitian, AdjOrTransAbsVec, checksquare, mul!, eigvals, eigen, eigvecs, Eigen
 
 
 import Base.Broadcast: broadcasted, DefaultArrayStyle, broadcast_shape

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -10,7 +10,8 @@ import Base: size, getindex, setindex!, IndexStyle, checkbounds, convert,
 
 import LinearAlgebra: rank, svdvals!, tril, triu, tril!, triu!, diag, transpose, adjoint, fill!,
     dot, norm2, norm1, normInf, normMinusInf, normp, lmul!, rmul!, diagzero, AdjointAbsVec, TransposeAbsVec,
-    issymmetric, ishermitian, AdjOrTransAbsVec, checksquare, mul!, eigvals, eigen, eigvecs, Eigen
+    issymmetric, ishermitian, AdjOrTransAbsVec, checksquare, mul!, eigvals, eigen, eigvecs, Eigen,
+    HermOrSym
 
 
 import Base.Broadcast: broadcasted, DefaultArrayStyle, broadcast_shape

--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -486,7 +486,10 @@ end
 _eigvec_prefactor(A, cm1, c1, m) = sqrt(complex(cm1/c1))^m
 _eigvec_prefactor(A::Union{SymTridiagonal, Symmetric{<:Any, <:Tridiagonal}}, cm1, c1, m) = oneunit(_eigvec_eltype(A))
 
-_eigvec_prefactors(A, cm1, c1) = [_eigvec_prefactor(A, cm1, c1, j-1) for j in axes(A,1)]
+function _eigvec_prefactors(A, cm1, c1)
+    x = _eigvec_prefactor(A, cm1, c1, 1)
+    [x^(j-1) for j in axes(A,1)]
+end
 _eigvec_prefactors(A::Union{SymTridiagonal, Symmetric{<:Any, <:Tridiagonal}}, cm1, c1) =
     Fill(_eigvec_prefactor(A, cm1, c1, 1), size(A,1))
 

--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -562,8 +562,12 @@ function _eigvecs_toeplitz(T; sortby = nothing)
     prefactors = _eigvec_prefactors(T, cm1, c1)
     for q in axes(M,2)
         qrev = n+1-q # match the default eigenvalue sorting
+        x = qrev/(n+1)
+        cs = cispi(x)
+        cs1 = copy(cs)
         for j in 1:cld(n,2)
-            M[j, q] = prefactors[j] * sinpi(j*qrev/(n+1))
+            M[j, q] = prefactors[j] * imag(cs)
+            cs *= cs1
         end
         phase = iseven(n+q) ? 1 : -1
         for j in cld(n,2)+1:n

--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -455,7 +455,7 @@ function eigvals(H::Hermitian{T, <:Tridiagonal{T, <:AbstractFillVector{T}}}; sor
     _eigvals_toeplitz(H; sortby)
 end
 
-__eigvals_toeplitz(::Tridiagonal, a, b, c, n) = [a + 2√(b*c) * cospi(k/(n+1)) for k in n:-1:1]
+__eigvals_toeplitz(::Tridiagonal, a, b, c, n) = [a + 2 * √(b*c) * cospi(k/(n+1)) for k in n:-1:1]
 __eigvals_toeplitz(::SymTridiagonal, a, b, c, n) = [a + 2b * cospi(k/(n+1)) for k in n:-1:1]
 __eigvals_toeplitz(::Hermitian{<:Union{Real, Complex}, <:Tridiagonal}, a, b, c, n) =
     [real(a + 2abs(b) * cospi(k/(n+1))) for k in n:-1:1]

--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -554,8 +554,11 @@ function _eigvecs_toeplitz(T; sortby = nothing)
     prefactors = _eigvec_prefactors(T, cm1, c1)
     for q in axes(M,2)
         qrev = n+1-q # match the default eigenvalue sorting
-        for j in axes(M,1)
+        for j in 1:cld(n,2)
             M[j, q] = prefactors[j] * sinpi(j*qrev/(n+1))
+        end
+        for j in cld(n,2)+1:n
+            M[j, q] = (-1)^(n+q) * prefactors[2j-n] * M[n+1-j,q]
         end
         normalize!(view(M, :, q))
     end

--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -496,7 +496,7 @@ _eigvec_prefactors(A::Union{SymTridiagonal, Symmetric{<:Any, <:Tridiagonal}}, cm
 _eigvec_eltype(A::SymTridiagonal) = float(eltype(A))
 _eigvec_eltype(A) = complex(float(eltype(A)))
 
-# The following methods are copied from Julia Base, which is under the MIT License
+# The functions swapcols! and permutecols!! are copied from Julia Base, which is under the MIT License
 # https://github.com/JuliaLang/julia/blob/master/LICENSE.md
 #=
 MIT License

--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -552,7 +552,7 @@ function _eigvecs_toeplitz(T; sortby = nothing)
     cm1 = T[2,1] # subdiagonal
     c1 = T[1,2]  # superdiagonal
     prefactors = _eigvec_prefactors(T, cm1, c1)
-    for q in reverse(axes(M,2))
+    for q in axes(M,2)
         qrev = n+1-q # match the default eigenvalue sorting
         for j in axes(M,1)
             M[j, q] = prefactors[j] * sinpi(j*qrev/(n+1))

--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -421,10 +421,11 @@ end
 
 function eigvecs(A::AbstractFillMatrix{<:Number}; sortby = nothing)
     Base.require_one_based_indexing(A)
-    val = getindex_value(A)
     n = checksquare(A)
-    ind = _eigenind(val, n, sortby)
     M = similar(A, float(eltype(A)))
+    n == 0 && return M
+    val = getindex_value(A)
+    ind = _eigenind(val, n, sortby)
     # The non-trivial eigenvector is normalize(ones(n))
     M[:, ind] .= 1/sqrt(n)
     # eigenvectors corresponding to zero eigenvalues

--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -486,9 +486,9 @@ end
 _eigvec_prefactor(A, cm1, c1, m) = sqrt(complex(cm1/c1))^m
 _eigvec_prefactor(A::Union{SymTridiagonal, Symmetric{<:Any, <:Tridiagonal}}, cm1, c1, m) = oneunit(_eigvec_eltype(A))
 
-_eigvec_prefactors(A, cm1, c1) = [_eigvec_prefactor(T, cm1, c1, j-1) for j in axes(T,1)]
+_eigvec_prefactors(A, cm1, c1) = [_eigvec_prefactor(A, cm1, c1, j-1) for j in axes(A,1)]
 _eigvec_prefactors(A::Union{SymTridiagonal, Symmetric{<:Any, <:Tridiagonal}}, cm1, c1) =
-    Fill(_eigvec_prefactor(A, cm1, c1, 1), size(T,1))
+    Fill(_eigvec_prefactor(A, cm1, c1, 1), size(A,1))
 
 _eigvec_eltype(A::SymTridiagonal) = float(eltype(A))
 _eigvec_eltype(A) = complex(float(eltype(A)))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1410,6 +1410,17 @@ end
     end
 end
 
+@testset "eigen" begin
+    for val in (2.0, -2.0, 2im, 4 - 5im)
+        F = Fill(val, 4, 4)
+        M = Matrix(F)
+        @test eigvals(F) ≈ eigvals(M)
+        λ, V = eigen(F)
+        @test V'V ≈ I
+        @test V' * F * V ≈ Diagonal(λ)
+    end
+end
+
 @testset "count" begin
     @test count(Ones{Bool}(10)) == count(Fill(true,10)) == 10
     @test count(Zeros{Bool}(10)) == count(Fill(false,10)) == 0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1413,7 +1413,7 @@ end
 @testset "eigen" begin
     sortby = x -> (real(x), imag(x))
     @testset "AbstractFill" begin
-        @testset for val in (2.0, -2, 2im, 4 - 5im), n in (0, 1, 4)
+        @testset for val in (2.0, -2, 3+2im, 4 - 5im), n in (0, 1, 4)
             F = Fill(val, n, n)
             M = Matrix(F)
             @test eigvals(F; sortby) ≈ eigvals(M; sortby)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1411,8 +1411,16 @@ end
 end
 
 @testset "eigen" begin
-    for val in (2.0, -2.0, 2im, 4 - 5im)
+    for val in (2.0, -2, 2im, 4 - 5im)
         F = Fill(val, 4, 4)
+        M = Matrix(F)
+        @test eigvals(F) ≈ eigvals(M)
+        λ, V = eigen(F)
+        @test V'V ≈ I
+        @test V' * F * V ≈ Diagonal(λ)
+    end
+    for T in (Ones, Zeros)
+        F = Ones(5,5)
         M = Matrix(F)
         @test eigvals(F) ≈ eigvals(M)
         λ, V = eigen(F)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1453,7 +1453,7 @@ end
                 ev = Fill(3, max(0,n-1))
                 for ST in (SymTridiagonal(dv, ev), Symmetric(Tridiagonal(ev, dv, ev)))
                     evST = eigvals(ST; sortby)
-                    @test evST ≈ eigvals(Symmetric(Matrix(ST)); sortby)
+                    @test evST ≈ eigvals(Matrix(ST); sortby)
                     @test eltype(evST) <: Real
                     λ, V = eigen(ST)
                     @test V'V ≈ I

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1411,21 +1411,42 @@ end
 end
 
 @testset "eigen" begin
-    for val in (2.0, -2, 2im, 4 - 5im)
-        F = Fill(val, 4, 4)
-        M = Matrix(F)
-        @test eigvals(F) ≈ eigvals(M)
-        λ, V = eigen(F)
-        @test V'V ≈ I
-        @test V' * F * V ≈ Diagonal(λ)
+    sortby = x -> (real(x), imag(x))
+    @testset "AbstractFill" begin
+        @testset for val in (2.0, -2, 2im, 4 - 5im)
+            F = Fill(val, 4, 4)
+            M = Matrix(F)
+            @test eigvals(F; sortby) ≈ eigvals(M; sortby)
+            λ, V = eigen(F; sortby)
+            @test λ == eigvals(F; sortby)
+            @test V'V ≈ I
+            @test V' * F * V ≈ Diagonal(λ)
+        end
+        @testset for MT in (Ones, Zeros), T in (Float64, Int, ComplexF64)
+            F = MT{T}(5,5)
+            M = Matrix(F)
+            @test eigvals(F; sortby) ≈ eigvals(M; sortby)
+            λ, V = eigen(F; sortby)
+            @test λ == eigvals(F; sortby)
+            @test V'V ≈ I
+            @test V' * F * V ≈ Diagonal(λ)
+        end
     end
-    for T in (Ones, Zeros)
-        F = Ones(5,5)
-        M = Matrix(F)
-        @test eigvals(F) ≈ eigvals(M)
-        λ, V = eigen(F)
-        @test V'V ≈ I
-        @test V' * F * V ≈ Diagonal(λ)
+    @testset "Tridiagonal" begin
+        @testset for n in (0, 1, 6)
+            T = Tridiagonal(Fill(2, max(0, n-1)), Fill(-4, n), Fill(3, max(0,n-1)))
+            @test eigvals(T; sortby) ≈ eigvals(Matrix(T); sortby)
+            T = Tridiagonal(Fill(2+3im, max(0, n-1)), Fill(-4+4im, n), Fill(3im, max(0,n-1)))
+            @test eigvals(T; sortby) ≈ eigvals(Matrix(T); sortby)
+
+            T = SymTridiagonal(Fill(1, n), Fill(3, max(0,n-1)))
+            @test eigvals(T; sortby) ≈ eigvals(Matrix(T); sortby)
+            T = SymTridiagonal(Fill(-4+4im, n), Fill(2+3im, max(0,n-1)))
+            @test eigvals(T; sortby) ≈ eigvals(Matrix(T); sortby)
+
+            T = Hermitian(Tridiagonal(Fill(3-4im, max(0, n-1)), Fill(2+0im, n), Fill(3+4im, max(0, n-1))))
+            @test eigvals(T) ≈ eigvals(Hermitian(Matrix(T)))
+        end
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1433,7 +1433,7 @@ end
         end
     end
     @testset "Tridiagonal" begin
-        @testset for n in (0, 1, 6)
+        @testset for n in (0, 1, 2, 6)
             T = Tridiagonal(Fill(2, max(0, n-1)), Fill(-4, n), Fill(3, max(0,n-1)))
             @test eigvals(T; sortby) ≈ eigvals(Matrix(T); sortby)
             T = Tridiagonal(Fill(2+3im, max(0, n-1)), Fill(-4+4im, n), Fill(3im, max(0,n-1)))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1443,6 +1443,8 @@ end
                     @test eigvals(T; sortby) ≈ eigvals(Matrix(T); sortby)
                     λ, V = eigen(T)
                     @test T * V ≈ V * Diagonal(λ)
+                    λ, V = eigen(T, sortby=abs)
+                    @test T * V ≈ V * Diagonal(λ)
                 end
             end
 
@@ -1456,12 +1458,17 @@ end
                     λ, V = eigen(ST)
                     @test V'V ≈ I
                     @test V' * ST * V ≈ Diagonal(λ)
+                    λ, V = eigen(ST, sortby=abs)
+                    @test V'V ≈ I
+                    @test V' * ST * V ≈ Diagonal(λ)
                 end
                 dv = Fill(-4+4im, n)
                 ev = Fill(2+3im, max(0,n-1))
                 for ST2 in (SymTridiagonal(dv, ev), Symmetric(Tridiagonal(ev, dv, ev)))
                     @test eigvals(ST2; sortby) ≈ eigvals(Matrix(ST2); sortby)
                     λ, V = eigen(ST2)
+                    @test ST2 * V ≈ V * Diagonal(λ)
+                    λ, V = eigen(ST2, sortby=abs)
                     @test ST2 * V ≈ V * Diagonal(λ)
                 end
             end
@@ -1471,9 +1478,12 @@ end
                                     (Fill(2, n), Fill(3, max(0, n-1))))
                     HT = Hermitian(Tridiagonal(ev, dv, ev))
                     evHT = eigvals(HT; sortby)
-                    @test evHT ≈ eigvals(Hermitian(Matrix(HT)); sortby)
+                    @test evHT ≈ eigvals(Matrix(HT); sortby)
                     @test eltype(evHT) <: Real
                     λ, V = eigen(HT)
+                    @test V'V ≈ I
+                    @test V' * HT * V ≈ Diagonal(λ)
+                    λ, V = eigen(HT, sortby=abs)
                     @test V'V ≈ I
                     @test V' * HT * V ≈ Diagonal(λ)
                 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1413,8 +1413,8 @@ end
 @testset "eigen" begin
     sortby = x -> (real(x), imag(x))
     @testset "AbstractFill" begin
-        @testset for val in (2.0, -2, 2im, 4 - 5im)
-            F = Fill(val, 4, 4)
+        @testset for val in (2.0, -2, 2im, 4 - 5im), n in (0, 1, 4)
+            F = Fill(val, n, n)
             M = Matrix(F)
             @test eigvals(F; sortby) ≈ eigvals(M; sortby)
             λ, V = eigen(F; sortby)
@@ -1422,8 +1422,8 @@ end
             @test V'V ≈ I
             @test V' * F * V ≈ Diagonal(λ)
         end
-        @testset for MT in (Ones, Zeros), T in (Float64, Int, ComplexF64)
-            F = MT{T}(5,5)
+        @testset for MT in (Ones, Zeros), T in (Float64, Int, ComplexF64), n in (0, 1, 4)
+            F = MT{T}(n,n)
             M = Matrix(F)
             @test eigvals(F; sortby) ≈ eigvals(M; sortby)
             λ, V = eigen(F; sortby)
@@ -1445,7 +1445,9 @@ end
             @test eigvals(T; sortby) ≈ eigvals(Matrix(T); sortby)
 
             T = Hermitian(Tridiagonal(Fill(3-4im, max(0, n-1)), Fill(2+0im, n), Fill(3+4im, max(0, n-1))))
-            @test eigvals(T) ≈ eigvals(Hermitian(Matrix(T)))
+            evT = eigvals(T)
+            @test evT ≈ eigvals(Hermitian(Matrix(T)))
+            @test eltype(evT) <: Real
         end
     end
 end


### PR DESCRIPTION
The various tridiagonal matrices that wrap `AbstractFillVector`s are Toeplitz matrices, and their eigenvalues may be computed analytically in `O(n)` time, and eigenvectors in `O(n^2)`. Aside from this, since a square `AbstractFillMatrix` is of rank-1, it has only one non-zero eigenvalue that may be computed trivially in `O(1)` time, and the eigenvectors may also be evaluated in `O(n^2)`.

```julia
julia> T = Tridiagonal(Fill(2,400), Fill(5,401), Fill(2,400));

julia> @btime eigvals($T);
  12.503 μs (1 allocation: 3.31 KiB)  # This PR
  8.211 ms (11 allocations: 1.37 MiB) # master

julia> @btime eigen($T);
  875.773 μs (4 allocations: 2.46 MiB) # This PR
  26.678 ms (16 allocations: 3.83 MiB) # master

julia> F = Fill(2, 40, 40);

julia> @btime eigvals($F); # This PR
  4.211 ns (0 allocations: 0 bytes)

julia> @btime eigen($F);
  1.444 μs (1 allocation: 12.62 KiB)

julia> @btime eigvals($(Matrix(F))); # as on aster
  106.181 μs (10 allocations: 27.94 KiB)
```