### PR TITLE
Introduce `AbstractZeros` and `AbstractOnes`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FillArrays"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "1.6.2"
+version = "1.7.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -329,27 +329,27 @@ for (AbsTyp, Typ, funcs, func) in ((:AbstractZeros, :Zeros, :zeros, :zero), (:Ab
         getindex(F::$AbsTyp{T,0}) where T = getindex_value(F)
 
         promote_rule(::Type{$Typ{T, N, Axes}}, ::Type{$Typ{V, N, Axes}}) where {T,V,N,Axes} = $Typ{promote_type(T,V),N,Axes}
-        function convert(::Type{$AbsTyp{T,N,Axes}}, A::$AbsTyp{V,N,Axes}) where {T,V,N,Axes}
+        function convert(::Type{Typ}, A::$AbsTyp{V,N,Axes}) where {T,V,N,Axes,Typ<:$AbsTyp{T,N,Axes}}
             convert(T, getindex_value(A)) # checks that the types are convertible
-            $AbsTyp{T,N,Axes}(axes(A))
+            Typ(axes(A))
         end
-        convert(::Type{$AbsTyp{T,N}}, A::$AbsTyp{V,N,Axes}) where {T,V,N,Axes} = convert($AbsTyp{T,N,Axes}, A)
-        convert(::Type{$AbsTyp{T}}, A::$AbsTyp{V,N,Axes}) where {T,V,N,Axes} = convert($AbsTyp{T,N,Axes}, A)
-        function convert(::Type{$AbsTyp{T,N,Axes}}, A::AbstractFill{V,N}) where {T,V,N,Axes}
+        convert(::Type{$Typ{T,N}}, A::$AbsTyp{V,N,Axes}) where {T,V,N,Axes} = convert($Typ{T,N,Axes}, A)
+        convert(::Type{$Typ{T}}, A::$AbsTyp{V,N,Axes}) where {T,V,N,Axes} = convert($Typ{T,N,Axes}, A)
+        function convert(::Type{Typ}, A::AbstractFill{V,N}) where {T,V,N,Axes,Typ<:$AbsTyp{T,N,Axes}}
             axes(A) isa Axes || throw(ArgumentError("cannot convert, as axes of array are not $Axes"))
             val = getindex_value(A)
             y = convert(T, val)
             y == $func(T) || throw(ArgumentError(string("cannot convert an array containinig $val to ", $Typ)))
-            $Typ{T,N,Axes}(axes(A))
+            Typ(axes(A))
         end
-        function convert(::Type{$AbsTyp{T,N}}, A::AbstractFill{<:Any,N}) where {T,N}
-            convert($AbsTyp{T,N,typeof(axes(A))}, A)
+        function convert(::Type{$Typ{T,N}}, A::AbstractFill{<:Any,N}) where {T,N}
+            convert($Typ{T,N,typeof(axes(A))}, A)
         end
-        function convert(::Type{$AbsTyp{T}}, A::AbstractFill{<:Any,N}) where {T,N}
-            convert($AbsTyp{T,N}, A)
+        function convert(::Type{$Typ{T}}, A::AbstractFill{<:Any,N}) where {T,N}
+            convert($Typ{T,N}, A)
         end
-        function convert(::Type{$AbsTyp}, A::AbstractFill{V,N}) where {V,N}
-            convert($AbsTyp{V,N}, A)
+        function convert(::Type{$Typ}, A::AbstractFill{V,N}) where {V,N}
+            convert($Typ{V,N}, A)
         end
     end
 end

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -317,7 +317,6 @@ for (AbsTyp, Typ, funcs, func) in ((:AbstractZeros, :Zeros, :zeros, :zero), (:Ab
         @inline $Typ(::Type{T}, m...) where T = $Typ{T}(m...)
 
         @inline axes(Z::$Typ) = Z.axes
-        # TODO: Should these be generic to `AbstractZeros`/`AbstractOnes`?
         @inline size(Z::$AbsTyp) = length.(axes(Z))
         @inline getindex_value(Z::$AbsTyp{T}) where T = $func(T)
 

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -278,9 +278,6 @@ Base._reshape(parent::AbstractFill, dims::Tuple{Integer,Vararg{Integer}}) = fill
 # Resolves ambiguity error with `_reshape(v::AbstractArray{T, 1}, dims::Tuple{Int})`
 Base._reshape(parent::AbstractFill{T, 1, Axes}, dims::Tuple{Int}) where {T, Axes} = fill_reshape(parent, dims...)
 
-abstract type AbstractZeros{T, N, Axes} <: AbstractFill{T, N, Axes} end
-abstract type AbstractOnes{T, N, Axes} <: AbstractFill{T, N, Axes} end
-
 for (AbsTyp, Typ, funcs, func) in ((:AbstractZeros, :Zeros, :zeros, :zero), (:AbstractOnes, :Ones, :ones, :one))
     @eval begin
         abstract type $AbsTyp{T, N, Axes} <: AbstractFill{T, N, Axes} end

--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -6,8 +6,8 @@ vec(a::AbstractFill) = fillsimilar(a, length(a))
 # cannot do this for vectors since that would destroy scalar dot product
 
 
-transpose(a::Union{OnesMatrix, ZerosMatrix}) = fillsimilar(a, reverse(axes(a)))
-adjoint(a::Union{OnesMatrix, ZerosMatrix}) = fillsimilar(a, reverse(axes(a)))
+transpose(a::Union{AbstractOnesMatrix, AbstractZerosMatrix}) = fillsimilar(a, reverse(axes(a)))
+adjoint(a::Union{AbstractOnesMatrix, AbstractZerosMatrix}) = fillsimilar(a, reverse(axes(a)))
 transpose(a::FillMatrix{T}) where T = Fill{T}(transpose(a.value), reverse(a.axes))
 adjoint(a::FillMatrix{T}) where T = Fill{T}(adjoint(a.value), reverse(a.axes))
 
@@ -36,7 +36,7 @@ function _mult_fill(a::AbstractFill, b::AbstractFill, ax, ::Type{Fill})
     return Fill(val, ax)
 end
 
-function _mult_fill(a, b, ax, ::Type{OnesZeros}) where {OnesZeros<:Union{Ones,Zeros}}
+function _mult_fill(a, b, ax, ::Type{OnesZeros}) where {OnesZeros<:Union{AbstractOnes,AbstractZeros}}
     # This is currently only used in contexts where zero is defined
     # might need a rethink
     ElType = typeof(zero(eltype(a)) * zero(eltype(b)))
@@ -63,20 +63,20 @@ mult_ones(a, b) = mult_fill(a, b, Ones)
 
 # this treats a size (n,) vector as a nx1 matrix, so b needs to have 1 row
 # special cased, as OnesMatrix * OnesMatrix isn't a Ones
-*(a::OnesVector, b::OnesMatrix) = mult_ones(a, b)
+*(a::AbstractOnesVector, b::AbstractOnesMatrix) = mult_ones(a, b)
 
-*(a::ZerosMatrix, b::ZerosMatrix) = mult_zeros(a, b)
-*(a::ZerosMatrix, b::ZerosVector) = mult_zeros(a, b)
+*(a::AbstractZerosMatrix, b::AbstractZerosMatrix) = mult_zeros(a, b)
+*(a::AbstractZerosMatrix, b::AbstractZerosVector) = mult_zeros(a, b)
 
-*(a::ZerosMatrix, b::AbstractFillMatrix) = mult_zeros(a, b)
-*(a::ZerosMatrix, b::AbstractFillVector) = mult_zeros(a, b)
-*(a::AbstractFillMatrix, b::ZerosMatrix) = mult_zeros(a, b)
-*(a::AbstractFillMatrix, b::ZerosVector) = mult_zeros(a, b)
+*(a::AbstractZerosMatrix, b::AbstractFillMatrix) = mult_zeros(a, b)
+*(a::AbstractZerosMatrix, b::AbstractFillVector) = mult_zeros(a, b)
+*(a::AbstractFillMatrix, b::AbstractZerosMatrix) = mult_zeros(a, b)
+*(a::AbstractFillMatrix, b::AbstractZerosVector) = mult_zeros(a, b)
 
-*(a::ZerosMatrix, b::AbstractMatrix) = mult_zeros(a, b)
-*(a::AbstractMatrix, b::ZerosVector) = mult_zeros(a, b)
-*(a::AbstractMatrix, b::ZerosMatrix) = mult_zeros(a, b)
-*(a::ZerosMatrix, b::AbstractVector) = mult_zeros(a, b)
+*(a::AbstractZerosMatrix, b::AbstractMatrix) = mult_zeros(a, b)
+*(a::AbstractMatrix, b::AbstractZerosVector) = mult_zeros(a, b)
+*(a::AbstractMatrix, b::AbstractZerosMatrix) = mult_zeros(a, b)
+*(a::AbstractZerosMatrix, b::AbstractVector) = mult_zeros(a, b)
 
 function lmul_diag(a::Diagonal, b)
     size(a,2) == size(b,1) || throw(DimensionMismatch("A has dimensions $(size(a)) but B has dimensions $(size(b))"))
@@ -87,9 +87,9 @@ function rmul_diag(a, b::Diagonal)
     a .* permutedims(parent(b)) # use special broadcast
 end
 
-*(a::ZerosMatrix, b::Diagonal) = rmul_diag(a, b)
-*(a::Diagonal, b::ZerosVector) = lmul_diag(a, b)
-*(a::Diagonal, b::ZerosMatrix) = lmul_diag(a, b)
+*(a::AbstractZerosMatrix, b::Diagonal) = rmul_diag(a, b)
+*(a::Diagonal, b::AbstractZerosVector) = lmul_diag(a, b)
+*(a::Diagonal, b::AbstractZerosMatrix) = lmul_diag(a, b)
 *(a::Diagonal, b::AbstractFillMatrix) = lmul_diag(a, b)
 *(a::AbstractFillMatrix, b::Diagonal) = rmul_diag(a, b)
 
@@ -270,25 +270,25 @@ function _adjvec_mul_zeros(a, b)
     return a1 * b[1]
 end
 
-*(a::AdjointAbsVec{<:Any,<:ZerosVector}, b::AbstractMatrix) = (b' * a')'
-*(a::AdjointAbsVec{<:Any,<:ZerosVector}, b::ZerosMatrix) = (b' * a')'
-*(a::TransposeAbsVec{<:Any,<:ZerosVector}, b::AbstractMatrix) = transpose(transpose(b) * transpose(a))
-*(a::TransposeAbsVec{<:Any,<:ZerosVector}, b::ZerosMatrix) = transpose(transpose(b) * transpose(a))
+*(a::AdjointAbsVec{<:Any,<:AbstractZerosVector}, b::AbstractMatrix) = (b' * a')'
+*(a::AdjointAbsVec{<:Any,<:AbstractZerosVector}, b::AbstractZerosMatrix) = (b' * a')'
+*(a::TransposeAbsVec{<:Any,<:AbstractZerosVector}, b::AbstractMatrix) = transpose(transpose(b) * transpose(a))
+*(a::TransposeAbsVec{<:Any,<:AbstractZerosVector}, b::AbstractZerosMatrix) = transpose(transpose(b) * transpose(a))
 
-*(a::AbstractVector, b::AdjOrTransAbsVec{<:Any,<:ZerosVector}) = a * permutedims(parent(b))
-*(a::AbstractMatrix, b::AdjOrTransAbsVec{<:Any,<:ZerosVector}) = a * permutedims(parent(b))
-*(a::ZerosVector, b::AdjOrTransAbsVec{<:Any,<:ZerosVector}) = a * permutedims(parent(b))
-*(a::ZerosMatrix, b::AdjOrTransAbsVec{<:Any,<:ZerosVector}) = a * permutedims(parent(b))
+*(a::AbstractVector, b::AdjOrTransAbsVec{<:Any,<:AbstractZerosVector}) = a * permutedims(parent(b))
+*(a::AbstractMatrix, b::AdjOrTransAbsVec{<:Any,<:AbstractZerosVector}) = a * permutedims(parent(b))
+*(a::AbstractZerosVector, b::AdjOrTransAbsVec{<:Any,<:AbstractZerosVector}) = a * permutedims(parent(b))
+*(a::AbstractZerosMatrix, b::AdjOrTransAbsVec{<:Any,<:AbstractZerosVector}) = a * permutedims(parent(b))
 
-*(a::AdjointAbsVec, b::ZerosVector) = _adjvec_mul_zeros(a, b)
-*(a::AdjointAbsVec{<:Number}, b::ZerosVector{<:Number}) = _adjvec_mul_zeros(a, b)
-*(a::TransposeAbsVec, b::ZerosVector) = _adjvec_mul_zeros(a, b)
-*(a::TransposeAbsVec{<:Number}, b::ZerosVector{<:Number}) = _adjvec_mul_zeros(a, b)
+*(a::AdjointAbsVec, b::AbstractZerosVector) = _adjvec_mul_zeros(a, b)
+*(a::AdjointAbsVec{<:Number}, b::AbstractZerosVector{<:Number}) = _adjvec_mul_zeros(a, b)
+*(a::TransposeAbsVec, b::AbstractZerosVector) = _adjvec_mul_zeros(a, b)
+*(a::TransposeAbsVec{<:Number}, b::AbstractZerosVector{<:Number}) = _adjvec_mul_zeros(a, b)
 
-*(a::Adjoint{T, <:AbstractMatrix{T}} where T, b::Zeros{<:Any, 1}) = mult_zeros(a, b)
+*(a::Adjoint{T, <:AbstractMatrix{T}} where T, b::AbstractZeros{<:Any, 1}) = mult_zeros(a, b)
 
-*(a::AdjointAbsVec{<:Any,<:ZerosVector}, D::Diagonal) = (D*a')'
-*(a::TransposeAbsVec{<:Any,<:ZerosVector}, D::Diagonal) = transpose(D*transpose(a))
+*(a::AdjointAbsVec{<:Any,<:AbstractZerosVector}, D::Diagonal) = (D*a')'
+*(a::TransposeAbsVec{<:Any,<:AbstractZerosVector}, D::Diagonal) = transpose(D*transpose(a))
 function _triple_zeromul(x, D::Diagonal, y)
     if !(length(x) == length(D.diag) == length(y))
         throw(DimensionMismatch("x has length $(length(x)), D has size $(size(D)), and y has $(length(y))"))
@@ -296,22 +296,22 @@ function _triple_zeromul(x, D::Diagonal, y)
     zero(promote_type(eltype(x), eltype(D), eltype(y)))
 end
 
-*(x::AdjointAbsVec{<:Any,<:ZerosVector}, D::Diagonal, y::AbstractVector) = _triple_zeromul(x, D, y)
-*(x::TransposeAbsVec{<:Any,<:ZerosVector}, D::Diagonal, y::AbstractVector) = _triple_zeromul(x, D, y)
-*(x::AdjointAbsVec, D::Diagonal, y::ZerosVector) = _triple_zeromul(x, D, y)
-*(x::TransposeAbsVec, D::Diagonal, y::ZerosVector) = _triple_zeromul(x, D, y)
-*(x::AdjointAbsVec{<:Any,<:ZerosVector}, D::Diagonal, y::ZerosVector) = _triple_zeromul(x, D, y)
-*(x::TransposeAbsVec{<:Any,<:ZerosVector}, D::Diagonal, y::ZerosVector) = _triple_zeromul(x, D, y)
+*(x::AdjointAbsVec{<:Any,<:AbstractZerosVector}, D::Diagonal, y::AbstractVector) = _triple_zeromul(x, D, y)
+*(x::TransposeAbsVec{<:Any,<:AbstractZerosVector}, D::Diagonal, y::AbstractVector) = _triple_zeromul(x, D, y)
+*(x::AdjointAbsVec, D::Diagonal, y::AbstractZerosVector) = _triple_zeromul(x, D, y)
+*(x::TransposeAbsVec, D::Diagonal, y::AbstractZerosVector) = _triple_zeromul(x, D, y)
+*(x::AdjointAbsVec{<:Any,<:AbstractZerosVector}, D::Diagonal, y::AbstractZerosVector) = _triple_zeromul(x, D, y)
+*(x::TransposeAbsVec{<:Any,<:AbstractZerosVector}, D::Diagonal, y::AbstractZerosVector) = _triple_zeromul(x, D, y)
 
 
-function *(a::Transpose{T, <:AbstractVector{T}}, b::ZerosVector{T}) where T<:Real
+function *(a::Transpose{T, <:AbstractVector{T}}, b::AbstractZerosVector{T}) where T<:Real
     la, lb = length(a), length(b)
     if la ≠ lb
         throw(DimensionMismatch("dot product arguments have lengths $la and $lb"))
     end
     return zero(T)
 end
-*(a::Transpose{T, <:AbstractMatrix{T}}, b::ZerosVector{T}) where T<:Real = mult_zeros(a, b)
+*(a::Transpose{T, <:AbstractMatrix{T}}, b::AbstractZerosVector{T}) where T<:Real = mult_zeros(a, b)
 
 # support types with fast sum
 # infinite cases should be supported in InfiniteArrays.jl
@@ -350,24 +350,24 @@ end
 
 # Addition and Subtraction
 +(a::AbstractFill) = a
--(a::Zeros) = a
+-(a::AbstractZeros) = a
 -(a::AbstractFill) = Fill(-getindex_value(a), size(a))
 
 # special-cased for type-stability, as Ones + Ones is not a Ones
-Base.reduce_first(::typeof(+), x::Ones) = Fill(Base.reduce_first(+, getindex_value(x)), axes(x))
+Base.reduce_first(::typeof(+), x::AbstractOnes) = Fill(Base.reduce_first(+, getindex_value(x)), axes(x))
 
-function +(a::Zeros{T}, b::Zeros{V}) where {T, V} # for disambiguity
+function +(a::AbstractZeros{T}, b::AbstractZeros{V}) where {T, V} # for disambiguity
     promote_shape(a,b)
     return elconvert(promote_op(+,T,V),a)
 end
 # no AbstractArray. Otherwise incompatible with StaticArrays.jl
 # AbstractFill for disambiguity
 for TYPE in (:Array, :AbstractFill, :AbstractRange, :Diagonal)
-    @eval function +(a::$TYPE{T}, b::Zeros{V}) where {T, V}
+    @eval function +(a::$TYPE{T}, b::AbstractZeros{V}) where {T, V}
         promote_shape(a,b)
         return elconvert(promote_op(+,T,V),a)
     end
-    @eval +(a::Zeros, b::$TYPE) = b + a
+    @eval +(a::AbstractZeros, b::$TYPE) = b + a
 end
 
 # for VERSION other than 1.6, could use ZerosMatrix only
@@ -380,7 +380,7 @@ end
 # so the implementation of `-(a::UniformScaling, b::AbstractFill{<:Any,2})` is sufficient
 -(a::UniformScaling, b::AbstractFill) = -b + a # @test I-Zeros(3,3) === Diagonal(Ones(3))
 
--(a::Ones, b::Ones) = Zeros(a) + Zeros(b)
+-(a::AbstractOnes, b::AbstractOnes) = Zeros(a) + Zeros(b)
 
 # no AbstractArray. Otherwise incompatible with StaticArrays.jl
 for TYPE in (:Array, :AbstractRange)
@@ -413,10 +413,10 @@ end
 ####
 
 for op in (:norm1, :norm2, :normInf, :normMinusInf)
-    @eval $op(a::Zeros) = norm(getindex_value(a))
+    @eval $op(a::AbstractZeros) = norm(getindex_value(a))
 end
 
-normp(a::Zeros, p) = norm(getindex_value(a))
+normp(a::AbstractZeros, p) = norm(getindex_value(a))
 
 norm1(a::AbstractFill) = length(a)*norm(getindex_value(a))
 norm2(a::AbstractFill) = sqrt(length(a))*norm(getindex_value(a))
@@ -446,7 +446,7 @@ function rmul!(z::AbstractFill, x::Number)
 end
 
 fillzero(::Type{Fill{T,N,AXIS}}, n, m) where {T,N,AXIS} = Fill{T,N,AXIS}(zero(T), (n, m))
-fillzero(::Type{Zeros{T,N,AXIS}}, n, m) where {T,N,AXIS} = Zeros{T,N,AXIS}((n, m))
+fillzero(::Type{<:AbstractZeros{T,N,AXIS}}, n, m) where {T,N,AXIS} = Zeros{T,N,AXIS}((n, m))
 fillzero(::Type{F}, n, m) where F = throw(ArgumentError("Cannot create a zero array of type $F"))
 
 diagzero(D::Diagonal{F}, i, j) where F<:AbstractFill = fillzero(F, axes(D.diag[i], 1), axes(D.diag[j], 2))
@@ -459,10 +459,10 @@ function _kron(f::AbstractFill, g::AbstractFill, sz)
     v = getindex_value(f)*getindex_value(g)
     Fill(v, sz)
 end
-function _kron(f::Zeros, g::Zeros, sz)
+function _kron(f::AbstractZeros, g::AbstractZeros, sz)
     Zeros{promote_type(eltype(f), eltype(g))}(sz)
 end
-function _kron(f::Ones, g::Ones, sz)
+function _kron(f::AbstractOnes, g::AbstractOnes, sz)
     Ones{promote_type(eltype(f), eltype(g))}(sz)
 end
 function kron(f::AbstractFillVecOrMat, g::AbstractFillVecOrMat)

--- a/src/fillbroadcast.jl
+++ b/src/fillbroadcast.jl
@@ -79,16 +79,16 @@ function broadcasted(::DefaultArrayStyle{N}, op, r::AbstractFill{T,N}) where {T,
     return Fill(op(getindex_value(r)), axes(r))
 end
 
-broadcasted(::DefaultArrayStyle, ::typeof(+), r::Zeros) = r
-broadcasted(::DefaultArrayStyle, ::typeof(-), r::Zeros) = r
-broadcasted(::DefaultArrayStyle, ::typeof(+), r::Ones) = r
+broadcasted(::DefaultArrayStyle, ::typeof(+), r::AbstractZeros) = r
+broadcasted(::DefaultArrayStyle, ::typeof(-), r::AbstractZeros) = r
+broadcasted(::DefaultArrayStyle, ::typeof(+), r::AbstractOnes) = r
 
-broadcasted(::DefaultArrayStyle{N}, ::typeof(conj), r::Zeros{T,N}) where {T,N} = r
-broadcasted(::DefaultArrayStyle{N}, ::typeof(conj), r::Ones{T,N}) where {T,N} = r
-broadcasted(::DefaultArrayStyle{N}, ::typeof(real), r::Zeros{T,N}) where {T,N} = Zeros{real(T)}(r.axes)
-broadcasted(::DefaultArrayStyle{N}, ::typeof(real), r::Ones{T,N}) where {T,N} = Ones{real(T)}(r.axes)
-broadcasted(::DefaultArrayStyle{N}, ::typeof(imag), r::Zeros{T,N}) where {T,N} = Zeros{real(T)}(r.axes)
-broadcasted(::DefaultArrayStyle{N}, ::typeof(imag), r::Ones{T,N}) where {T,N} = Zeros{real(T)}(r.axes)
+broadcasted(::DefaultArrayStyle{N}, ::typeof(conj), r::AbstractZeros{T,N}) where {T,N} = r
+broadcasted(::DefaultArrayStyle{N}, ::typeof(conj), r::AbstractOnes{T,N}) where {T,N} = r
+broadcasted(::DefaultArrayStyle{N}, ::typeof(real), r::AbstractZeros{T,N}) where {T,N} = Zeros{real(T)}(r.axes)
+broadcasted(::DefaultArrayStyle{N}, ::typeof(real), r::AbstractOnes{T,N}) where {T,N} = Ones{real(T)}(r.axes)
+broadcasted(::DefaultArrayStyle{N}, ::typeof(imag), r::AbstractZeros{T,N}) where {T,N} = Zeros{real(T)}(r.axes)
+broadcasted(::DefaultArrayStyle{N}, ::typeof(imag), r::AbstractOnes{T,N}) where {T,N} = Zeros{real(T)}(r.axes)
 
 ### Binary broadcasting
 
@@ -97,61 +97,60 @@ function broadcasted(::DefaultArrayStyle, op, a::AbstractFill, b::AbstractFill)
     return Fill(val, broadcast_shape(axes(a), axes(b)))
 end
 
-
 _broadcasted_zeros(f, a, b) = Zeros{Base.Broadcast.combine_eltypes(f, (a, b))}(broadcast_shape(axes(a), axes(b)))
 _broadcasted_ones(f, a, b) = Ones{Base.Broadcast.combine_eltypes(f, (a, b))}(broadcast_shape(axes(a), axes(b)))
 _broadcasted_nan(f, a, b) = Fill(convert(Base.Broadcast.combine_eltypes(f, (a, b)), NaN), broadcast_shape(axes(a), axes(b)))
 
-broadcasted(::DefaultArrayStyle, ::typeof(+), a::Zeros, b::Zeros) = _broadcasted_zeros(+, a, b)
-broadcasted(::DefaultArrayStyle, ::typeof(+), a::Ones, b::Zeros) = _broadcasted_ones(+, a, b)
-broadcasted(::DefaultArrayStyle, ::typeof(+), a::Zeros, b::Ones) = _broadcasted_ones(+, a, b)
+broadcasted(::DefaultArrayStyle, ::typeof(+), a::AbstractZeros, b::AbstractZeros) = _broadcasted_zeros(+, a, b)
+broadcasted(::DefaultArrayStyle, ::typeof(+), a::AbstractOnes, b::AbstractZeros) = _broadcasted_ones(+, a, b)
+broadcasted(::DefaultArrayStyle, ::typeof(+), a::AbstractZeros, b::AbstractOnes) = _broadcasted_ones(+, a, b)
 
-broadcasted(::DefaultArrayStyle, ::typeof(-), a::Zeros, b::Zeros) = _broadcasted_zeros(-, a, b)
-broadcasted(::DefaultArrayStyle, ::typeof(-), a::Ones, b::Zeros) = _broadcasted_ones(-, a, b)
-broadcasted(::DefaultArrayStyle, ::typeof(-), a::Ones, b::Ones) = _broadcasted_zeros(-, a, b)
+broadcasted(::DefaultArrayStyle, ::typeof(-), a::AbstractZeros, b::AbstractZeros) = _broadcasted_zeros(-, a, b)
+broadcasted(::DefaultArrayStyle, ::typeof(-), a::AbstractOnes, b::AbstractZeros) = _broadcasted_ones(-, a, b)
+broadcasted(::DefaultArrayStyle, ::typeof(-), a::AbstractOnes, b::AbstractOnes) = _broadcasted_zeros(-, a, b)
 
-broadcasted(::DefaultArrayStyle{1}, ::typeof(+), a::ZerosVector, b::ZerosVector) = _broadcasted_zeros(+, a, b)
-broadcasted(::DefaultArrayStyle{1}, ::typeof(+), a::OnesVector, b::ZerosVector) = _broadcasted_ones(+, a, b)
-broadcasted(::DefaultArrayStyle{1}, ::typeof(+), a::ZerosVector, b::OnesVector) = _broadcasted_ones(+, a, b)
+broadcasted(::DefaultArrayStyle{1}, ::typeof(+), a::AbstractZerosVector, b::AbstractZerosVector) = _broadcasted_zeros(+, a, b)
+broadcasted(::DefaultArrayStyle{1}, ::typeof(+), a::AbstractOnesVector, b::AbstractZerosVector) = _broadcasted_ones(+, a, b)
+broadcasted(::DefaultArrayStyle{1}, ::typeof(+), a::AbstractZerosVector, b::AbstractOnesVector) = _broadcasted_ones(+, a, b)
 
-broadcasted(::DefaultArrayStyle{1}, ::typeof(-), a::ZerosVector, b::ZerosVector) = _broadcasted_zeros(-, a, b)
-broadcasted(::DefaultArrayStyle{1}, ::typeof(-), a::OnesVector, b::ZerosVector) = _broadcasted_ones(-, a, b)
+broadcasted(::DefaultArrayStyle{1}, ::typeof(-), a::AbstractZerosVector, b::AbstractZerosVector) = _broadcasted_zeros(-, a, b)
+broadcasted(::DefaultArrayStyle{1}, ::typeof(-), a::AbstractOnesVector, b::AbstractZerosVector) = _broadcasted_ones(-, a, b)
 
 
-broadcasted(::DefaultArrayStyle, ::typeof(*), a::Zeros, b::Zeros) = _broadcasted_zeros(*, a, b)
+broadcasted(::DefaultArrayStyle, ::typeof(*), a::AbstractZeros, b::AbstractZeros) = _broadcasted_zeros(*, a, b)
 
 # In following, need to restrict to <: Number as otherwise we cannot infer zero from type
 # TODO: generalise to things like SVector
 for op in (:*, :/)
     @eval begin
-        broadcasted(::DefaultArrayStyle, ::typeof($op), a::Zeros, b::Ones) = _broadcasted_zeros($op, a, b)
-        broadcasted(::DefaultArrayStyle, ::typeof($op), a::Zeros, b::Fill{<:Number}) = _broadcasted_zeros($op, a, b)
-        broadcasted(::DefaultArrayStyle, ::typeof($op), a::Zeros, b::Number) = _broadcasted_zeros($op, a, b)
-        broadcasted(::DefaultArrayStyle, ::typeof($op), a::Zeros, b::AbstractRange) = _broadcasted_zeros($op, a, b)
-        broadcasted(::DefaultArrayStyle, ::typeof($op), a::Zeros, b::AbstractArray{<:Number}) = _broadcasted_zeros($op, a, b)
-        broadcasted(::DefaultArrayStyle, ::typeof($op), a::Zeros, b::Base.Broadcast.Broadcasted) = _broadcasted_zeros($op, a, b)
-        broadcasted(::DefaultArrayStyle{1}, ::typeof($op), a::Zeros, b::AbstractRange) = _broadcasted_zeros($op, a, b)
+        broadcasted(::DefaultArrayStyle, ::typeof($op), a::AbstractZeros, b::AbstractOnes) = _broadcasted_zeros($op, a, b)
+        broadcasted(::DefaultArrayStyle, ::typeof($op), a::AbstractZeros, b::Fill{<:Number}) = _broadcasted_zeros($op, a, b)
+        broadcasted(::DefaultArrayStyle, ::typeof($op), a::AbstractZeros, b::Number) = _broadcasted_zeros($op, a, b)
+        broadcasted(::DefaultArrayStyle, ::typeof($op), a::AbstractZeros, b::AbstractRange) = _broadcasted_zeros($op, a, b)
+        broadcasted(::DefaultArrayStyle, ::typeof($op), a::AbstractZeros, b::AbstractArray{<:Number}) = _broadcasted_zeros($op, a, b)
+        broadcasted(::DefaultArrayStyle, ::typeof($op), a::AbstractZeros, b::Base.Broadcast.Broadcasted) = _broadcasted_zeros($op, a, b)
+        broadcasted(::DefaultArrayStyle{1}, ::typeof($op), a::AbstractZeros, b::AbstractRange) = _broadcasted_zeros($op, a, b)
     end
 end
 
 for op in (:*, :\)
     @eval begin
-        broadcasted(::DefaultArrayStyle, ::typeof($op), a::Ones, b::Zeros) = _broadcasted_zeros($op, a, b)
-        broadcasted(::DefaultArrayStyle, ::typeof($op), a::Fill{<:Number}, b::Zeros) = _broadcasted_zeros($op, a, b)
-        broadcasted(::DefaultArrayStyle, ::typeof($op), a::Number, b::Zeros) = _broadcasted_zeros($op, a, b)
-        broadcasted(::DefaultArrayStyle, ::typeof($op), a::AbstractRange, b::Zeros) = _broadcasted_zeros($op, a, b)
-        broadcasted(::DefaultArrayStyle, ::typeof($op), a::AbstractArray{<:Number}, b::Zeros) = _broadcasted_zeros($op, a, b)
-        broadcasted(::DefaultArrayStyle, ::typeof($op), a::Base.Broadcast.Broadcasted, b::Zeros) = _broadcasted_zeros($op, a, b)
-        broadcasted(::DefaultArrayStyle{1}, ::typeof($op), a::AbstractRange, b::Zeros) = _broadcasted_zeros($op, a, b)
+        broadcasted(::DefaultArrayStyle, ::typeof($op), a::AbstractOnes, b::AbstractZeros) = _broadcasted_zeros($op, a, b)
+        broadcasted(::DefaultArrayStyle, ::typeof($op), a::Fill{<:Number}, b::AbstractZeros) = _broadcasted_zeros($op, a, b)
+        broadcasted(::DefaultArrayStyle, ::typeof($op), a::Number, b::AbstractZeros) = _broadcasted_zeros($op, a, b)
+        broadcasted(::DefaultArrayStyle, ::typeof($op), a::AbstractRange, b::AbstractZeros) = _broadcasted_zeros($op, a, b)
+        broadcasted(::DefaultArrayStyle, ::typeof($op), a::AbstractArray{<:Number}, b::AbstractZeros) = _broadcasted_zeros($op, a, b)
+        broadcasted(::DefaultArrayStyle, ::typeof($op), a::Base.Broadcast.Broadcasted, b::AbstractZeros) = _broadcasted_zeros($op, a, b)
+        broadcasted(::DefaultArrayStyle{1}, ::typeof($op), a::AbstractRange, b::AbstractZeros) = _broadcasted_zeros($op, a, b)
     end
 end
 
 for op in (:*, :/, :\)
-    @eval broadcasted(::DefaultArrayStyle, ::typeof($op), a::Ones, b::Ones) = _broadcasted_ones($op, a, b)
+    @eval broadcasted(::DefaultArrayStyle, ::typeof($op), a::AbstractOnes, b::AbstractOnes) = _broadcasted_ones($op, a, b)
 end
 
 for op in (:/, :\)
-    @eval broadcasted(::DefaultArrayStyle, ::typeof($op), a::Zeros{<:Number}, b::Zeros{<:Number}) = _broadcasted_nan($op, a, b)
+    @eval broadcasted(::DefaultArrayStyle, ::typeof($op), a::AbstractZeros{<:Number}, b::AbstractZeros{<:Number}) = _broadcasted_nan($op, a, b)
 end
 
 # special case due to missing converts for ranges
@@ -183,13 +182,13 @@ _range_convert(::Type{AbstractVector{T}}, a::AbstractRange) where T = convert(T,
 #     end
 # end
 
-function broadcasted(::DefaultArrayStyle{1}, ::typeof(*), a::OnesVector, b::AbstractRange)
+function broadcasted(::DefaultArrayStyle{1}, ::typeof(*), a::AbstractOnesVector, b::AbstractRange)
     broadcast_shape(axes(a), axes(b)) == axes(b) || throw(ArgumentError("Cannot broadcast $a and $b. Convert $b to a Vector first."))
     TT = typeof(zero(eltype(a)) * zero(eltype(b)))
     return _range_convert(AbstractVector{TT}, b)
 end
 
-function broadcasted(::DefaultArrayStyle{1}, ::typeof(*), a::AbstractRange, b::OnesVector)
+function broadcasted(::DefaultArrayStyle{1}, ::typeof(*), a::AbstractRange, b::AbstractOnesVector)
     broadcast_shape(axes(a), axes(b)) == axes(a) || throw(ArgumentError("Cannot broadcast $a and $b. Convert $b to a Vector first."))
     TT = typeof(zero(eltype(a)) * zero(eltype(b)))
     return _range_convert(AbstractVector{TT}, a)
@@ -197,22 +196,22 @@ end
 
 for op in (:+, :-)
     @eval begin
-        function broadcasted(::DefaultArrayStyle{1}, ::typeof($op), a::AbstractVector, b::ZerosVector)
+        function broadcasted(::DefaultArrayStyle{1}, ::typeof($op), a::AbstractVector, b::AbstractZerosVector)
             broadcast_shape(axes(a), axes(b)) == axes(a) || throw(ArgumentError("Cannot broadcast $a and $b. Convert $b to a Vector first."))
             TT = typeof($op(zero(eltype(a)), zero(eltype(b))))
             # Use `TT ∘ (+)` to fix AD issues with `broadcasted(TT, x)`
             eltype(a) === TT ? a : broadcasted(TT ∘ (+), a)
         end
-        function broadcasted(::DefaultArrayStyle{1}, ::typeof($op), a::ZerosVector, b::AbstractVector)
+        function broadcasted(::DefaultArrayStyle{1}, ::typeof($op), a::AbstractZerosVector, b::AbstractVector)
             broadcast_shape(axes(a), axes(b)) == axes(b) || throw(ArgumentError("Cannot broadcast $a and $b. Convert $a to a Vector first."))
             TT = typeof($op(zero(eltype(a)), zero(eltype(b))))
             $op === (+) && eltype(b) === TT ? b : broadcasted(TT ∘ ($op), b)
         end
 
-        broadcasted(::DefaultArrayStyle{1}, ::typeof($op), a::AbstractFillVector, b::ZerosVector) =
+        broadcasted(::DefaultArrayStyle{1}, ::typeof($op), a::AbstractFillVector, b::AbstractZerosVector) =
             Base.invoke(broadcasted, Tuple{DefaultArrayStyle, typeof($op), AbstractFill, AbstractFill}, DefaultArrayStyle{1}(), $op, a, b)
 
-        broadcasted(::DefaultArrayStyle{1}, ::typeof($op), a::ZerosVector, b::AbstractFillVector) =
+        broadcasted(::DefaultArrayStyle{1}, ::typeof($op), a::AbstractZerosVector, b::AbstractFillVector) =
             Base.invoke(broadcasted, Tuple{DefaultArrayStyle, typeof($op), AbstractFill, AbstractFill}, DefaultArrayStyle{1}(), $op, a, b)
     end
 end
@@ -239,11 +238,11 @@ broadcasted(::DefaultArrayStyle{N}, op, x::Ref, r::AbstractFill{T,N}) where {T,N
 
 # support AbstractFill .^ k
 broadcasted(::DefaultArrayStyle{N}, ::typeof(Base.literal_pow), ::Base.RefValue{typeof(^)}, r::AbstractFill{T,N}, ::Base.RefValue{Val{k}}) where {T,N,k} = Fill(getindex_value(r)^k, axes(r))
-broadcasted(::DefaultArrayStyle{N}, ::typeof(Base.literal_pow), ::Base.RefValue{typeof(^)}, r::Ones{T,N}, ::Base.RefValue{Val{k}}) where {T,N,k} = Ones{T}(axes(r))
-broadcasted(::DefaultArrayStyle{N}, ::typeof(Base.literal_pow), ::Base.RefValue{typeof(^)}, r::Zeros{T,N}, ::Base.RefValue{Val{0}}) where {T,N} = Ones{T}(axes(r))
-broadcasted(::DefaultArrayStyle{N}, ::typeof(Base.literal_pow), ::Base.RefValue{typeof(^)}, r::Zeros{T,N}, ::Base.RefValue{Val{k}}) where {T,N,k} = Zeros{T}(axes(r))
+broadcasted(::DefaultArrayStyle{N}, ::typeof(Base.literal_pow), ::Base.RefValue{typeof(^)}, r::AbstractOnes{T,N}, ::Base.RefValue{Val{k}}) where {T,N,k} = Ones{T}(axes(r))
+broadcasted(::DefaultArrayStyle{N}, ::typeof(Base.literal_pow), ::Base.RefValue{typeof(^)}, r::AbstractZeros{T,N}, ::Base.RefValue{Val{0}}) where {T,N} = Ones{T}(axes(r))
+broadcasted(::DefaultArrayStyle{N}, ::typeof(Base.literal_pow), ::Base.RefValue{typeof(^)}, r::AbstractZeros{T,N}, ::Base.RefValue{Val{k}}) where {T,N,k} = Zeros{T}(axes(r))
 
 # supports structured broadcast
 if isdefined(LinearAlgebra, :fzero)
-    LinearAlgebra.fzero(x::Zeros) = zero(eltype(x))
+    LinearAlgebra.fzero(x::AbstractZeros) = zero(eltype(x))
 end

--- a/src/oneelement.jl
+++ b/src/oneelement.jl
@@ -56,7 +56,7 @@ Base.replace_in_print_matrix(o::OneElementVector, k::Integer, j::Integer, s::Abs
 Base.replace_in_print_matrix(o::OneElementMatrix, k::Integer, j::Integer, s::AbstractString) =
     o.ind == (k,j) ? s : Base.replace_with_centered_mark(s)
 
-Base.@propagate_inbounds function Base.setindex(A::Zeros{T,N}, v, kj::Vararg{Int,N}) where {T,N}
+Base.@propagate_inbounds function Base.setindex(A::AbstractZeros{T,N}, v, kj::Vararg{Int,N}) where {T,N}
     @boundscheck checkbounds(A, kj...)
     OneElement(convert(T, v), kj, axes(A))
 end


### PR DESCRIPTION
This introduces `AbstactZeros` and `AbstractOnes` as proposed in #298.

For now, it just replaces function signatures that were specialized to `Zeros` and `Ones` with `AbstactZeros` and `AbstractOnes`. I'm currently testing out what it is like to define custom `AbstractZeros` and `AbstractOnes` subtypes and have those types preserved through operations, which would require deeper changes. Perhaps that could make use of [ArrayLayouts.jl](https://github.com/JuliaLinearAlgebra/ArrayLayouts.jl).