### PR TITLE
Non-numeric eltypes in `OneElement`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FillArrays"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "1.8.0"
+version = "1.9.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -119,12 +119,10 @@ const FillVecOrMat{T} = Union{FillVector{T},FillMatrix{T}}
 Fill{T,N,Axes}(x, sz::Axes) where Axes<:Tuple{Vararg{AbstractUnitRange,N}} where {T, N} =
     Fill{T,N,Axes}(convert(T, x)::T, sz)
 
-Fill{T,0}(x::T, ::Tuple{}) where T = Fill{T,0,Tuple{}}(x, ()) # ambiguity fix
+Fill{T,0}(x, ::Tuple{}) where T = Fill{T,0,Tuple{}}(convert(T, x)::T, ()) # ambiguity fix
 
-@inline Fill{T, N}(x::T, sz::Axes) where Axes<:Tuple{Vararg{AbstractUnitRange,N}} where {T, N} =
-    Fill{T,N,Axes}(x, sz)
 @inline Fill{T, N}(x, sz::Axes) where Axes<:Tuple{Vararg{AbstractUnitRange,N}} where {T, N} =
-    Fill{T,N}(convert(T, x)::T, sz)
+    Fill{T,N,Axes}(convert(T, x)::T, sz)
 
 @inline Fill{T, N}(x, sz::SZ) where SZ<:Tuple{Vararg{Integer,N}} where {T, N} =
     Fill{T,N}(x, oneto.(sz))

--- a/src/oneelement.jl
+++ b/src/oneelement.jl
@@ -9,7 +9,8 @@ struct OneElement{T,N,I,A} <: AbstractArray{T,N}
   val::T
   ind::I
   axes::A
-  OneElement(val::T, ind::I, axes::A) where {T<:Number, I<:NTuple{N,Int}, A<:NTuple{N,AbstractUnitRange}} where {N} = new{T,N,I,A}(val, ind, axes)
+  OneElement(val::T, ind::I, axes::A) where {T, I<:NTuple{N,Int}, A<:NTuple{N,AbstractUnitRange}} where {N} = new{T,N,I,A}(val, ind, axes)
+  OneElement(val::T, ind::Tuple{}, axes::Tuple{}) where {T} = new{T,0,Tuple{},Tuple{}}(val, ind, axes)
 end
 
 const OneElementVector{T,I,A} = OneElement{T,1,I,A}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -97,14 +97,18 @@ oneton(sz...) = oneton(Float64, sz...)
 
 
     for T in (Int, Float64)
-        F = Fill{T}(one(T), 5)
+        F = Fill{T, 0}(2)
+        @test size(F) == ()
+        @test F[] === T(2)
+
+        F = Fill{T}(1, 5)
 
         @test eltype(F) == T
         @test Array(F) == fill(one(T),5)
         @test Array{T}(F) == fill(one(T),5)
         @test Array{T,1}(F) == fill(one(T),5)
 
-        F = Fill{T}(one(T), 5, 5)
+        F = Fill{T}(1, 5, 5)
         @test eltype(F) == T
         @test Array(F) == fill(one(T),5,5)
         @test Array{T}(F) == fill(one(T),5,5)
@@ -1901,6 +1905,10 @@ end
 end
 
 @testset "OneElement" begin
+    A = OneElement(2, (), ())
+    @test A == Fill(2, ())
+    @test A[] === 2
+
     e₁ = OneElement(2, 5)
     @test e₁ == [0,1,0,0,0]
     @test_throws BoundsError e₁[6]
@@ -1935,6 +1943,13 @@ end
     @test Base.setindex(Zeros(5), 2, 2) ≡ OneElement(2.0, 2, 5)
     @test Base.setindex(Zeros(5,3), 2, 2, 3) ≡ OneElement(2.0, (2,3), (5,3))
     @test_throws BoundsError Base.setindex(Zeros(5), 2, 6)
+
+    @testset "non-numeric" begin
+        S = SMatrix{2,2}(1:4)
+        A = OneElement(S, (2,2), (2,2))
+        @test A[2,2] === S
+        @test A[1,1] === A[1,2] === A[2,1] === zero(S)
+    end
 
     @testset "adjoint/transpose" begin
         A = OneElement(3im, (2,4), (4,6))


### PR DESCRIPTION
This lifts the somewhat unnecessary restriction to numeric `eltype`s in the `OneElement` constructor. After this, the following works:
```julia
julia> OneElement(SMatrix{2,2}(1:4), (2,2), (2,2))
2×2 OneElement{SMatrix{2, 2, Int64, 4}, 2, Tuple{Int64, Int64}, Tuple{Base.OneTo{Int64}, Base.OneTo{Int64}}}:
     ⋅           ⋅     
     ⋅       [1 3; 2 4]
```
In general, indexing into this requires that the element type defines `zero(T)` and ideally returns a value of type `T`.

Also, fixes some ambiguities in the 0-D `Fill` and `OneElement` constructors.