### PR TITLE
Use `Base.require_one_based_indexing` in RectDiagonal constructor

### DIFF
--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -358,10 +358,10 @@ struct RectDiagonal{T,V<:AbstractVector{T},Axes<:Tuple{Vararg{AbstractUnitRange,
     axes::Axes
 
     @inline function RectDiagonal{T,V}(A::V, axes::Axes) where {T,V<:AbstractVector{T},Axes<:Tuple{Vararg{AbstractUnitRange,2}}}
-        @assert !Base.has_offset_axes(A)
+        Base.require_one_based_indexing(A)
         @assert any(length(ax) == length(A) for ax in axes)
         rd = new{T,V,Axes}(A, axes)
-        @assert !Base.has_offset_axes(rd)
+        Base.require_one_based_indexing(rd)
         return rd
     end
 end


### PR DESCRIPTION
This improves the error message
```julia
julia> FillArrays.RectDiagonal(Base.IdentityUnitRange(4:5))
ERROR: ArgumentError: offset arrays are not supported but got an array with index other than 1
```
vs on master
```julia
julia> FillArrays.RectDiagonal(Base.IdentityUnitRange(4:5))
ERROR: AssertionError: !(Base.has_offset_axes(A))
```