### PR TITLE
Point to `getindex_value` in `AbstractFill` docstring

### DIFF
--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -23,8 +23,8 @@ import Base: oneto
 """
     AbstractFill{T, N, Axes} <: AbstractArray{T, N}
 
-Supertype for lazy array types whose entries are all equal to constant.
-Subtypes of `AbstractFill` should implement [`FillArrays.getindex_value`](@ref) for themselves.
+Supertype for lazy array types whose entries are all equal.
+Subtypes of `AbstractFill` should implement [`FillArrays.getindex_value`](@ref) to return the value of the entries.
 """
 abstract type AbstractFill{T, N, Axes} <: AbstractArray{T, N} end
 const AbstractFillVector{T} = AbstractFill{T,1}

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -24,6 +24,7 @@ import Base: oneto
     AbstractFill{T, N, Axes} <: AbstractArray{T, N}
 
 Supertype for lazy array types whose entries are all equal to constant.
+Subtypes of `AbstractFill` should implement [`FillArrays.getindex_value`](@ref) for themselves.
 """
 abstract type AbstractFill{T, N, Axes} <: AbstractArray{T, N} end
 const AbstractFillVector{T} = AbstractFill{T,1}
@@ -145,7 +146,7 @@ Fill{T,0}(x, ::Tuple{}) where T = Fill{T,0,Tuple{}}(convert(T, x)::T, ()) # ambi
 @inline size(F::Fill) = map(length, F.axes)
 
 """
-    getindex_value(F::AbstractFill)
+    FillArrays.getindex_value(F::AbstractFill)
 
 Return the value that `F` is filled with.
 


### PR DESCRIPTION
Extending this is necessary to get most functions to work.