### PR TITLE
Add DSP tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,14 +10,16 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 Aqua = "0.5, 0.6"
+DSP = "0.7"
 julia = "1.6"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"
 ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "Test", "Base64", "ReverseDiff", "StaticArrays"]
+test = ["Aqua", "Test", "Base64", "DSP", "ReverseDiff", "StaticArrays"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,14 @@
-using FillArrays, LinearAlgebra, SparseArrays, StaticArrays, ReverseDiff, Random, Base64, Test, Statistics
+using Base64
+using DSP
+using FillArrays
+using LinearAlgebra
+using Random
+using ReverseDiff
+using SparseArrays
+using StaticArrays
+using Statistics
+using Test
+
 import FillArrays: AbstractFill, RectDiagonal, SquareEye
 
 using Aqua
@@ -2175,4 +2185,10 @@ end
     @test ReverseDiff.gradient(x -> sum(abs2.((zeros(5) .+ Zeros(5)) ./ x)), rand(5)) == zeros(5)
     @test ReverseDiff.gradient(x -> sum(abs2.((Zeros{eltype(x)}(5) .+ zeros(5)) ./ x)), rand(5)) == zeros(5)
     @test ReverseDiff.gradient(x -> sum(abs2.((zeros(5) .+ Zeros{eltype(x)}(5)) ./ x)), rand(5)) == zeros(5)
+end
+
+@testset "DSP" begin
+    @test conv(Fill(2, 3), Ones(4)) == conv(fill(2, 3), ones(4))
+    @test conv(Fill(2, 3), ones(4)) == conv(fill(2, 3), ones(4))
+    @test conv(fill(2, 3), Ones(4)) == conv(fill(2, 3), ones(4))
 end


### PR DESCRIPTION
Since `conv` methods may be excised from `InfiniteLinearAlgebra`, it's best to have tests for these here. The specialized `conv` methods for `AbstractFill` are unnecessary, and are actually less efficient than the fallback ones.