### PR TITLE
Fix matrix multiplication with non-commutative elements

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FillArrays"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "1.9.2"
+version = "1.9.3"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/Project.toml
+++ b/Project.toml
@@ -25,6 +25,7 @@ Base64 = "1.6"
 Infinities = "0.1"
 LinearAlgebra = "1.6"
 PDMats = "0.11.17"
+Quaternions = "0.7"
 Random = "1.6"
 ReverseDiff = "1"
 SparseArrays = "1.6"
@@ -38,6 +39,7 @@ Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 Infinities = "e1ba4f0e-776d-440f-acd9-e1d2e9742647"
 PDMats = "90014a1f-27ba-587c-ab20-58faa44d9150"
+Quaternions = "94ee1d12-ae83-5a48-8b1c-48b8ff168ae0"
 ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
@@ -45,4 +47,4 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "Test", "Base64", "Infinities", "PDMats", "ReverseDiff", "SparseArrays", "StaticArrays", "Statistics"]
+test = ["Aqua", "Test", "Base64", "Infinities", "PDMats", "ReverseDiff", "SparseArrays", "StaticArrays", "Statistics", "Quaternions"]

--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -144,9 +144,9 @@ function mul!(y::AbstractVector, A::AbstractFillMatrix, b::AbstractFillVector, a
     αAb = alpha * getindex_value(A) * getindex_value(b) * length(b)
 
     if iszero(beta)
-        y .= αAb
+        y .= Ref(αAb)
     else
-        y .= αAb .+ beta .* y
+        y .= Ref(αAb) .+ beta .* y
     end
     y
 end
@@ -157,14 +157,14 @@ function mul!(y::StridedVector, A::StridedMatrix, b::AbstractFillVector, alpha::
     αb = alpha * getindex_value(b)
 
     if iszero(beta)
-        y .= zero(eltype(y))
+        y .= Ref(zero(eltype(y)))
         for col in eachcol(A)
-            y .+= αb .* col
+            y .+= col .* Ref(αb)
         end
     else
         lmul!(beta, y)
         for col in eachcol(A)
-            y .+= αb .* col
+            y .+= col .* Ref(αb)
         end
     end
     y

--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -154,17 +154,17 @@ end
 function mul!(y::StridedVector, A::StridedMatrix, b::AbstractFillVector, alpha::Number, beta::Number)
     check_matmul_sizes(y, A, b)
 
-    αb = alpha * getindex_value(b)
+    αb = Ref(alpha * getindex_value(b))
 
     if iszero(beta)
         y .= Ref(zero(eltype(y)))
         for col in eachcol(A)
-            y .+= col .* Ref(αb)
+            y .+= col .* αb
         end
     else
         lmul!(beta, y)
         for col in eachcol(A)
-            y .+= col .* Ref(αb)
+            y .+= col .* αb
         end
     end
     y
@@ -173,18 +173,18 @@ end
 function mul!(y::StridedVector, A::AbstractFillMatrix, b::StridedVector, alpha::Number, beta::Number)
     check_matmul_sizes(y, A, b)
 
-    αA = alpha * getindex_value(A)
+    αA = Ref(alpha * getindex_value(A))
 
     if iszero(beta)
-        y .= αA .* sum(b)
+        y .= αA .* Ref(sum(b))
     else
-        y .= αA .* sum(b) .+ beta .* y
+        y .= αA .* Ref(sum(b)) .+ beta .* y
     end
     y
 end
 
 function _mul_adjtrans!(y::AbstractVector, A::AbstractMatrix, b::AbstractVector, alpha, beta, f)
-    α = alpha * getindex_value(b)
+    α = Ref(alpha * getindex_value(b))
 
     At = f(A)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,15 +1,4 @@
-using Base64
-using FillArrays
-using LinearAlgebra
-using PDMats
-using Quaternions
-using Random
-using ReverseDiff
-using SparseArrays
-using StaticArrays
-using Statistics
-using Test
-
+using FillArrays, LinearAlgebra, PDMats, SparseArrays, StaticArrays, ReverseDiff, Random, Base64, Test, Statistics, Quaternions
 import FillArrays: AbstractFill, RectDiagonal, SquareEye
 
 using Aqua

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1539,6 +1539,11 @@ end
         Z = Zeros(SMatrix{1,1,SMatrix{2,2,Int,4},1},1)
         Z2 = zeros(SMatrix{1,1,SMatrix{2,2,Int,4},1},1)
         @test A * Z == A * Z2
+
+        x = [1 2 3; 4 5 6]
+        A = reshape([x,2x,3x,4x],2,2)
+        F = Fill(x,2,2)
+        @test A' * F == A' * fill(x,size(F))
     end
 
     for W in (zeros(3,4), @MMatrix zeros(3,4))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1532,7 +1532,9 @@ end
         A = reshape([S,2S,3S,4S],2,2)
         F = Fill(S',2,2)
         @test A * F == A * fill(S',size(F))
+        @test mul!(A * F, A, F, 2, 1) == 3 * A * fill(S',size(F))
         @test F * A == fill(S',size(F)) * A
+        @test mul!(F * A, F, A, 2, 1) == 3 * fill(S',size(F)) * A
 
         # doubly nested
         A = [[[1,2]]]'
@@ -1544,6 +1546,7 @@ end
         A = reshape([x,2x,3x,4x],2,2)
         F = Fill(x,2,2)
         @test A' * F == A' * fill(x,size(F))
+        @test mul!(A' * F, A', F, 2, 1) == 3 * A' * fill(x,size(F))
     end
 
     for W in (zeros(3,4), @MMatrix zeros(3,4))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1530,8 +1530,9 @@ end
 
         S = SMatrix{2,3}(1:6)
         A = reshape([S,2S,3S,4S],2,2)
-        F = Fill(S',2,3)
+        F = Fill(S',2,2)
         @test A * F == A * fill(S',size(F))
+        @test F * A == fill(S',size(F)) * A
 
         # doubly nested
         A = [[[1,2]]]'

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1528,6 +1528,11 @@ end
         Z = Zeros(SMatrix{2,3,Float64,6}, 2)
         @test Z' * D == Array(Z)' * D
 
+        S = SMatrix{2,3}(1:6)
+        A = reshape([S,2S,3S,4S],2,2)
+        F = Fill(S',2,3)
+        @test A * F == A * fill(S',size(F))
+
         # doubly nested
         A = [[[1,2]]]'
         Z = Zeros(SMatrix{1,1,SMatrix{2,2,Int,4},1},1)


### PR DESCRIPTION
Fixes various issues like
```julia
julia> using FillArrays, LinearAlgebra, StaticArrays

julia> S = SMatrix{2,3}(1:6);

julia> A = reshape([S,2S,3S,4S],2,2);

julia> F = Fill(S',2,2);

julia> A * F
2×2 Matrix{SMatrix{2, 2, Int64, 4}}:
 [140 176; 176 224]  [140 176; 176 224]
 [210 264; 264 336]  [210 264; 264 336]

julia> mul!(similar(A * F), A, F) ≈ A * F
true
```
This example errors on master currently as the order of terms is incorrect (assumes commutativity).