### PR TITLE
Add extension for PDMats

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,28 +1,34 @@
 name = "FillArrays"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "1.7.0"
+version = "1.8.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [weakdeps]
+PDMats = "90014a1f-27ba-587c-ab20-58faa44d9150"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [extensions]
+FillArraysPDMatsExt = "PDMats"
 FillArraysSparseArraysExt = "SparseArrays"
 FillArraysStatisticsExt = "Statistics"
 
 [compat]
 Aqua = "0.5, 0.6, 0.7"
+PDMats = "0.11.17"
+Requires = "1"
 julia = "1.6"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+PDMats = "90014a1f-27ba-587c-ab20-58faa44d9150"
 ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
@@ -30,4 +36,4 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "Test", "Base64", "ReverseDiff", "SparseArrays", "StaticArrays", "Statistics"]
+test = ["Aqua", "Test", "Base64", "PDMats", "ReverseDiff", "SparseArrays", "StaticArrays", "Statistics"]

--- a/Project.toml
+++ b/Project.toml
@@ -4,8 +4,8 @@ version = "1.8.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+PDMats = "90014a1f-27ba-587c-ab20-58faa44d9150"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
@@ -25,7 +25,6 @@ Base64 = "1.6"
 LinearAlgebra = "1.6"
 PDMats = "0.11.17"
 Random = "1.6"
-Requires = "1"
 ReverseDiff = "1"
 SparseArrays = "1.6"
 StaticArrays = "1"

--- a/ext/FillArraysPDMatsExt.jl
+++ b/ext/FillArraysPDMatsExt.jl
@@ -1,14 +1,8 @@
 module FillArraysPDMatsExt
 
-if isdefined(Base, :get_extension)
-    import FillArrays
-    import FillArrays.LinearAlgebra
-    import PDMats
-else
-    import ..FillArrays
-    import ..FillArrays.LinearAlgebra
-    import ..PDMats
-end
+import FillArrays
+import FillArrays.LinearAlgebra
+import PDMats
 
 function PDMats.AbstractPDMat(a::LinearAlgebra.Diagonal{T,<:FillArrays.AbstractFill{T,1}}) where {T<:Real}
     dim = size(a, 1)

--- a/ext/FillArraysPDMatsExt.jl
+++ b/ext/FillArraysPDMatsExt.jl
@@ -1,0 +1,18 @@
+module FillArraysPDMatsExt
+
+if isdefined(Base, :get_extension)
+    import FillArrays
+    import FillArrays.LinearAlgebra
+    import PDMats
+else
+    import ..FillArrays
+    import ..FillArrays.LinearAlgebra
+    import ..PDMats
+end
+
+function PDMats.AbstractPDMat(a::LinearAlgebra.Diagonal{T,<:FillArrays.AbstractFill{T,1}}) where {T<:Real}
+    dim = size(a, 1)
+    return PDMats.ScalMat(dim, FillArrays.getindex_value(a.diag))
+end
+
+end # module

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -669,9 +669,17 @@ include("fillalgebra.jl")
 include("fillbroadcast.jl")
 include("trues.jl")
 
-@static if !isdefined(Base, :get_extension)
+if !isdefined(Base, :get_extension)
+    import Requires
     include("../ext/FillArraysSparseArraysExt.jl")
     include("../ext/FillArraysStatisticsExt.jl")
+end
+@static if !isdefined(Base, :get_extension)
+    function __init__()
+        Requires.@requires PDMats = "90014a1f-27ba-587c-ab20-58faa44d9150" begin
+            include("../ext/FillArraysPDMatsExt.jl")
+        end
+    end
 end
 
 ##

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -676,7 +676,7 @@ if !isdefined(Base, :get_extension)
 end
 @static if !isdefined(Base, :get_extension)
     function __init__()
-        Requires.@requires PDMats = "90014a1f-27ba-587c-ab20-58faa44d9150" begin
+        Requires.@require PDMats = "90014a1f-27ba-587c-ab20-58faa44d9150" begin
             include("../ext/FillArraysPDMatsExt.jl")
         end
     end

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -670,16 +670,9 @@ include("fillbroadcast.jl")
 include("trues.jl")
 
 if !isdefined(Base, :get_extension)
-    import Requires
+    include("../ext/FillArraysPDMatsExt.jl")
     include("../ext/FillArraysSparseArraysExt.jl")
     include("../ext/FillArraysStatisticsExt.jl")
-end
-@static if !isdefined(Base, :get_extension)
-    function __init__()
-        Requires.@require PDMats = "90014a1f-27ba-587c-ab20-58faa44d9150" begin
-            include("../ext/FillArraysPDMatsExt.jl")
-        end
-    end
 end
 
 ##

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using FillArrays, LinearAlgebra, SparseArrays, StaticArrays, ReverseDiff, Random, Base64, Test, Statistics
+using FillArrays, LinearAlgebra, PDMats, SparseArrays, StaticArrays, ReverseDiff, Random, Base64, Test, Statistics
 import FillArrays: AbstractFill, RectDiagonal, SquareEye
 
 using Aqua
@@ -7,6 +7,8 @@ using Aqua
         # only test formatting on VERSION >= v1.7
         # https://github.com/JuliaTesting/Aqua.jl/issues/105#issuecomment-1551405866
         project_toml_formatting = VERSION >= v"1.7",
+        # Requires is only loaded on Julia < 1.9
+        stale_deps = (ignore = VERSION < v"1.9-" ? Symbol[] : [:Requires],),
     )
 end
 
@@ -2194,3 +2196,13 @@ end
     @test ReverseDiff.gradient(x -> sum(abs2.((Zeros{eltype(x)}(5) .+ zeros(5)) ./ x)), rand(5)) == zeros(5)
     @test ReverseDiff.gradient(x -> sum(abs2.((zeros(5) .+ Zeros{eltype(x)}(5)) ./ x)), rand(5)) == zeros(5)
 end
+
+@testset "FillArraysPDMatsExt" begin
+    for diag in (Ones(5), Fill(4.1, 8))
+        a = @inferred(AbstractPDMat(Diagonal(diag)))
+        @test a isa ScalMat
+        @test a.dim == length(diag)
+        @test a.value == first(diag)
+    end
+end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,8 +6,6 @@ using Aqua
     Aqua.test_all(FillArrays;
         # https://github.com/JuliaArrays/FillArrays.jl/issues/105#issuecomment-1582516319
         ambiguities=(; broken=true),
-        # Requires is only loaded on Julia < 1.9
-        stale_deps = (ignore = VERSION < v"1.9-" ? Symbol[] : [:Requires],),
     )
 end
 


### PR DESCRIPTION
This PR adds an extension for PDMats that is optionally loaded on Julia < 1.9 via Requires.

The sole purpose of the extension is to define the `PDMats.AbstractPDMat` constructor (added in https://github.com/JuliaStats/PDMats.jl/pull/172) for `Diagonal` matrices with `AbstractFill` diagonals, so it is extremely lightweight. This constructor is very useful for packages that work with positive-definite matrices and use the type system and/or traits in PDMats and want to support generic user-provided matrices. A concrete use case is Distributions: For instance, with this extension the constructors of `MvNormal` in https://github.com/JuliaStats/Distributions.jl/blob/87aebc29b2b9608801b70aae09fbc1d2dad56e3f/src/multivariate/mvnormal.jl#L201-L210 (and similar constructors for other distributions that are constructed from positive-definite matrices) could be simplified to
```julia
MvNormal(μ::AbstractVector{<:Real}, Σ::AbstractMatrix{<:Real}) = MvNormal(μ, AbstractPDMat(Σ))
MvNormal(μ::AbstractVector{<:Real}, Σ::UniformScaling{<:Real}) =
    MvNormal(μ, ScalMat(length(μ), Σ.λ))
```
Without this extension, a `Diagonal` matrix with an `AbstractFill` diagonal would be converted to a `PDiagMat`, a type for positive-definite diagonal matrices, instead of the more efficient `ScalMat` type for positive-definite scaled identity matrices.

Originally, I proposed to add this extension to PDMats (https://github.com/JuliaStats/PDMats.jl/pull/192) but after some discussions it was decided that it would be more suitable to add the extension to FillArrays: As pointed out in https://github.com/JuliaStats/PDMats.jl/pull/182#issuecomment-1736061820, currently PDMats loads very quickly compared with FillArrays (possibly due to invalidations?). For instance on my computer the latest releases of FillArrays and PDMats load in
```julia
% julia --startup-file=no -e '@time using FillArrays'
  0.054321 seconds (118.30 k allocations: 8.031 MiB)
% julia --startup-file=no -e '@time using FillArrays'
  0.050830 seconds (118.30 k allocations: 8.031 MiB)
% julia --startup-file=no -e '@time using PDMats'
  0.014219 seconds (25.44 k allocations: 1.587 MiB)
% julia --startup-file=no -e '@time using PDMats'
  0.013974 seconds (25.44 k allocations: 1.586 MiB)
% julia --startup-file=no -e '@time using PDMats, FillArrays'
  0.061822 seconds (135.90 k allocations: 9.130 MiB)
% julia --startup-file=no -e '@time using PDMats, FillArrays'
  0.061529 seconds (135.90 k allocations: 9.126 MiB)
```
Conceptually, it is also not feasible to add extensions for every custom array type to PDMats, so adding an extension to FillArrays and, whenever suitable, to other array packages seems more practical.

It also seems that this PR does not have a significant impact on loading times of FillArrays. With this PR, on Julia 1.9.3 I see
```julia
% julia --startup-file=no -e '@time using FillArrays'
  0.051712 seconds (119.53 k allocations: 8.144 MiB)
% julia --startup-file=no -e '@time using FillArrays'
  0.051962 seconds (119.53 k allocations: 8.142 MiB)
% julia --startup-file=no -e '@time using PDMats, FillArrays'
  0.062234 seconds (137.70 k allocations: 9.309 MiB)
% julia --startup-file=no -e '@time using PDMats, FillArrays'
  0.062471 seconds (137.70 k allocations: 9.306 MiB)
```