### PR TITLE
Specialize isbanded for OneElement

### DIFF
--- a/src/oneelement.jl
+++ b/src/oneelement.jl
@@ -151,3 +151,8 @@ end
 
 adjoint(A::OneElementMatrix) = OneElement(adjoint(A.val), reverse(A.ind), reverse(A.axes))
 transpose(A::OneElementMatrix) = OneElement(transpose(A.val), reverse(A.ind), reverse(A.axes))
+
+# isbanded
+function LinearAlgebra.isbanded(A::OneElementMatrix, kl::Integer, ku::Integer)
+    iszero(getindex_value(A)) || kl <= A.ind[2] - A.ind[1] <= ku
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2218,6 +2218,36 @@ end
         @test A * (2 + 3.0im) === OneElement(val * (2 + 3.0im), (2,2), (3,4)) == B * (2 + 3.0im)
         @test A / (2 + 3.0im) === OneElement(val / (2 + 3.0im), (2,2), (3,4)) == B / (2 + 3.0im)
     end
+
+    @testset "isbanded" begin
+        A = OneElement(3, (2,3), (4,5))
+        @test !isdiag(A)
+        @test istriu(A)
+        @test !istril(A)
+        @test LinearAlgebra.isbanded(A, 1, 2)
+        @test LinearAlgebra.isbanded(A, -1, 2)
+        @test !LinearAlgebra.isbanded(A, 2, 2)
+
+        A = OneElement(3, (4,2), (4,5))
+        @test !isdiag(A)
+        @test !istriu(A)
+        @test istril(A)
+        @test LinearAlgebra.isbanded(A, -2, -2)
+        @test LinearAlgebra.isbanded(A, -2, 2)
+        @test !LinearAlgebra.isbanded(A, 2, 2)
+
+        for A in (OneElement(3, (2,2), (4,5)), OneElement(3, (1,1), (1,2)), OneElement(3, (8,7), (2,1)))
+            @test isdiag(A)
+            @test istriu(A)
+            @test istril(A)
+        end
+
+        for A in (OneElement(0, (2,3), (4,5)), OneElement(0, (3,2), (4,5)))
+            @test isdiag(A)
+            @test istriu(A)
+            @test istril(A)
+        end
+    end
 end
 
 @testset "repeat" begin


### PR DESCRIPTION
This allows `O(1)` checks for the bandedness of a `OneElement`.
```julia
julia> A = OneElement(3, (20,20), (20,20));

julia> @btime isdiag($A);
  542.590 ns (0 allocations: 0 bytes) # master
  3.382 ns (0 allocations: 0 bytes) # PR
```