### PR TITLE
show eltype for Zeros/Ones

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FillArrays"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "1.4.2"
+version = "1.4.3"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FillArrays"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "1.4.3"
+version = "1.5.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -765,11 +765,19 @@ function Base.show(io::IO, ::MIME"text/plain", x::Union{Eye, AbstractFill})
 end
 
 function Base.show(io::IO, x::AbstractFill)  # for example (Fill(π,3),)
-    print(io, nameof(typeof(x)), "(")
-    if x isa Union{Zeros, Ones}
+    print(io, nameof(typeof(x)))
+    sz = size(x)
+    args = if x isa Union{Zeros, Ones}
+        T = eltype(x)
+        if T != Float64
+            print(io,"{", T, "}")
+        end
+        print(io, "(")
     else
-        show(io, getindex_value(x))  # show not print to handle (Fill(1f0,2),)
-        ndims(x) > 0 && print(io, ", ")
+        # show, not print, to handle (Fill(1f0,2),)
+        print(io, "(")
+        show(io, getindex_value(x))
+        ndims(x) == 0 || print(io, ", ")
     end
     join(io, size(x), ", ")
     print(io, ")")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1719,7 +1719,11 @@ end
     @test Base.replace_in_print_matrix(Zeros(5,3), 1, 2, "0.0") == " ⋅ "
 
     # 2-arg show, compact printing
+    @test repr(Zeros{Int}()) == "Zeros{$Int}()"
+    @test repr(Zeros{Int}(3)) == "Zeros{$Int}(3)"
     @test repr(Zeros(3)) == "Zeros(3)"
+    @test repr(Ones{Int}(3)) == "Ones{$Int}(3)"
+    @test repr(Ones{Int}(3,2)) == "Ones{$Int}(3, 2)"
     @test repr(Ones(3,2)) == "Ones(3, 2)"
     @test repr(Fill(7,3,2)) == "Fill(7, 3, 2)"
     @test repr(Fill(1f0,10)) == "Fill(1.0f0, 10)"  # Float32!


### PR DESCRIPTION
This changes the way `Zeros` and `Ones` are displayed compactly:
On master
```julia
julia> (Zeros{Int}(2),)
(Zeros(2),)
```
This PR
```julia
julia> (Zeros{Int}(2),)
(Zeros{Int64}(2),)
```
After this, the output represents a valid constructor for the displayed object.