### PR TITLE
Fix corner cases and short-circuit mapreduce

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FillArrays"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "1.7.0"
+version = "1.7.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -550,16 +550,6 @@ for SMT in (:Diagonal, :Bidiagonal, :Tridiagonal, :SymTridiagonal)
     end
 end
 
-
-#########
-# maximum/minimum
-#########
-
-for op in (:maximum, :minimum)
-    @eval $op(x::AbstractFill) = getindex_value(x)
-end
-
-
 #########
 # Cumsum
 #########

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1090,7 +1090,7 @@ end
                 @test Zeros(S, 10) .* (T(1):T(10)) ≡ Zeros(U, 10)
                 @test_throws DimensionMismatch Zeros(S, 10) .* (T(1):T(11))
             end
-        end        
+        end
     end
 end
 
@@ -1115,6 +1115,33 @@ end
 end
 
 @testset "mapreduce" begin
+    @testset "corner cases with small arrays" begin
+        @test_throws Exception mapreduce(identity, max, Fill(2,0))
+        @test_throws Exception mapreduce(identity, max, Fill(2,0), dims=1)
+        @testset for op in (+, *)
+            @test mapreduce(identity, op, Fill(2,0)) == mapreduce(identity, op, fill(2,0))
+            @test mapreduce(identity, op, Fill(2,0), dims=1) == mapreduce(identity, op, fill(2,0), dims=1)
+        end
+        @testset for op in (&, |)
+            @test mapreduce(identity, op, Fill(true,0)) == mapreduce(identity, op, fill(true,0))
+            @test mapreduce(identity, op, Fill(true,0), dims=1) == mapreduce(identity, op, fill(true,0), dims=1)
+        end
+        @testset for op in (max, +, *)
+            @test mapreduce(identity, op, Fill(2,0), dims=2) == mapreduce(identity, op, fill(2,0), dims=2)
+            @test mapreduce(identity, op, Fill(2,0,1), dims=2) == mapreduce(identity, op, fill(2,0,1), dims=2)
+            @test mapreduce(identity, op, Fill(2,1)) == mapreduce(identity, op, fill(2,1))
+            @test mapreduce(identity, op, Fill(2,1), dims=1) == mapreduce(identity, op, fill(2,1), dims=1)
+            @test mapreduce(identity, op, Fill(2,1), dims=2) == mapreduce(identity, op, fill(2,1), dims=2)
+            @test mapreduce(identity, op, Fill(2,1,1), dims=1) == mapreduce(identity, op, fill(2,1,1), dims=1)
+            @test mapreduce(identity, op, Fill(2,1,1), dims=2) == mapreduce(identity, op, fill(2,1,1), dims=2)
+            @test mapreduce(identity, op, Fill(2,2)) == mapreduce(identity, op, fill(2,2))
+            @test mapreduce(identity, op, Fill(2,2), dims=1) == mapreduce(identity, op, fill(2,2), dims=1)
+            @test mapreduce(identity, op, Fill(2,2), dims=2) == mapreduce(identity, op, fill(2,2), dims=2)
+            @test mapreduce(identity, op, Fill(2,2,2), dims=1) == mapreduce(identity, op, fill(2,2,2), dims=1)
+            @test mapreduce(identity, op, Fill(2,2,2), dims=2) == mapreduce(identity, op, fill(2,2,2), dims=2)
+        end
+    end
+
     x = rand(3, 4)
     y = fill(1.0, 3, 4)
     Y = Fill(1.0, 3, 4)


### PR DESCRIPTION
Fixes certain cases (`min`/`max`) from #301

After this,
```julia
julia> C = Fill(1,10000000)
10000000-element Fill{Int64}, with entries equal to 1

julia> @btime mapreduce(identity, max, $(Ref(C))[])
  2.950 ns (0 allocations: 0 bytes)
1
```