### PR TITLE
Fix `isone` for an empty `AbstractFill`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FillArrays"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "1.9.2"
+version = "1.9.3"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -4,7 +4,7 @@ module FillArrays
 using LinearAlgebra
 import Base: size, getindex, setindex!, IndexStyle, checkbounds, convert,
     +, -, *, /, \, diff, sum, cumsum, maximum, minimum, sort, sort!,
-    any, all, axes, isone, iterate, unique, allunique, permutedims, inv,
+    any, all, axes, isone, iszero, iterate, unique, allunique, permutedims, inv,
     copy, vec, setindex!, count, ==, reshape, map, zero,
     show, view, in, mapreduce, one, reverse, promote_op, promote_rule, repeat,
     parent, similar, issorted
@@ -621,9 +621,10 @@ end
 #########
 
 function isone(AF::AbstractFillMatrix)
-    isone(getindex_value(AF)) || return false
     (n,m) = size(AF)
     n != m && return false
+    (n == 0 || m == 0) && return true
+    isone(getindex_value(AF)) || return false
     n == 1 && return true
     return false
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1271,9 +1271,17 @@ end
             @test isone(onem) == isone(Array(onem))
             @test iszero(onem) == isempty(onem) == iszero(Array(onem))
 
+            if d > 0
+                @test !isone(Ones{T}(d, 2d))
+            end
+
             zerom = Zeros{T}(d, d)
             @test  isone(zerom) == isempty(zerom) == isone(Array(zerom))
             @test  iszero(zerom) == iszero(Array(zerom))
+
+            if d > 0
+                @test iszero(Zeros{T}(d, 2d))
+            end
 
             fillm0 = Fill(T(0), d, d)
             @test   isone(fillm0) == isempty(fillm0) == isone(Array(fillm0))
@@ -1319,6 +1327,10 @@ end
             @test ! iszero(m4)
         end
     end
+
+    @test iszero(Zeros{SMatrix{2,2,Int,4}}(2))
+    @test iszero(Fill(SMatrix{2,2}(0,0,0,0), 2))
+    @test iszero(Fill(SMatrix{2,2}(0,0,0,1), 0))
 
     @testset "all/any" begin
         @test any(Ones{Bool}(10)) === all(Ones{Bool}(10)) === any(Fill(true,10)) === all(Fill(true,10)) === true

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1114,7 +1114,7 @@ end
                 @test Zeros(S, 10) .* (T(1):T(10)) ≡ Zeros(U, 10)
                 @test_throws DimensionMismatch Zeros(S, 10) .* (T(1):T(11))
             end
-        end        
+        end
     end
 end
 
@@ -1238,40 +1238,54 @@ end
             @test ! all(iszero, m)
             @test ! all(isone, m)
         end
-        for d in (1, )
+        @testset for d in (0, 1)
             for m in (Eye{T}(d), Eye{T}(d, d))
+                M = Array(m)
                 @test ! any(iszero, m)
                 @test ! all(iszero, m)
-                @test any(isone, m)
-                @test all(isone, m)
+                @test any(isone, m) == !isempty(m)
+                @test all(isone, m) == !isempty(m)
+                if !isempty(m)
+                    @test ! any(iszero, m) == ! any(iszero, M)
+                    @test ! all(iszero, m) == ! all(iszero, M)
+                    @test any(isone, m) == any(isone, M)
+                    @test all(isone, m) == all(isone, M)
+                end
             end
 
             for m in (Eye{T}(d, d + 1), Eye{T}(d + 1, d))
-                @test any(iszero, m)
+                M = Array(m)
+                @test any(iszero, m) == !isempty(m)
                 @test ! all(iszero, m)
-                @test any(isone, m)
+                @test any(isone, m) == !isempty(m)
                 @test ! all(isone, m)
+                if !isempty(M)
+                    @test any(iszero, m) == any(iszero, M)
+                    @test ! all(iszero, m) == ! all(iszero, M)
+                    @test any(isone, m) == any(isone, M)
+                    @test ! all(isone, m) == ! all(isone, M)
+                end
             end
 
             onem = Ones{T}(d, d)
-            @test isone(onem)
-            @test ! iszero(onem)
+            @test isone(onem) == isone(Array(onem))
+            @test iszero(onem) == isempty(onem) == iszero(Array(onem))
 
             zerom = Zeros{T}(d, d)
-            @test ! isone(zerom)
-            @test  iszero(zerom)
+            @test  isone(zerom) == isempty(zerom) == isone(Array(zerom))
+            @test  iszero(zerom) == iszero(Array(zerom))
 
             fillm0 = Fill(T(0), d, d)
-            @test ! isone(fillm0)
-            @test   iszero(fillm0)
+            @test   isone(fillm0) == isempty(fillm0) == isone(Array(fillm0))
+            @test   iszero(fillm0) == iszero(Array(fillm0))
 
             fillm1 = Fill(T(1), d, d)
-            @test isone(fillm1)
-            @test ! iszero(fillm1)
+            @test isone(fillm1) == isone(Array(fillm1))
+            @test iszero(fillm1) == isempty(fillm1) == iszero(Array(fillm1))
 
             fillm2 = Fill(T(2), d, d)
-            @test ! isone(fillm2)
-            @test ! iszero(fillm2)
+            @test isone(fillm2) == isempty(fillm2) == isone(Array(fillm2))
+            @test iszero(fillm2) == isempty(fillm2) == iszero(Array(fillm2))
         end
         for d in (2, 3)
             for m in (Eye{T}(d), Eye{T}(d, d), Eye{T}(d, d + 2), Eye{T}(d + 2, d))
@@ -2291,4 +2305,3 @@ end
         @test a.value == first(diag)
     end
 end
-


### PR DESCRIPTION
After this, the behaviour of an `AbstractFill` matches that of an `Array`