### PR TITLE
`tril`/`triu` for `ZerosMatrix` and `OneElementMatrix`

### DIFF
--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -524,3 +524,6 @@ end
 function LinearAlgebra.istril(A::AbstractFillMatrix, k::Integer = 0)
     iszero(A) || k >= size(A,2)-1
 end
+
+triu(A::AbstractZerosMatrix, k::Integer=0) = A
+tril(A::AbstractZerosMatrix, k::Integer=0) = A

--- a/src/oneelement.jl
+++ b/src/oneelement.jl
@@ -151,3 +151,15 @@ end
 
 adjoint(A::OneElementMatrix) = OneElement(adjoint(A.val), reverse(A.ind), reverse(A.axes))
 transpose(A::OneElementMatrix) = OneElement(transpose(A.val), reverse(A.ind), reverse(A.axes))
+
+# tril/triu
+
+function tril(A::OneElementMatrix, k::Integer=0)
+    nzband = A.ind[2] - A.ind[1]
+    OneElement(nzband > k ? zero(A.val) : A.val, A.ind, axes(A))
+end
+
+function triu(A::OneElementMatrix, k::Integer=0)
+    nzband = A.ind[2] - A.ind[1]
+    OneElement(nzband < k ? zero(A.val) : A.val, A.ind, axes(A))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2218,6 +2218,16 @@ end
         @test A * (2 + 3.0im) === OneElement(val * (2 + 3.0im), (2,2), (3,4)) == B * (2 + 3.0im)
         @test A / (2 + 3.0im) === OneElement(val / (2 + 3.0im), (2,2), (3,4)) == B / (2 + 3.0im)
     end
+
+    @testset "tril/triu" begin
+        for A in (OneElement(3, (4,2), (4,5)), OneElement(3, (2,3), (4,5)), OneElement(3, (3,3), (4,5)))
+            B = Array(A)
+            for k in -5:5
+                @test tril(A, k) == tril(B, k)
+                @test triu(A, k) == triu(B, k)
+            end
+        end
+    end
 end
 
 @testset "repeat" begin
@@ -2382,4 +2392,12 @@ end
             @test istril(A, k) == istril(B, k)
         end
     end
+end
+
+@testset "triu/tril for Zeros" begin
+    Z = Zeros(3, 4)
+    @test triu(Z) === Z
+    @test tril(Z) === Z
+    @test triu(Z, 2) === Z
+    @test tril(Z, 2) === Z
 end


### PR DESCRIPTION
With this, `tril/triu` are no-ops for a `ZerosMatrix`, and O(1) for a `OneElementMatrix`
```julia
julia> @btime triu($(Ref(Zeros(100,100)))[]);
  2.019 μs (0 allocations: 0 bytes) # master
  2.945 ns (0 allocations: 0 bytes) # PR

julia> @btime triu($(Ref(OneElement(3, (100,100), (100,100))))[]);
  25.277 μs (2 allocations: 78.17 KiB) # master
  3.780 ns (0 allocations: 0 bytes) # PR
```