### PR TITLE
Remove downstream test against ContinuumArrays

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -40,7 +40,6 @@ jobs:
           - {repo: ArrayLayouts.jl, group: JuliaLinearAlgebra}
           - {repo: LazyBandedMatrices.jl, group: JuliaLinearAlgebra}
           - {repo: BandedMatrices.jl, group: JuliaLinearAlgebra}
-          - {repo: ContinuumArrays.jl, group: JuliaApproximation}
           - {repo: BlockBandedMatrices.jl, group: JuliaLinearAlgebra}
           - {repo: InfiniteLinearAlgebra.jl, group: JuliaLinearAlgebra}
           - {repo: Optim.jl, group: JuliaNLSolvers}


### PR DESCRIPTION
The CI for `ContinuumArrays` appears quite brittle, so it's not a reliable indicator of breakages arising from this package at present