### PR TITLE
Type-inference improvement in reduce over Ones

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FillArrays"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "1.6.0"
+version = "1.6.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -354,7 +354,7 @@ end
 -(a::AbstractFill) = Fill(-getindex_value(a), size(a))
 
 # special-cased for type-stability, as Ones + Ones is not a Ones
-Base.reduce_first(::typeof(+), x::Ones) = convert(Fill, x)
+Base.reduce_first(::typeof(+), x::Ones) = Fill(Base.reduce_first(+, getindex_value(x)), axes(x))
 
 function +(a::Zeros{T}, b::Zeros{V}) where {T, V} # for disambiguity
     promote_shape(a,b)

--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -353,6 +353,8 @@ end
 -(a::Zeros) = a
 -(a::AbstractFill) = Fill(-getindex_value(a), size(a))
 
+# special-cased for type-stability, as Ones + Ones is not a Ones
+Base.reduce_first(::typeof(+), x::Ones) = convert(Fill, x)
 
 function +(a::Zeros{T}, b::Zeros{V}) where {T, V} # for disambiguity
     promote_shape(a,b)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -825,6 +825,8 @@ end
     @test diff(Ones{Float64}(10)) ≡ Zeros{Float64}(9)
     @test_throws UndefKeywordError cumsum(Fill(1,1,5))
 
+    @test @inferred(sum([Ones(4)])) ≡ Fill(1.0, 4)
+
     @testset "infinite arrays" begin
         r = InfiniteArrays.OneToInf()
         A = Ones{Int}((r,))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -826,6 +826,7 @@ end
     @test_throws UndefKeywordError cumsum(Fill(1,1,5))
 
     @test @inferred(sum([Ones(4)])) ≡ Fill(1.0, 4)
+    @test @inferred(sum([Trues(4)])) ≡ Fill(1, 4)
 
     @testset "infinite arrays" begin
         r = InfiniteArrays.OneToInf()


### PR DESCRIPTION
This makes the following concretely type-inferred:
```julia
julia> @inferred sum([Ones(4)])
4-element Fill{Float64}, with entries equal to 1.0
```
Without this, the return type is inferred to be a `Union{Ones, Fill}`