### PR TITLE
Fix recursive adjoint/transpose

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FillArrays"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "1.9.1"
+version = "1.9.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -6,10 +6,17 @@ vec(a::AbstractFill) = fillsimilar(a, length(a))
 # cannot do this for vectors since that would destroy scalar dot product
 
 
-transpose(a::Union{AbstractOnesMatrix, AbstractZerosMatrix}) = fillsimilar(a, reverse(axes(a)))
-adjoint(a::Union{AbstractOnesMatrix, AbstractZerosMatrix}) = fillsimilar(a, reverse(axes(a)))
-transpose(a::FillMatrix{T}) where T = Fill{T}(transpose(a.value), reverse(a.axes))
-adjoint(a::FillMatrix{T}) where T = Fill{T}(adjoint(a.value), reverse(a.axes))
+for OP in (:transpose, :adjoint)
+    @eval begin
+        function $OP(a::AbstractZerosMatrix)
+            v = getindex_value(a)
+            T = typeof($OP(v))
+            Zeros{T}(reverse(axes(a)))
+        end
+        $OP(a::AbstractOnesMatrix) = fillsimilar(a, reverse(axes(a)))
+        $OP(a::FillMatrix) = Fill($OP(a.value), reverse(a.axes))
+    end
+end
 
 permutedims(a::AbstractFillVector) = fillsimilar(a, (1, length(a)))
 permutedims(a::AbstractFillMatrix) = fillsimilar(a, reverse(a.axes))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1394,6 +1394,19 @@ end
     @test permutedims(Ones(2,4,5), [3,2,1]) ≡ Ones(5,4,2)
     @test permutedims(Zeros(2,4,5), [3,2,1]) ≡ Zeros(5,4,2)
     @test permutedims(Fill(2.0,2,4,5), [3,2,1]) ≡ Fill(2.0,5,4,2)
+
+    @testset "recursive" begin
+        S = SMatrix{2,3}(1:6)
+        Z = Zeros(typeof(S), 2, 3)
+        Y = zeros(typeof(S), 2, 3)
+        @test Z' == Y'
+        @test transpose(Z) == transpose(Y)
+
+        F = Fill(S, 2, 3)
+        G = fill(S, 2, 3)
+        @test F' == G'
+        @test transpose(F) == transpose(G)
+    end
 end
 
 @testset "reverse" begin


### PR DESCRIPTION
On master
```julia
julia> S = SMatrix{2,3}(1:6)
2×3 SMatrix{2, 3, Int64, 6} with indices SOneTo(2)×SOneTo(3):
 1  3  5
 2  4  6

julia> Z = Zeros(typeof(S), 2,2)
2×2 Zeros{SMatrix{2, 3, Int64, 6}}

julia> Z' # element type is incorrect, as adjoint should be recursive
2×2 Zeros{SMatrix{2, 3, Int64, 6}}
```
After this,
```julia
julia> Z'
2×2 Zeros{SMatrix{3, 2, Int64, 6}}
```