### PR TITLE
Fix ReverseDiff bug

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,8 +15,9 @@ julia = "1.6"
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "Test", "Base64", "StaticArrays"]
+test = ["Aqua", "Test", "Base64", "ReverseDiff", "StaticArrays"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FillArrays"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "1.4.0"
+version = "1.4.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using FillArrays, LinearAlgebra, SparseArrays, StaticArrays, Random, Base64, Test, Statistics
+using FillArrays, LinearAlgebra, SparseArrays, StaticArrays, ReverseDiff, Random, Base64, Test, Statistics
 import FillArrays: AbstractFill, RectDiagonal, SquareEye
 
 using Aqua
@@ -2070,4 +2070,13 @@ end
             end
         end
     end
+end
+
+@testset "ReverseDiff with Zeros" begin
+    # MWE in https://github.com/JuliaArrays/FillArrays.jl/issues/252
+    @test ReverseDiff.gradient(x -> sum(abs2.((Zeros(5) .- zeros(5)) ./ x)), rand(5)) == zeros(5)
+    @test ReverseDiff.gradient(x -> sum(abs2.((zeros(5) .- Zeros(5)) ./ x)), rand(5)) == zeros(5)
+    # MWE in https://github.com/JuliaArrays/FillArrays.jl/pull/278
+    @test ReverseDiff.gradient(x -> sum(abs2.((Zeros{eltype(x)}(5) .- zeros(5)) ./ x)), rand(5)) == zeros(5)
+    @test ReverseDiff.gradient(x -> sum(abs2.((zeros(5) .- Zeros{eltype(x)}(5)) ./ x)), rand(5)) == zeros(5)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2079,4 +2079,10 @@ end
     # MWE in https://github.com/JuliaArrays/FillArrays.jl/pull/278
     @test ReverseDiff.gradient(x -> sum(abs2.((Zeros{eltype(x)}(5) .- zeros(5)) ./ x)), rand(5)) == zeros(5)
     @test ReverseDiff.gradient(x -> sum(abs2.((zeros(5) .- Zeros{eltype(x)}(5)) ./ x)), rand(5)) == zeros(5)
+
+    # Corresponding tests with +
+    @test ReverseDiff.gradient(x -> sum(abs2.((Zeros(5) .+ zeros(5)) ./ x)), rand(5)) == zeros(5)
+    @test ReverseDiff.gradient(x -> sum(abs2.((zeros(5) .+ Zeros(5)) ./ x)), rand(5)) == zeros(5)
+    @test ReverseDiff.gradient(x -> sum(abs2.((Zeros{eltype(x)}(5) .+ zeros(5)) ./ x)), rand(5)) == zeros(5)
+    @test ReverseDiff.gradient(x -> sum(abs2.((zeros(5) .+ Zeros{eltype(x)}(5)) ./ x)), rand(5)) == zeros(5)
 end


### PR DESCRIPTION
Unfortunately, the last commit in #273 (which fixed type inference issues) broke a ReverseDiff example (slightly modified version of the MWE in #252). On the master branch:
```julia
julia> using ReverseDiff, FillArrays

julia> ReverseDiff.gradient(x -> sum(abs2.((zeros(5) .- Zeros{eltype(x)}(5)) ./ x)), rand(5))
ERROR: MethodError: no method matching Float64(::ForwardDiff.Dual{ForwardDiff.Tag{ReverseDiff.var"#109#111"{Base.Broadcast.var"#12#14"{Base.Broadcast.var"#18#20"{Base.Broadcast.var"#11#13", Base.Broadcast.var"#18#20"{Base.Broadcast.var"#15#16"{Base.Broadcast.var"#17#19"}, Base.Broadcast.var"#15#16"{Base.Broadcast.var"#17#19"}, Base.Broadcast.var"#25#26"{Base.Broadcast.var"#27#28"}, Base.Broadcast.var"#21#22"{Base.Broadcast.var"#23#24"}, FillArrays.Constructor{ReverseDiff.TrackedReal{Float64, Float64, Nothing}}}, Base.Broadcast.var"#25#26"{Base.Broadcast.var"#25#26"{Base.Broadcast.var"#27#28"}}, Base.Broadcast.var"#21#22"{Base.Broadcast.var"#21#22"{Base.Broadcast.var"#23#24"}}, typeof(/)}, typeof(abs2)}, Tuple{}, Val{(1, 2)}}, Float64}, Float64, 2})

Closest candidates are:
  (::Type{T})(::Real, ::RoundingMode) where T<:AbstractFloat
   @ Base rounding.jl:207
  (::Type{T})(::T) where T<:Number
   @ Core boot.jl:792
  (::Type{T})(::AbstractChar) where T<:Union{AbstractChar, Number}
   @ Base char.jl:50
  ...

Stacktrace:
  [1] convert(#unused#::Type{Float64}, x::ForwardDiff.Dual{ForwardDiff.Tag{ReverseDiff.var"#109#111"{Base.Broadcast.var"#12#14"{Base.Broadcast.var"#18#20"{Base.Broadcast.var"#11#13", Base.Broadcast.var"#18#20"{Base.Broadcast.var"#15#16"{Base.Broadcast.var"#17#19"}, Base.Broadcast.var"#15#16"{Base.Broadcast.var"#17#19"}, Base.Broadcast.var"#25#26"{Base.Broadcast.var"#27#28"}, Base.Broadcast.var"#21#22"{Base.Broadcast.var"#23#24"}, FillArrays.Constructor{ReverseDiff.TrackedReal{Float64, Float64, Nothing}}}, Base.Broadcast.var"#25#26"{Base.Broadcast.var"#25#26"{Base.Broadcast.var"#27#28"}}, Base.Broadcast.var"#21#22"{Base.Broadcast.var"#21#22"{Base.Broadcast.var"#23#24"}}, typeof(/)}, typeof(abs2)}, Tuple{}, Val{(1, 2)}}, Float64}, Float64, 2})
    @ Base ./number.jl:7
  [2] ReverseDiff.TrackedReal{Float64, Float64, Nothing}(value::ForwardDiff.Dual{ForwardDiff.Tag{ReverseDiff.var"#109#111"{Base.Broadcast.var"#12#14"{Base.Broadcast.var"#18#20"{Base.Broadcast.var"#11#13", Base.Broadcast.var"#18#20"{Base.Broadcast.var"#15#16"{Base.Broadcast.var"#17#19"}, Base.Broadcast.var"#15#16"{Base.Broadcast.var"#17#19"}, Base.Broadcast.var"#25#26"{Base.Broadcast.var"#27#28"}, Base.Broadcast.var"#21#22"{Base.Broadcast.var"#23#24"}, FillArrays.Constructor{ReverseDiff.TrackedReal{Float64, Float64, Nothing}}}, Base.Broadcast.var"#25#26"{Base.Broadcast.var"#25#26"{Base.Broadcast.var"#27#28"}}, Base.Broadcast.var"#21#22"{Base.Broadcast.var"#21#22"{Base.Broadcast.var"#23#24"}}, typeof(/)}, typeof(abs2)}, Tuple{}, Val{(1, 2)}}, Float64}, Float64, 2})
    @ ReverseDiff ~/.julia/packages/ReverseDiff/wIfrd/src/tracked.jl:56
  [3] (::FillArrays.Constructor{ReverseDiff.TrackedReal{Float64, Float64, Nothing}})(x::ForwardDiff.Dual{ForwardDiff.Tag{ReverseDiff.var"#109#111"{Base.Broadcast.var"#12#14"{Base.Broadcast.var"#18#20"{Base.Broadcast.var"#11#13", Base.Broadcast.var"#18#20"{Base.Broadcast.var"#15#16"{Base.Broadcast.var"#17#19"}, Base.Broadcast.var"#15#16"{Base.Broadcast.var"#17#19"}, Base.Broadcast.var"#25#26"{Base.Broadcast.var"#27#28"}, Base.Broadcast.var"#21#22"{Base.Broadcast.var"#23#24"}, FillArrays.Constructor{ReverseDiff.TrackedReal{Float64, Float64, Nothing}}}, Base.Broadcast.var"#25#26"{Base.Broadcast.var"#25#26"{Base.Broadcast.var"#27#28"}}, Base.Broadcast.var"#21#22"{Base.Broadcast.var"#21#22"{Base.Broadcast.var"#23#24"}}, typeof(/)}, typeof(abs2)}, Tuple{}, Val{(1, 2)}}, Float64}, Float64, 2})
    @ FillArrays ~/.julia/packages/FillArrays/eFtCC/src/fillbroadcast.jl:203
  [4] #18
    @ ./broadcast.jl:396 [inlined]
  [5] #18
    @ ./broadcast.jl:394 [inlined]
  [6] #12
    @ ./broadcast.jl:342 [inlined]
  [7] macro expansion
    @ ~/.julia/packages/ReverseDiff/wIfrd/src/derivatives/broadcast.jl:126 [inlined]
  [8] splatcall
    @ ~/.julia/packages/ReverseDiff/wIfrd/src/derivatives/broadcast.jl:111 [inlined]
  [9] (::ReverseDiff.var"#109#111"{Base.Broadcast.var"#12#14"{Base.Broadcast.var"#18#20"{Base.Broadcast.var"#11#13", Base.Broadcast.var"#18#20"{Base.Broadcast.var"#15#16"{Base.Broadcast.var"#17#19"}, Base.Broadcast.var"#15#16"{Base.Broadcast.var"#17#19"}, Base.Broadcast.var"#25#26"{Base.Broadcast.var"#27#28"}, Base.Broadcast.var"#21#22"{Base.Broadcast.var"#23#24"}, FillArrays.Constructor{ReverseDiff.TrackedReal{Float64, Float64, Nothing}}}, Base.Broadcast.var"#25#26"{Base.Broadcast.var"#25#26"{Base.Broadcast.var"#27#28"}}, Base.Broadcast.var"#21#22"{Base.Broadcast.var"#21#22"{Base.Broadcast.var"#23#24"}}, typeof(/)}, typeof(abs2)}, Tuple{}, Val{(1, 2)}})(s::StaticArraysCore.SVector{2, ForwardDiff.Dual{ForwardDiff.Tag{ReverseDiff.var"#109#111"{Base.Broadcast.var"#12#14"{Base.Broadcast.var"#18#20"{Base.Broadcast.var"#11#13", Base.Broadcast.var"#18#20"{Base.Broadcast.var"#15#16"{Base.Broadcast.var"#17#19"}, Base.Broadcast.var"#15#16"{Base.Broadcast.var"#17#19"}, Base.Broadcast.var"#25#26"{Base.Broadcast.var"#27#28"}, Base.Broadcast.var"#21#22"{Base.Broadcast.var"#23#24"}, FillArrays.Constructor{ReverseDiff.TrackedReal{Float64, Float64, Nothing}}}, Base.Broadcast.var"#25#26"{Base.Broadcast.var"#25#26"{Base.Broadcast.var"#27#28"}}, Base.Broadcast.var"#21#22"{Base.Broadcast.var"#21#22"{Base.Broadcast.var"#23#24"}}, typeof(/)}, typeof(abs2)}, Tuple{}, Val{(1, 2)}}, Float64}, Float64, 2}})
    @ ReverseDiff ~/.julia/packages/ReverseDiff/wIfrd/src/derivatives/broadcast.jl:150
 [10] static_dual_eval
    @ ~/.julia/packages/ForwardDiff/vXysl/ext/ForwardDiffStaticArraysExt.jl:24 [inlined]
 [11] vector_mode_gradient!(result::DiffResults.ImmutableDiffResult{1, Float64, Tuple{StaticArraysCore.SVector{2, Float64}}}, f::Function, x::StaticArraysCore.SVector{2, Float64})
    @ ForwardDiffStaticArraysExt ~/.julia/packages/ForwardDiff/vXysl/ext/ForwardDiffStaticArraysExt.jl:64
 [12] gradient!(result::DiffResults.ImmutableDiffResult{1, Float64, Tuple{StaticArraysCore.SVector{2, Float64}}}, f::Function, x::StaticArraysCore.SVector{2, Float64})
    @ ForwardDiffStaticArraysExt ~/.julia/packages/ForwardDiff/vXysl/ext/ForwardDiffStaticArraysExt.jl:44
 [13] (::ReverseDiff.var"#df#110"{Base.Broadcast.var"#12#14"{Base.Broadcast.var"#18#20"{Base.Broadcast.var"#11#13", Base.Broadcast.var"#18#20"{Base.Broadcast.var"#15#16"{Base.Broadcast.var"#17#19"}, Base.Broadcast.var"#15#16"{Base.Broadcast.var"#17#19"}, Base.Broadcast.var"#25#26"{Base.Broadcast.var"#27#28"}, Base.Broadcast.var"#21#22"{Base.Broadcast.var"#23#24"}, FillArrays.Constructor{ReverseDiff.TrackedReal{Float64, Float64, Nothing}}}, Base.Broadcast.var"#25#26"{Base.Broadcast.var"#25#26"{Base.Broadcast.var"#27#28"}}, Base.Broadcast.var"#21#22"{Base.Broadcast.var"#21#22"{Base.Broadcast.var"#23#24"}}, typeof(/)}, typeof(abs2)}, DiffResults.ImmutableDiffResult{1, Float64, Tuple{StaticArraysCore.SVector{2, Float64}}}, Tuple{}, Val{(1, 2)}})(::Float64, ::Vararg{Float64})
    @ ReverseDiff ~/.julia/packages/ReverseDiff/wIfrd/src/derivatives/broadcast.jl:148
 [14] _broadcast_getindex_evalf
    @ ./broadcast.jl:683 [inlined]
 [15] _broadcast_getindex
    @ ./broadcast.jl:656 [inlined]
 [16] getindex
    @ ./broadcast.jl:610 [inlined]
 [17] copy
    @ ./broadcast.jl:912 [inlined]
 [18] materialize
    @ ./broadcast.jl:873 [inlined]
 [19] broadcast(::ReverseDiff.var"#df#110"{Base.Broadcast.var"#12#14"{Base.Broadcast.var"#18#20"{Base.Broadcast.var"#11#13", Base.Broadcast.var"#18#20"{Base.Broadcast.var"#15#16"{Base.Broadcast.var"#17#19"}, Base.Broadcast.var"#15#16"{Base.Broadcast.var"#17#19"}, Base.Broadcast.var"#25#26"{Base.Broadcast.var"#27#28"}, Base.Broadcast.var"#21#22"{Base.Broadcast.var"#23#24"}, FillArrays.Constructor{ReverseDiff.TrackedReal{Float64, Float64, Nothing}}}, Base.Broadcast.var"#25#26"{Base.Broadcast.var"#25#26"{Base.Broadcast.var"#27#28"}}, Base.Broadcast.var"#21#22"{Base.Broadcast.var"#21#22"{Base.Broadcast.var"#23#24"}}, typeof(/)}, typeof(abs2)}, DiffResults.ImmutableDiffResult{1, Float64, Tuple{StaticArraysCore.SVector{2, Float64}}}, Tuple{}, Val{(1, 2)}}, ::Vector{Float64}, ::Vector{Float64})
    @ Base.Broadcast ./broadcast.jl:811
 [20] ∇broadcast(::Base.Broadcast.var"#12#14"{Base.Broadcast.var"#18#20"{Base.Broadcast.var"#11#13", Base.Broadcast.var"#18#20"{Base.Broadcast.var"#15#16"{Base.Broadcast.var"#17#19"}, Base.Broadcast.var"#15#16"{Base.Broadcast.var"#17#19"}, Base.Broadcast.var"#25#26"{Base.Broadcast.var"#27#28"}, Base.Broadcast.var"#21#22"{Base.Broadcast.var"#23#24"}, FillArrays.Constructor{ReverseDiff.TrackedReal{Float64, Float64, Nothing}}}, Base.Broadcast.var"#25#26"{Base.Broadcast.var"#25#26"{Base.Broadcast.var"#27#28"}}, Base.Broadcast.var"#21#22"{Base.Broadcast.var"#21#22"{Base.Broadcast.var"#23#24"}}, typeof(/)}, typeof(abs2)}, ::Vector{Float64}, ::Vararg{Any})
    @ ReverseDiff ~/.julia/packages/ReverseDiff/wIfrd/src/derivatives/broadcast.jl:154
 [21] copy(_bc::Base.Broadcast.Broadcasted{ReverseDiff.TrackedStyle, Tuple{Base.OneTo{Int64}}, typeof(abs2), Tuple{Base.Broadcast.Broadcasted{ReverseDiff.TrackedStyle, Nothing, typeof(/), Tuple{Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, FillArrays.Constructor{ReverseDiff.TrackedReal{Float64, Float64, Nothing}}, Tuple{Vector{Float64}}}, ReverseDiff.TrackedArray{Float64, Float64, 1, Vector{Float64}, Vector{Float64}}}}}})
    @ ReverseDiff ~/.julia/packages/ReverseDiff/wIfrd/src/derivatives/broadcast.jl:94
 [22] materialize
    @ ./broadcast.jl:873 [inlined]
 [23] (::var"#5#6")(x::ReverseDiff.TrackedArray{Float64, Float64, 1, Vector{Float64}, Vector{Float64}})
    @ Main ./REPL[5]:1
 [24] ReverseDiff.GradientTape(f::var"#5#6", input::Vector{Float64}, cfg::ReverseDiff.GradientConfig{ReverseDiff.TrackedArray{Float64, Float64, 1, Vector{Float64}, Vector{Float64}}})
    @ ReverseDiff ~/.julia/packages/ReverseDiff/wIfrd/src/api/tape.jl:199
 [25] gradient(f::Function, input::Vector{Float64}, cfg::ReverseDiff.GradientConfig{ReverseDiff.TrackedArray{Float64, Float64, 1, Vector{Float64}, Vector{Float64}}})
    @ ReverseDiff ~/.julia/packages/ReverseDiff/wIfrd/src/api/gradients.jl:22
 [26] gradient(f::Function, input::Vector{Float64})
    @ ReverseDiff ~/.julia/packages/ReverseDiff/wIfrd/src/api/gradients.jl:22
 [27] top-level scope
    @ REPL[5]:1
```

Put simply, the general problem with broadcasting and AD is that most backends fall back to compute derivatives of the applied function with ForwardDiff - but the type of the output type is fixed to one that is incompatible with the internally used `Dual` numbers. This PR seems to fix the example above in an arguably simple way.

In an ideal world, FillArrays would not have to care about these AD-specific details. AD packages should be improved and their broadcasting should be more stable. But I don't see this happening anytime soon given the number of contributors to packages such as ReverseDiff or Tracker, and the huge number of possibilities of breaking downstream code that is working fine right now. I'm not a maintainer of FillArrays but since all these FillArray-specific issues did not exist prior to FillArrays 1.0.1, it seems reasonable to me to apply these AD fixes directly in FillArrays.

Unfortunately, I don't see a good way of testing these ReverseDiff issues without adding AD tests or downstream tests on DistributionsAD.

I'll rerun the DistributionsAD tests with this PR in the DistributionsAD repo: https://github.com/TuringLang/DistributionsAD.jl/pull/250