### PR TITLE
Broadcast arithmetic operators for OneElement

### DIFF
--- a/src/oneelement.jl
+++ b/src/oneelement.jl
@@ -151,3 +151,26 @@ end
 
 adjoint(A::OneElementMatrix) = OneElement(adjoint(A.val), reverse(A.ind), reverse(A.axes))
 transpose(A::OneElementMatrix) = OneElement(transpose(A.val), reverse(A.ind), reverse(A.axes))
+
+# broadcast
+function broadcasted(::DefaultArrayStyle{N}, ::typeof(conj), r::OneElement{<:Any,N}) where {N}
+    OneElement(conj(r.val), r.ind, axes(r))
+end
+function broadcasted(::DefaultArrayStyle{N}, ::typeof(real), r::OneElement{<:Any,N}) where {N}
+    OneElement(real(r.val), r.ind, axes(r))
+end
+function broadcasted(::DefaultArrayStyle{N}, ::typeof(imag), r::OneElement{<:Any,N}) where {N}
+    OneElement(imag(r.val), r.ind, axes(r))
+end
+function broadcasted(::DefaultArrayStyle{N}, ::typeof(^), r::OneElement{<:Any,N}, x::Number) where {N}
+    OneElement(r.val^x, r.ind, axes(r))
+end
+function broadcasted(::DefaultArrayStyle{N}, ::typeof(*), r::OneElement{<:Any,N}, x::Number) where {N}
+    OneElement(r.val*x, r.ind, axes(r))
+end
+function broadcasted(::DefaultArrayStyle{N}, ::typeof(/), r::OneElement{<:Any,N}, x::Number) where {N}
+    OneElement(r.val/x, r.ind, axes(r))
+end
+function broadcasted(::DefaultArrayStyle{N}, ::typeof(\), x::Number, r::OneElement{<:Any,N}) where {N}
+    OneElement(x \ r.val, r.ind, axes(r))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2218,6 +2218,20 @@ end
         @test A * (2 + 3.0im) === OneElement(val * (2 + 3.0im), (2,2), (3,4)) == B * (2 + 3.0im)
         @test A / (2 + 3.0im) === OneElement(val / (2 + 3.0im), (2,2), (3,4)) == B / (2 + 3.0im)
     end
+
+    @testset "broadcasting" begin
+        for v in (OneElement(2, 3, 4), OneElement(2im, (1,2), (3,4)))
+            w = Array(v)
+            n = 2
+            @test real.(v) == real.(w)
+            @test imag.(v) == imag.(w)
+            @test conj.(v) == conj.(w)
+            @test v .^ n == w .^ n
+            @test v .* n == w .* n
+            @test v ./ n == w ./ n
+            @test n .\ v == n .\ w
+        end
+    end
 end
 
 @testset "repeat" begin


### PR DESCRIPTION
On master
```julia
julia> v = OneElement(2, 3, 4)
4-element OneElement{Int64, 1, Tuple{Int64}, Tuple{Base.OneTo{Int64}}}:
 ⋅
 ⋅
 2
 ⋅

julia> v * 2
4-element OneElement{Int64, 1, Tuple{Int64}, Tuple{Base.OneTo{Int64}}}:
 ⋅
 ⋅
 4
 ⋅

julia> v .* 2
4-element Vector{Int64}:
 0
 0
 4
 0
```
This PR
```julia
julia> v .* 2
4-element OneElement{Int64, 1, Tuple{Int64}, Tuple{Base.OneTo{Int64}}}:
 ⋅
 ⋅
 4
 ⋅
```