### PR TITLE
Fix adjoint-Diagonal multiplication for non-square elements

### DIFF
--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -300,6 +300,7 @@ end
 
 *(a::Adjoint{T, <:AbstractMatrix{T}} where T, b::AbstractZeros{<:Any, 1}) = mult_zeros(a, b)
 
+*(D::Diagonal, a::AdjointAbsVec{<:Any,<:AbstractZerosVector}) = (a * D')'
 *(a::AdjointAbsVec{<:Any,<:AbstractZerosVector}, D::Diagonal) = (D*a')'
 *(a::TransposeAbsVec{<:Any,<:AbstractZerosVector}, D::Diagonal) = transpose(D*transpose(a))
 function _triple_zeromul(x, D::Diagonal, y)

--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -300,7 +300,7 @@ end
 
 *(a::Adjoint{T, <:AbstractMatrix{T}} where T, b::AbstractZeros{<:Any, 1}) = mult_zeros(a, b)
 
-*(D::Diagonal, a::AdjointAbsVec{<:Any,<:AbstractZerosVector}) = (a * D')'
+*(D::Diagonal, a::AdjointAbsVec{<:Any,<:AbstractZerosVector}) = (a' * D')'
 *(a::AdjointAbsVec{<:Any,<:AbstractZerosVector}, D::Diagonal) = (D' * a')'
 *(a::TransposeAbsVec{<:Any,<:AbstractZerosVector}, D::Diagonal) = transpose(D*transpose(a))
 function _triple_zeromul(x, D::Diagonal, y)

--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -301,7 +301,7 @@ end
 *(a::Adjoint{T, <:AbstractMatrix{T}} where T, b::AbstractZeros{<:Any, 1}) = mult_zeros(a, b)
 
 *(D::Diagonal, a::AdjointAbsVec{<:Any,<:AbstractZerosVector}) = (a * D')'
-*(a::AdjointAbsVec{<:Any,<:AbstractZerosVector}, D::Diagonal) = (D*a')'
+*(a::AdjointAbsVec{<:Any,<:AbstractZerosVector}, D::Diagonal) = (D' * a')'
 *(a::TransposeAbsVec{<:Any,<:AbstractZerosVector}, D::Diagonal) = transpose(D*transpose(a))
 function _triple_zeromul(x, D::Diagonal, y)
     if !(length(x) == length(D.diag) == length(y))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1487,9 +1487,9 @@ end
         D = Diagonal([[1 2; 3 4], [1 2 3; 4 5 6]])
         @test @inferred(Zeros(TSM, 2,2) * D) == zeros(TSM, 2,2) * D
 
-        D = Diagonal(fill(SMatrix{2,2}(im,0,0,2im),1))
-        Z = Zeros(SMatrix{2,2,ComplexF64,4},1)
-        @test D * Z' == D * Array(Z)
+        D = Diagonal(fill(SMatrix{2,3}(fill(im,6)),1))
+        Z = Zeros(SMatrix{2,3,ComplexF64,6},1)
+        @test D * Z' == fill(zero(SMatrix{2,2,ComplexF64,4}),1,1)
 
         D = Diagonal(fill(zeros(2,3), 2))
         Z = Zeros(SMatrix{2,3,Float64,6}, 2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1487,6 +1487,10 @@ end
         D = Diagonal([[1 2; 3 4], [1 2 3; 4 5 6]])
         @test @inferred(Zeros(TSM, 2,2) * D) == zeros(TSM, 2,2) * D
 
+        D = Diagonal(fill(SMatrix{2,2}(im,0,0,2im),1))
+        Z = Zeros(SMatrix{2,2,ComplexF64,4},1)
+        @test D * Z' == D * zeros(SMatrix{2,2,ComplexF64,4},1)
+
         # doubly nested
         A = [[[1,2]]]'
         Z = Zeros(SMatrix{1,1,SMatrix{2,2,Int,4},1},1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1489,7 +1489,11 @@ end
 
         D = Diagonal(fill(SMatrix{2,2}(im,0,0,2im),1))
         Z = Zeros(SMatrix{2,2,ComplexF64,4},1)
-        @test D * Z' == D * zeros(SMatrix{2,2,ComplexF64,4},1)
+        @test D * Z' == D * Array(Z)
+
+        D = Diagonal(fill(zeros(2,3), 2))
+        Z = Zeros(SMatrix{2,3,Float64,6}, 2)
+        @test Z' * D == Array(Z)' * D
 
         # doubly nested
         A = [[[1,2]]]'


### PR DESCRIPTION
Also resolves an ambiguity in `Diagonal * Adjoint(::AbstractZerosVector)`