### PR TITLE
Short-circuit `all` for `AbstractFill`

### DIFF
--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -652,10 +652,10 @@ function all(f::Function, x::AbstractFill)
         return fval || isempty(x)
     elseif isempty(x) # cases like all(Fill(2,0))
         return true
-    elseif fval # throw an error for non-Bool values
-        return fval
+    elseif ismissing(fval)
+        return missing
     end
-    return false
+    return all(fval)
 end
 any(x::AbstractFill) = any(identity, x)
 all(x::AbstractFill) = all(identity, x)

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -643,19 +643,17 @@ end
 
 # In particular, these make iszero(Eye(n))  efficient.
 # use any/all on scalar to get Boolean error message
-any(f::Function, x::AbstractFill) = !isempty(x) && any(f(getindex_value(x)))
-function all(f::Function, x::AbstractFill)
+function any(f::Function, x::AbstractFill)
+    isempty(x) && return false
+    # If the condition is true for one value, then it's true for all
     fval = f(getindex_value(x))
-    # checking the Bool path before isempty(x) allows short-curcuiting
-    # in case the value is known from the type, e.g. in Zeros
-    if fval isa Bool
-        return fval || isempty(x)
-    elseif isempty(x) # cases like all(Fill(2,0))
-        return true
-    elseif ismissing(fval)
-        return missing
-    end
-    return all(fval)
+    any((fval,))
+end
+function all(f::Function, x::AbstractFill)
+    isempty(x) && return true
+    # If the condition is true for one value, then it's true for all
+    fval = f(getindex_value(x))
+    return all((fval,))
 end
 any(x::AbstractFill) = any(identity, x)
 all(x::AbstractFill) = all(identity, x)

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -644,7 +644,9 @@ end
 # In particular, these make iszero(Eye(n))  efficient.
 # use any/all on scalar to get Boolean error message
 any(f::Function, x::AbstractFill) = !isempty(x) && any(f(getindex_value(x)))
-all(f::Function, x::AbstractFill) = isempty(x) || all(f(getindex_value(x)))
+# evaluating all(f(getindex_value(x))) before isempty(x) allows short-curcuiting
+# in case the value is known from the type, e.g. in Zeros
+all(f::Function, x::AbstractFill) = all(f(getindex_value(x))) || isempty(x)
 any(x::AbstractFill) = any(identity, x)
 all(x::AbstractFill) = all(identity, x)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1348,6 +1348,8 @@ end
         @test all(Fill(2,0))
         @test !any(Fill(2,0))
         @test any(Trues(2,0)) == any(trues(2,0))
+        @test_throws TypeError all(Fill(2,2))
+        @test all(iszero, Fill(missing,2)) === all(iszero, fill(missing,2))
     end
 
     @testset "Error" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1336,6 +1336,9 @@ end
     @test iszero(Fill(SMatrix{2,2}(0,0,0,0), 2))
     @test iszero(Fill(SMatrix{2,2}(0,0,0,1), 0))
 
+    # compile-time evaluation
+    @test @inferred((Z -> Val(iszero(Z)))(Zeros(3,3))) == Val(true)
+
     @testset "all/any" begin
         @test any(Ones{Bool}(10)) === all(Ones{Bool}(10)) === any(Fill(true,10)) === all(Fill(true,10)) === true
         @test any(Zeros{Bool}(10)) === all(Zeros{Bool}(10)) === any(Fill(false,10)) === all(Fill(false,10)) === false

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1349,7 +1349,10 @@ end
         @test !any(Fill(2,0))
         @test any(Trues(2,0)) == any(trues(2,0))
         @test_throws TypeError all(Fill(2,2))
-        @test all(iszero, Fill(missing,2)) === all(iszero, fill(missing,2))
+        @test all(iszero, Fill(missing,0)) === all(iszero, fill(missing,0)) === true
+        @test all(iszero, Fill(missing,2)) === all(iszero, fill(missing,2)) === missing
+        @test any(iszero, Fill(missing,0)) === any(iszero, fill(missing,0)) === false
+        @test any(iszero, Fill(missing,2)) === any(iszero, fill(missing,2)) === missing
     end
 
     @testset "Error" begin


### PR DESCRIPTION
This makes the following evaluate at compile time:
```julia
julia> @code_typed iszero(Zeros(3,3))
CodeInfo(
1 ─     return true
) => Bool
```