### PR TITLE
`diag` for structured matrices with `Fill` bands

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FillArrays"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "1.2.1"
+version = "1.3.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -481,7 +481,21 @@ function convert(::Type{T}, A::AbstractFillMatrix) where T<:Diagonal
     isdiag(A) ? T(A) : throw(InexactError(:convert, T, A))
 end
 
+#################
+# Structured matrix types
+#################
+
+for SMT in (:Diagonal, :Bidiagonal, :Tridiagonal, :SymTridiagonal)
+    @eval function diag(D::$SMT{<:Number,<:AbstractFillVector}, k::Integer=0)
+        inds = (1,1) .+ (k >= 0 ? (0,k) : (-k,0))
+        v = get(D, inds, zero(eltype(D)))
+        Fill(v, length(diagind(D, k)))
+    end
+end
+
+##################
 ## Sparse arrays
+##################
 SparseVector{T}(Z::ZerosVector) where T = spzeros(T, length(Z))
 SparseVector{Tv,Ti}(Z::ZerosVector) where {Tv,Ti} = spzeros(Tv, Ti, length(Z))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1952,3 +1952,17 @@ end
         @test_throws ArgumentError repeat(Fill(2,3,4), outer=(1,))
     end
 end
+
+@testset "structured matrix" begin
+    @testset for (dv, ev) in ((Fill(2,3), Fill(6,2)), (Zeros(3), Zeros(2)))
+        for D in (Diagonal(dv), Bidiagonal(dv, ev, :U),
+                    Tridiagonal(ev, dv, ev), SymTridiagonal(dv, ev))
+
+            M = Matrix(D)
+            for k in -5:5
+                @test diag(D, k) isa FillArrays.AbstractFill{eltype(D),1}
+                @test diag(D, k) == diag(M, k)
+            end
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1954,7 +1954,14 @@ end
 end
 
 @testset "structured matrix" begin
-    @testset for (dv, ev) in ((Fill(2,3), Fill(6,2)), (Zeros(3), Zeros(2)))
+    # strange bug on Julia v1.6, see
+    # https://discourse.julialang.org/t/strange-seemingly-out-of-bounds-access-bug-in-julia-v1-6/101041
+    bands = if VERSION >= v"1.9"
+        ((Fill(2,3), Fill(6,2)), (Zeros(3), Zeros(2)))
+    else
+        ((Fill(2,3), Fill(6,2)),)
+    end
+    @testset for (dv, ev) in bands
         for D in (Diagonal(dv), Bidiagonal(dv, ev, :U),
                     Tridiagonal(ev, dv, ev), SymTridiagonal(dv, ev))
 


### PR DESCRIPTION
After this, `diag` for structured matrix types with `Fill` bands returns a `Fill`
```julia
julia> D = Tridiagonal(Fill(3,4), Fill(10,5), Fill(3,4))
5×5 Tridiagonal{Int64, Fill{Int64, 1, Tuple{Base.OneTo{Int64}}}}:
 10   3   ⋅   ⋅   ⋅
  3  10   3   ⋅   ⋅
  ⋅   3  10   3   ⋅
  ⋅   ⋅   3  10   3
  ⋅   ⋅   ⋅   3  10

julia> diag(D,2)
3-element Fill{Int64}, with entries equal to 0

julia> diag(D,1)
4-element Fill{Int64}, with entries equal to 3

julia> diag(D)
5-element Fill{Int64}, with entries equal to 10
```