### PR TITLE
`AbstractArray` constructor for `OneElement`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FillArrays"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "1.1.0"
+version = "1.2.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/oneelement.jl
+++ b/src/oneelement.jl
@@ -45,6 +45,8 @@ function Base.getindex(A::OneElement{T,N}, kj::Vararg{Int,N}) where {T,N}
     ifelse(kj == A.ind, A.val, zero(T))
 end
 
+Base.AbstractArray{T,N}(A::OneElement{<:Any,N}) where {T,N} = OneElement(T(A.val), A.ind, A.axes)
+
 Base.replace_in_print_matrix(o::OneElementVector, k::Integer, j::Integer, s::AbstractString) =
     o.ind == (k,) ? s : Base.replace_with_centered_mark(s)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1641,12 +1641,12 @@ end
     @test e₁ == [0,1,0,0,0]
     @test_throws BoundsError e₁[6]
 
-    @test AbstractArray{Float64}(e₁) isa AbstractArray{Float64}
-    @test AbstractArray{Float64}(e₁) isa OneElement
-    @test AbstractArray{Float64}(e₁) == e₁
-    @test AbstractVector{Float64}(e₁) isa AbstractVector{Float64}
-    @test AbstractVector{Float64}(e₁) isa OneElement
-    @test AbstractVector{Float64}(e₁) == e₁
+    f₁ = AbstractArray{Float64}(e₁)
+    @test f₁ isa OneElement{Float64,1}
+    @test f₁ == e₁
+    fv₁ = AbstractVector{Float64}(e₁)
+    @test fv₁ isa OneElement{Float64,1}
+    @test fv₁ == e₁
 
     @test stringmime("text/plain", e₁) == "5-element OneElement{$Int, 1, Tuple{$Int}, Tuple{Base.OneTo{$Int}}}:\n ⋅\n 1\n ⋅\n ⋅\n ⋅"
 
@@ -1659,12 +1659,12 @@ end
     V = OneElement(2, (2,3), (3,4))
     @test V == [0 0 0 0; 0 0 2 0; 0 0 0 0]
 
-    @test AbstractArray{Float64}(V) isa AbstractArray{Float64}
-    @test AbstractArray{Float64}(V) isa OneElement
-    @test AbstractArray{Float64}(V) == V
-    @test AbstractMatrix{Float64}(V) isa AbstractMatrix{Float64}
-    @test AbstractMatrix{Float64}(V) isa OneElement
-    @test AbstractMatrix{Float64}(V) == V
+    Vf = AbstractArray{Float64}(V)
+    @test Vf isa OneElement{Float64,2}
+    @test Vf == V
+    VMf = AbstractMatrix{Float64}(V)
+    @test VMf isa OneElement{Float64,2}
+    @test VMf == V
 
     @test stringmime("text/plain", V) == "3×4 OneElement{$Int, 2, Tuple{$Int, $Int}, Tuple{Base.OneTo{$Int}, Base.OneTo{$Int}}}:\n ⋅  ⋅  ⋅  ⋅\n ⋅  ⋅  2  ⋅\n ⋅  ⋅  ⋅  ⋅"
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1641,6 +1641,13 @@ end
     @test e₁ == [0,1,0,0,0]
     @test_throws BoundsError e₁[6]
 
+    @test AbstractArray{Float64}(e₁) isa AbstractArray{Float64}
+    @test AbstractArray{Float64}(e₁) isa OneElement
+    @test AbstractArray{Float64}(e₁) == e₁
+    @test AbstractVector{Float64}(e₁) isa AbstractVector{Float64}
+    @test AbstractVector{Float64}(e₁) isa OneElement
+    @test AbstractVector{Float64}(e₁) == e₁
+
     @test stringmime("text/plain", e₁) == "5-element OneElement{$Int, 1, Tuple{$Int}, Tuple{Base.OneTo{$Int}}}:\n ⋅\n 1\n ⋅\n ⋅\n ⋅"
 
     e₁ = OneElement{Float64}(2, 5)
@@ -1651,6 +1658,13 @@ end
 
     V = OneElement(2, (2,3), (3,4))
     @test V == [0 0 0 0; 0 0 2 0; 0 0 0 0]
+
+    @test AbstractArray{Float64}(V) isa AbstractArray{Float64}
+    @test AbstractArray{Float64}(V) isa OneElement
+    @test AbstractArray{Float64}(V) == V
+    @test AbstractMatrix{Float64}(V) isa AbstractMatrix{Float64}
+    @test AbstractMatrix{Float64}(V) isa OneElement
+    @test AbstractMatrix{Float64}(V) == V
 
     @test stringmime("text/plain", V) == "3×4 OneElement{$Int, 2, Tuple{$Int, $Int}, Tuple{Base.OneTo{$Int}, Base.OneTo{$Int}}}:\n ⋅  ⋅  ⋅  ⋅\n ⋅  ⋅  2  ⋅\n ⋅  ⋅  ⋅  ⋅"
 


### PR DESCRIPTION
On master
```julia
julia> convert(AbstractArray{Float64}, OneElement(2, 4))
4-element Vector{Float64}:
 0.0
 1.0
 0.0
 0.0
```
This PR
```julia
julia> convert(AbstractArray{Float64}, OneElement(2, 4))
4-element OneElement{Float64, 1, Tuple{Int64}, Tuple{Base.OneTo{Int64}}}:
  ⋅ 
 1.0
  ⋅ 
  ⋅ 
```