### PR TITLE
Use axes function instead of field access

### DIFF
--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -8,11 +8,11 @@ vec(a::AbstractFill) = fillsimilar(a, length(a))
 
 transpose(a::Union{AbstractOnesMatrix, AbstractZerosMatrix}) = fillsimilar(a, reverse(axes(a)))
 adjoint(a::Union{AbstractOnesMatrix, AbstractZerosMatrix}) = fillsimilar(a, reverse(axes(a)))
-transpose(a::FillMatrix{T}) where T = Fill{T}(transpose(a.value), reverse(a.axes))
-adjoint(a::FillMatrix{T}) where T = Fill{T}(adjoint(a.value), reverse(a.axes))
+transpose(a::FillMatrix{T}) where T = Fill{T}(transpose(a.value), reverse(axes(a)))
+adjoint(a::FillMatrix{T}) where T = Fill{T}(adjoint(a.value), reverse(axes(a)))
 
 permutedims(a::AbstractFillVector) = fillsimilar(a, (1, length(a)))
-permutedims(a::AbstractFillMatrix) = fillsimilar(a, reverse(a.axes))
+permutedims(a::AbstractFillMatrix) = fillsimilar(a, reverse(axes(a)))
 
 function permutedims(B::AbstractFill, perm)
     dimsB = size(B)

--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -8,8 +8,8 @@ vec(a::AbstractFill) = fillsimilar(a, length(a))
 
 transpose(a::Union{AbstractOnesMatrix, AbstractZerosMatrix}) = fillsimilar(a, reverse(axes(a)))
 adjoint(a::Union{AbstractOnesMatrix, AbstractZerosMatrix}) = fillsimilar(a, reverse(axes(a)))
-transpose(a::FillMatrix{T}) where T = Fill{T}(transpose(a.value), reverse(axes(a)))
-adjoint(a::FillMatrix{T}) where T = Fill{T}(adjoint(a.value), reverse(axes(a)))
+transpose(a::FillMatrix{T}) where T = Fill{T}(transpose(a.value), reverse(a.axes))
+adjoint(a::FillMatrix{T}) where T = Fill{T}(adjoint(a.value), reverse(a.axes))
 
 permutedims(a::AbstractFillVector) = fillsimilar(a, (1, length(a)))
 permutedims(a::AbstractFillMatrix) = fillsimilar(a, reverse(axes(a)))

--- a/src/fillbroadcast.jl
+++ b/src/fillbroadcast.jl
@@ -85,10 +85,10 @@ broadcasted(::DefaultArrayStyle, ::typeof(+), r::AbstractOnes) = r
 
 broadcasted(::DefaultArrayStyle{N}, ::typeof(conj), r::AbstractZeros{T,N}) where {T,N} = r
 broadcasted(::DefaultArrayStyle{N}, ::typeof(conj), r::AbstractOnes{T,N}) where {T,N} = r
-broadcasted(::DefaultArrayStyle{N}, ::typeof(real), r::AbstractZeros{T,N}) where {T,N} = Zeros{real(T)}(r.axes)
-broadcasted(::DefaultArrayStyle{N}, ::typeof(real), r::AbstractOnes{T,N}) where {T,N} = Ones{real(T)}(r.axes)
-broadcasted(::DefaultArrayStyle{N}, ::typeof(imag), r::AbstractZeros{T,N}) where {T,N} = Zeros{real(T)}(r.axes)
-broadcasted(::DefaultArrayStyle{N}, ::typeof(imag), r::AbstractOnes{T,N}) where {T,N} = Zeros{real(T)}(r.axes)
+broadcasted(::DefaultArrayStyle{N}, ::typeof(real), r::AbstractZeros{T,N}) where {T,N} = Zeros{real(T)}(axes(r))
+broadcasted(::DefaultArrayStyle{N}, ::typeof(real), r::AbstractOnes{T,N}) where {T,N} = Ones{real(T)}(axes(r))
+broadcasted(::DefaultArrayStyle{N}, ::typeof(imag), r::AbstractZeros{T,N}) where {T,N} = Zeros{real(T)}(axes(r))
+broadcasted(::DefaultArrayStyle{N}, ::typeof(imag), r::AbstractOnes{T,N}) where {T,N} = Zeros{real(T)}(axes(r))
 
 ### Binary broadcasting
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1895,7 +1895,7 @@ end
         @test convert(Fill, transpose(a)) ≡ Fill(2.0+im,1,5)
     end
 
-    @testst "custom AbstractFill types" begin
+    @testset "custom AbstractFill types" begin
         # implicit axes
         struct StaticZerosVec{L,T} <: FillArrays.AbstractZeros{T,1,Tuple{SOneTo{L}}} end
         Base.size(::StaticZerosVec{L}) where {L} = (L,)


### PR DESCRIPTION
When the axes for an abstract type are fetched, it's best to use `axes(A)` instead of `A.axes` to avoid assuming that there is a field with that name in every subtype.