### PR TITLE
Fix broadcast ambiguities with AbstractFill

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FillArrays"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "1.9.0"
+version = "1.9.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/fillbroadcast.jl
+++ b/src/fillbroadcast.jl
@@ -145,7 +145,7 @@ broadcasted(::DefaultArrayStyle, ::typeof(*), a::AbstractZeros, b::AbstractZeros
 for op in (:*, :/)
     @eval begin
         broadcasted(::DefaultArrayStyle, ::typeof($op), a::AbstractZeros, b::AbstractOnes) = _broadcasted_zeros($op, a, b)
-        broadcasted(::DefaultArrayStyle, ::typeof($op), a::AbstractZeros, b::Fill{<:Number}) = _broadcasted_zeros($op, a, b)
+        broadcasted(::DefaultArrayStyle, ::typeof($op), a::AbstractZeros, b::AbstractFill{<:Number}) = _broadcasted_zeros($op, a, b)
         broadcasted(::DefaultArrayStyle, ::typeof($op), a::AbstractZeros, b::Number) = _broadcasted_zeros($op, a, b)
         broadcasted(::DefaultArrayStyle, ::typeof($op), a::AbstractZeros, b::AbstractRange) = _broadcasted_zeros($op, a, b)
         broadcasted(::DefaultArrayStyle, ::typeof($op), a::AbstractZeros, b::AbstractArray{<:Number}) = _broadcasted_zeros($op, a, b)
@@ -157,7 +157,7 @@ end
 for op in (:*, :\)
     @eval begin
         broadcasted(::DefaultArrayStyle, ::typeof($op), a::AbstractOnes, b::AbstractZeros) = _broadcasted_zeros($op, a, b)
-        broadcasted(::DefaultArrayStyle, ::typeof($op), a::Fill{<:Number}, b::AbstractZeros) = _broadcasted_zeros($op, a, b)
+        broadcasted(::DefaultArrayStyle, ::typeof($op), a::AbstractFill{<:Number}, b::AbstractZeros) = _broadcasted_zeros($op, a, b)
         broadcasted(::DefaultArrayStyle, ::typeof($op), a::Number, b::AbstractZeros) = _broadcasted_zeros($op, a, b)
         broadcasted(::DefaultArrayStyle, ::typeof($op), a::AbstractRange, b::AbstractZeros) = _broadcasted_zeros($op, a, b)
         broadcasted(::DefaultArrayStyle, ::typeof($op), a::AbstractArray{<:Number}, b::AbstractZeros) = _broadcasted_zeros($op, a, b)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -243,6 +243,26 @@ oneton(sz...) = oneton(Float64, sz...)
     end
 end
 
+@testset "interface" begin
+    struct Twos{T,N} <: FillArrays.AbstractFill{T,N,NTuple{N,Base.OneTo{Int}}}
+        sz :: NTuple{N,Int}
+    end
+    Twos{T}(sz::NTuple{N,Int}) where {T,N} = Twos{T,N}(sz)
+    Twos{T}(sz::Vararg{Int,N}) where {T,N} = Twos{T,N}(sz)
+    Base.size(A::Twos) = A.sz
+    FillArrays.getindex_value(A::Twos{T}) where {T} = oneunit(T) + oneunit(T)
+
+    @testset "broadcasting ambiguities" begin
+        A = Twos{Int}(3)
+        B = Zeros{Int}(size(A))
+        @test A .* B === B
+        @test B .* A === B
+        @test B ./ A === Zeros{Float64}(size(A))
+        @test A .\ B === Zeros{Float64}(size(A))
+        @test A ./ B === Fill(Inf, size(A))
+    end
+end
+
 @testset "indexing" begin
     A = Fill(3.0,5)
     @test A[1:3] ≡ Fill(3.0,3)


### PR DESCRIPTION
`(::AbstractFill) * (::Zeros)` and other similar functions were ambiguous for general `AbstractFill` subtypes (other than the ones defined in this package). This PR fixes these, and adds tests with a custom `AbstractFill` type.