### PR TITLE
Specalize `istriu`/`istril`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FillArrays"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "1.9.2"
+version = "1.10.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -520,3 +520,12 @@ function kron(f::AbstractFillVecOrMat, g::AbstractFillVecOrMat)
     sz = _kronsize(f, g)
     return _kron(f, g, sz)
 end
+
+# bandedness
+LinearAlgebra.isdiag(A::AbstractFillMatrix) = iszero(getindex_value(A)) || isempty(A)
+function LinearAlgebra.istriu(A::AbstractFillMatrix, k::Integer = 0)
+    iszero(getindex_value(A)) || isempty(A) || k <= -(size(A,1)-1)
+end
+function LinearAlgebra.istril(A::AbstractFillMatrix, k::Integer = 0)
+    iszero(getindex_value(A)) || isempty(A) || k >= size(A,2)-1
+end

--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -522,10 +522,9 @@ function kron(f::AbstractFillVecOrMat, g::AbstractFillVecOrMat)
 end
 
 # bandedness
-LinearAlgebra.isdiag(A::AbstractFillMatrix) = iszero(getindex_value(A)) || isempty(A)
 function LinearAlgebra.istriu(A::AbstractFillMatrix, k::Integer = 0)
-    iszero(getindex_value(A)) || isempty(A) || k <= -(size(A,1)-1)
+    iszero(A) || k <= -(size(A,1)-1)
 end
 function LinearAlgebra.istril(A::AbstractFillMatrix, k::Integer = 0)
-    iszero(getindex_value(A)) || isempty(A) || k >= size(A,2)-1
+    iszero(A) || k >= size(A,2)-1
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2293,8 +2293,9 @@ end
 end
 
 @testset "isbanded/isdiag" begin
-    @testset for A in (Zeros(2,3), Ones(3,4), Ones(0,4), Ones(7,0), Ones(7,2), Ones(2,7),
-            Fill(3, 2,4), Fill(0, 3, 4), Fill(2, 0, 4), Fill(2, 6, 0), Fill(0, 8, 8))
+    @testset for A in Any[Zeros(2,3), Zeros(0,1), Zeros(1,1), Zeros(1,2),
+            Ones(0,1), Ones(1,1), Ones(3,4), Ones(0,4), Ones(7,0), Ones(7,2), Ones(2,7),
+            Fill(3, 0,1), Fill(3, 1,1), Fill(3, 2,4), Fill(0, 3, 4), Fill(2, 0, 4), Fill(2, 6, 0), Fill(0, 8, 8)]
         B = Array(A)
         @test isdiag(A) == isdiag(B)
         for k in -5:5

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1114,7 +1114,7 @@ end
                 @test Zeros(S, 10) .* (T(1):T(10)) ≡ Zeros(U, 10)
                 @test_throws DimensionMismatch Zeros(S, 10) .* (T(1):T(11))
             end
-        end        
+        end
     end
 end
 
@@ -2292,3 +2292,14 @@ end
     end
 end
 
+@testset "isbanded/isdiag" begin
+    @testset for A in (Zeros(2,3), Ones(3,4), Ones(0,4), Ones(7,0), Ones(7,2), Ones(2,7),
+            Fill(3, 2,4), Fill(0, 3, 4), Fill(2, 0, 4), Fill(2, 6, 0), Fill(0, 8, 8))
+        B = Array(A)
+        @test isdiag(A) == isdiag(B)
+        for k in -5:5
+            @test istriu(A, k) == istriu(B, k)
+            @test istril(A, k) == istril(B, k)
+        end
+    end
+end


### PR DESCRIPTION
Avoid the fallbacks methods that loop over the entire array
```julia
julia> using LinearAlgebra, FillArrays

julia> @btime isdiag($(Ref(Zeros(1000,1000)))[]);
  4.408 μs (0 allocations: 0 bytes) # master
  1.687 ns (0 allocations: 0 bytes) # PR
```