### PR TITLE
Sorting should throw when a comparison is not defined

### DIFF
--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -7,7 +7,7 @@ import Base: size, getindex, setindex!, IndexStyle, checkbounds, convert,
     any, all, axes, isone, iterate, unique, allunique, permutedims, inv,
     copy, vec, setindex!, count, ==, reshape, _throw_dmrs, map, zero,
     show, view, in, mapreduce, one, reverse, promote_op, promote_rule, repeat,
-    parent
+    parent, issorted
 
 import LinearAlgebra: rank, svdvals!, tril, triu, tril!, triu!, diag, transpose, adjoint, fill!,
     dot, norm2, norm1, normInf, normMinusInf, normp, lmul!, rmul!, diagzero, AdjointAbsVec, TransposeAbsVec,
@@ -237,8 +237,22 @@ Base.@propagate_inbounds getindex(A::AbstractFill, kr::AbstractArray{Bool}) = _f
     v, (v, n+1)
 end
 
-sort(a::AbstractFill; kwds...) = a
-sort!(a::AbstractFill; kwds...) = a
+#################
+# Sorting
+#################
+function issorted(f::AbstractFill; kw...)
+    v = getindex_value(f)
+    issorted((v, v); kw...)
+end
+function sort(a::AbstractFill; kwds...)
+    issorted(a; kwds...) # ensure that the values may be compared
+    return a
+end
+function sort!(a::AbstractFill; kwds...)
+    issorted(a; kwds...) # ensure that the values may be compared
+    return a
+end
+
 svdvals!(a::AbstractFillMatrix) = [getindex_value(a)*sqrt(prod(size(a))); Zeros(min(size(a)...)-1)]
 
 function fill_reshape(parent, dims::Integer...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -730,6 +730,10 @@ end
     @test svdvals(fill(2,5,6)) ≈ svdvals(Fill(2,5,6))
     @test svdvals(Eye(5)) === Fill(1.0,5)
     @test sort(Ones(5)) == sort!(Ones(5))
+
+    @test_throws MethodError issorted(Fill(im, 2))
+    @test_throws MethodError sort(Fill(im, 2))
+    @test_throws MethodError sort!(Fill(im, 2))
 end
 
 @testset "Cumsum and diff" begin
@@ -777,6 +781,8 @@ end
             @test (@inferred Base.IteratorSize(Fill(2, (r, 1:2)))) == Base.IsInfinite()
             @test (@inferred Base.IteratorSize(Fill(2, (r, r)))) == Base.IsInfinite()
         end
+
+        @test issorted(Fill(2, (InfiniteArrays.OneToInf(),)))
     end
 end
 


### PR DESCRIPTION
This fixes the following behavior on master:
```julia
julia> sort(Fill(im,2))
2-element Fill{Complex{Bool}}, with entries equal to im
```
This doesn't make sense, as complex numbers can't be ordered. After this,
```julia
julia> sort(Fill(im,2))
ERROR: MethodError: no method matching isless(::Complex{Bool}, ::Complex{Bool})
```
which matches the `Base` behavior:
```julia
julia> sort(fill(im,2))
ERROR: MethodError: no method matching isless(::Complex{Bool}, ::Complex{Bool})
```