### PR TITLE
remove inbounds in Base._unsafe_getindex

### DIFF
--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -222,8 +222,8 @@ Base.@propagate_inbounds @inline function _fill_getindex(A::AbstractFill, kr::Ab
    fillsimilar(A, count(kr))
 end
 
-Base.@propagate_inbounds @inline Base._unsafe_getindex(::IndexStyle, F::AbstractFill, I::Vararg{Union{Real, AbstractArray}, N}) where N =
-    @inbounds(return _fill_getindex(F, I...))
+Base.@propagate_inbounds @inline Base._unsafe_getindex(::IndexStyle, F::AbstractFill, I::Vararg{Union{Real, AbstractArray}}) =
+    _fill_getindex(F, I...)
 
 
 


### PR DESCRIPTION
One of `@propagate_inbounds` and `@inbounds` is redundant here. Perhaps the `@propagate_inbounds` should be removed. Currently, I've removed the `@inbounds`, but I guess the `unsafe` in the name indicates that this may be declared to be `inbounds`.