### PR TITLE
Don't test for Project.toml formatting on v1.6

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,11 @@ import FillArrays: AbstractFill, RectDiagonal, SquareEye
 
 using Aqua
 @testset "Project quality" begin
-    Aqua.test_all(FillArrays, ambiguities=false)
+    Aqua.test_all(FillArrays, ambiguities=false,
+        # only test formatting on VERSION >= v1.7
+        # https://github.com/JuliaTesting/Aqua.jl/issues/105#issuecomment-1551405866
+        project_toml_formatting = VERSION >= v"1.7",
+    )
 end
 
 include("infinitearrays.jl")


### PR DESCRIPTION
This works around a Pkg bug on v1.6 that doesn't play well with extensions.