### PR TITLE
Use return types of calculations instead of `promote_type`

### DIFF
--- a/src/fillbroadcast.jl
+++ b/src/fillbroadcast.jl
@@ -203,12 +203,12 @@ for op in (:+, :-)
         function broadcasted(::DefaultArrayStyle{1}, ::typeof($op), a::AbstractRange{T}, b::ZerosVector{V}) where {T,V}
             broadcast_shape(axes(a), axes(b)) == axes(a) || throw(ArgumentError("Cannot broadcast $a and $b. Convert $b to a Vector first."))
             TT = typeof($op(zero(T), zero(V)))
-            _copy_oftype(a, TT)
+            _range_convert(AbstractVector{TT}, a)
         end
         function broadcasted(::DefaultArrayStyle{1}, ::typeof($op), a::AbstractVector{T}, b::ZerosVector{V}) where {T,V}
             broadcast_shape(axes(a), axes(b)) == axes(a) || throw(ArgumentError("Cannot broadcast $a and $b. Convert $b to a Vector first."))
             TT = typeof($op(zero(T), zero(V)))
-            _copy_oftype(a, TT)
+            convert(AbstractVector{TT}, a)
         end
 
         broadcasted(::DefaultArrayStyle{1}, ::typeof($op), a::AbstractFillVector{T}, b::ZerosVector) where T =

--- a/src/fillbroadcast.jl
+++ b/src/fillbroadcast.jl
@@ -208,7 +208,7 @@ for op in (:+, :-)
         function broadcasted(::DefaultArrayStyle{1}, ::typeof($op), a::AbstractVector{T}, b::ZerosVector{V}) where {T,V}
             broadcast_shape(axes(a), axes(b)) == axes(a) || throw(ArgumentError("Cannot broadcast $a and $b. Convert $b to a Vector first."))
             TT = typeof($op(zero(T), zero(V)))
-            broadcasted(TT, a)
+            _copy_oftype(a, TT)
         end
 
         broadcasted(::DefaultArrayStyle{1}, ::typeof($op), a::AbstractFillVector{T}, b::ZerosVector) where T =

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -938,30 +938,17 @@ end
             @test_throws DimensionMismatch Zeros{Int}(2) .+ (1:5)
             @test_throws DimensionMismatch (1:5) .+ Zeros{Int}(2)
 
-            for v in ([1:5;], SVector{5}(1:5), SVector{5,ComplexF16}(1:5))
-                a = Zeros{Int}(5) .+ v
-                b = v .+ Zeros{Int}(5)
-                c = v .- Zeros{Int}(5)
+            for v in (rand(Bool, 5), [1:5;], SVector{5}(1:5), SVector{5,ComplexF16}(1:5)), T in (Bool, Int, Float64)
+                TT = eltype(v + zeros(T, 5))
+                S = v isa SVector ? SVector{5,TT} : Vector{TT}
+                
+                a = Zeros{T}(5) .+ v
+                b = v .+ Zeros{T}(5)
+                c = v .- Zeros{T}(5)
                 @test a == b == c == v
-                @test all(x -> x isa AbstractVector{promote_type(eltype(v), Int)}, (a,b,c))
-
-                a = Zeros{Int}(1) .+ v
-                b = v .+ Zeros{Int}(1)
-                c = v .- Zeros{Int}(1)
-                @test a == b == c == 1:5
-                @test all(x -> x isa AbstractVector{promote_type(eltype(v), Int)}, (a,b,c))
-
-                a = Zeros{Float64}(5) .+ v
-                b = v .+ Zeros{Float64}(5)
-                c = v .- Zeros{Float64}(5)
-                @test a == b == c == v
-                @test all(x -> x isa AbstractVector{promote_type(eltype(v), Float64)}, (a,b,c))
-
-                a = Zeros{Float64}(1) .+ v
-                b = v .+ Zeros{Float64}(1)
-                c = v .- Zeros{Float64}(1)
-                @test a == b == c == v
-                @test all(x -> x isa AbstractVector{promote_type(eltype(v), Float64)}, (a,b,c))
+                d = Zeros{T}(5) .- v
+                @test d == -v
+                @test all(Base.Fix2(isa, S), (a,b,c,d))
             end
         end
     end


### PR DESCRIPTION
This (or at least the last line in the diff) seems to fix the MWE in #252. I'd also argue that it is more correct since, e.g. for `Bool` `promote_type(Bool, Bool) === Bool` but `true + false isa Int`.

I'm not sure what tests could be added to avoid AD regressions in the future. Maybe the boolean examples would be a start as they would have caught the incorrect types at least?