### PR TITLE
Version limit any/all specializations

### DIFF
--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -633,10 +633,12 @@ end
 
 # In particular, these make iszero(Eye(n))  efficient.
 # use any/all on scalar to get Boolean error message
-any(f::Function, x::AbstractFill) = !isempty(x) && any(f(getindex_value(x)))
-all(f::Function, x::AbstractFill) = isempty(x) || all(f(getindex_value(x)))
-any(x::AbstractFill) = any(identity, x)
-all(x::AbstractFill) = all(identity, x)
+if VERSION < v"1.9.2"
+    any(f::Function, x::AbstractFill) = !isempty(x) && any(f(getindex_value(x)))
+    all(f::Function, x::AbstractFill) = isempty(x) || all(f(getindex_value(x)))
+    any(x::AbstractFill) = any(identity, x)
+    all(x::AbstractFill) = all(identity, x)
+end
 
 count(x::Ones{Bool}) = length(x)
 count(x::Zeros{Bool}) = 0


### PR DESCRIPTION
These don't seem necessary on recent Julia versions. On Julia version v1.9.2, using this PR, I obtain
```julia
julia> @btime any(isone, Fill(2,10000));
  2.942 ns (0 allocations: 0 bytes)

julia> @btime all(Fill(true,10000));
  2.943 ns (0 allocations: 0 bytes)

julia> @btime iszero(Eye(1000));
  1.689 ns (0 allocations: 0 bytes)
```
These methods are necessary mainly for infinite arrays, so the specializations should probably be added in `InfiniteArrays.jl`