### PR TITLE
`Adjoint`/`transpose` for `OneElementMatrix` preserves type

### DIFF
--- a/src/oneelement.jl
+++ b/src/oneelement.jl
@@ -144,3 +144,8 @@ end
 function mul!(C::AbstractMatrix, A::AbstractFillMatrix, B::OneElementMatrix, alpha::Number, beta::Number)
     _mulonel!(C, A, B, alpha, beta)
 end
+
+# adjoint/transpose
+
+adjoint(A::OneElementMatrix) = OneElement(adjoint(A.val), reverse(A.ind), reverse(A.axes))
+transpose(A::OneElementMatrix) = OneElement(transpose(A.val), reverse(A.ind), reverse(A.axes))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1718,9 +1718,21 @@ end
         @test A' === OneElement(-3im, (4,2), (6,4))
         @test transpose(A) === OneElement(3im, (4,2), (6,4))
 
+        A = OneElement(3im, 2, 3)
+        @test A' isa Adjoint
+        @test transpose(A) isa Transpose
+        @test A' == OneElement(-3im, (1,2), (1,3))
+        @test transpose(A) == OneElement(3im, (1,2), (1,3))
+
         A = OneElement(3, (2,2), (4,4))
         @test adjoint(A) === A
         @test transpose(A) === A
+
+        A = OneElement(3, 2, 4)
+        @test transpose(A) isa Transpose
+        @test adjoint(A) isa Adjoint
+        @test transpose(A) == OneElement(3, (1,2), (1,4))
+        @test adjoint(A) == OneElement(3, (1,2), (1,4))
     end
 
     @testset "matmul" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1713,6 +1713,16 @@ end
     @test Base.setindex(Zeros(5,3), 2, 2, 3) ≡ OneElement(2.0, (2,3), (5,3))
     @test_throws BoundsError Base.setindex(Zeros(5), 2, 6)
 
+    @testset "adjoint/transpose" begin
+        A = OneElement(3im, (2,4), (4,6))
+        @test A' === OneElement(-3im, (4,2), (6,4))
+        @test transpose(A) === OneElement(3im, (4,2), (6,4))
+
+        A = OneElement(3, (2,2), (4,4))
+        @test adjoint(A) === A
+        @test transpose(A) === A
+    end
+
     @testset "matmul" begin
         A = reshape(Float64[1:9;], 3, 3)
         testinds(w::AbstractArray) = testinds(size(w))


### PR DESCRIPTION
After this PR
```julia
julia> A = OneElement(3im, (2,3), (3,4))
3×4 OneElement{Complex{Int64}, 2, Tuple{Int64, Int64}, Tuple{Base.OneTo{Int64}, Base.OneTo{Int64}}}:
   ⋅      ⋅      ⋅      ⋅  
   ⋅      ⋅    0+3im    ⋅  
   ⋅      ⋅      ⋅      ⋅  

julia> A'
4×3 OneElement{Complex{Int64}, 2, Tuple{Int64, Int64}, Tuple{Base.OneTo{Int64}, Base.OneTo{Int64}}}:
   ⋅      ⋅      ⋅  
   ⋅      ⋅      ⋅  
   ⋅    0-3im    ⋅  
   ⋅      ⋅      ⋅  
```
The result is also a `OneElementMatrix`