### PR TITLE
Fix OneElement multiplication with array elements

### DIFF
--- a/src/oneelement.jl
+++ b/src/oneelement.jl
@@ -213,11 +213,11 @@ function _mul!(C::AbstractMatrix, A::OneElementMatrix, B::AbstractMatrix, alpha,
     Aval = A.val
     if iszero(beta)
         C .= Ref(zero(eltype(C)))
-        y .= Aval .* view(B, nzcol, :) .* alpha
+        y .= Ref(Aval) .* view(B, nzcol, :) .* alpha
     else
         view(C, 1:nzrow-1, :) .*= beta
         view(C, nzrow+1:size(C,1), :) .*= beta
-        y .= Aval .* view(B, nzcol, :) .* alpha .+ y .* beta
+        y .= Ref(Aval) .* view(B, nzcol, :) .* alpha .+ y .* beta
     end
     C
 end

--- a/src/oneelement.jl
+++ b/src/oneelement.jl
@@ -145,12 +145,12 @@ function mul!(C::AbstractVector, A::OneElementMatrix, B::OneElementVector, alpha
 end
 
 @inline function __mul!(y, A::AbstractMatrix, x::OneElement, alpha, beta)
-    αx = alpha * x.val
+    xα = Ref(x.val * alpha)
     ind1 = x.ind[1]
     if iszero(beta)
-        y .= αx .* view(A, :, ind1)
+        y .= view(A, :, ind1) .* xα
     else
-        y .= αx .* view(A, :, ind1) .+ beta .* y
+        y .= view(A, :, ind1) .* xα .+ y .* beta
     end
     return y
 end
@@ -171,13 +171,14 @@ function _mul!(C::AbstractMatrix, A::AbstractMatrix, B::OneElementMatrix, alpha,
         mul!(C, A, Zeros{eltype(B)}(axes(B)), alpha, beta)
         return C
     end
+    nzrow, nzcol = B.ind
     if iszero(beta)
-        C .= zero(eltype(C))
+        C .= Ref(zero(eltype(C)))
     else
-        view(C, :, 1:B.ind[2]-1) .*= beta
-        view(C, :, B.ind[2]+1:size(C,2)) .*= beta
+        view(C, :, 1:nzcol-1) .*= beta
+        view(C, :, nzcol+1:size(C,2)) .*= beta
     end
-    y = view(C, :, B.ind[2])
+    y = view(C, :, nzcol)
     __mul!(y, A, B, alpha, beta)
     C
 end
@@ -187,17 +188,14 @@ function _mul!(C::AbstractMatrix, A::Diagonal, B::OneElementMatrix, alpha, beta)
         mul!(C, A, Zeros{eltype(B)}(axes(B)), alpha, beta)
         return C
     end
-    if iszero(beta)
-        C .= zero(eltype(C))
-    else
-        view(C, :, 1:B.ind[2]-1) .*= beta
-        view(C, :, B.ind[2]+1:size(C,2)) .*= beta
-    end
-    ABα = A * B * alpha
     nzrow, nzcol = B.ind
+    ABα = A * B * alpha
     if iszero(beta)
-        C[B.ind...] = ABα[B.ind...]
+        C .= Ref(zero(eltype(C)))
+        C[nzrow, nzcol] = ABα[nzrow, nzcol]
     else
+        view(C, :, 1:nzcol-1) .*= beta
+        view(C, :, nzcol+1:size(C,2)) .*= beta
         y = view(C, :, nzcol)
         y .= view(ABα, :, nzcol) .+ y .* beta
     end
@@ -210,19 +208,16 @@ function _mul!(C::AbstractMatrix, A::OneElementMatrix, B::AbstractMatrix, alpha,
         mul!(C, Zeros{eltype(A)}(axes(A)), B, alpha, beta)
         return C
     end
-    if iszero(beta)
-        C .= zero(eltype(C))
-    else
-        view(C, 1:A.ind[1]-1, :) .*= beta
-        view(C, A.ind[1]+1:size(C,1), :) .*= beta
-    end
-    y = view(C, A.ind[1], :)
-    ind2 = A.ind[2]
+    nzrow, nzcol = A.ind
+    y = view(C, nzrow, :)
     Aval = A.val
     if iszero(beta)
-        y .= Aval .* view(B, ind2, :) .* alpha
+        C .= Ref(zero(eltype(C)))
+        y .= Aval .* view(B, nzcol, :) .* alpha
     else
-        y .= Aval .* view(B, ind2, :) .* alpha .+ y .* beta
+        view(C, 1:nzrow-1, :) .*= beta
+        view(C, nzrow+1:size(C,1), :) .*= beta
+        y .= Aval .* view(B, nzcol, :) .* alpha .+ y .* beta
     end
     C
 end
@@ -232,17 +227,14 @@ function _mul!(C::AbstractMatrix, A::OneElementMatrix, B::Diagonal, alpha, beta)
         mul!(C, Zeros{eltype(A)}(axes(A)), B, alpha, beta)
         return C
     end
-    if iszero(beta)
-        C .= zero(eltype(C))
-    else
-        view(C, 1:A.ind[1]-1, :) .*= beta
-        view(C, A.ind[1]+1:size(C,1), :) .*= beta
-    end
-    ABα = A * B * alpha
     nzrow, nzcol = A.ind
+    ABα = A * B * alpha
     if iszero(beta)
-        C[A.ind...] = ABα[A.ind...]
+        C .= Ref(zero(eltype(C)))
+        C[nzrow, nzcol] = ABα[nzrow, nzcol]
     else
+        view(C, 1:nzrow-1, :) .*= beta
+        view(C, nzrow+1:size(C,1), :) .*= beta
         y = view(C, nzrow, :)
         y .= view(ABα, nzrow, :) .+ y .* beta
     end
@@ -256,16 +248,13 @@ function _mul!(C::AbstractVector, A::OneElementMatrix, B::AbstractVector, alpha,
         return C
     end
     nzrow, nzcol = A.ind
+    Aval = A.val
     if iszero(beta)
-        C .= zero(eltype(C))
+        C .= Ref(zero(eltype(C)))
+        C[nzrow] = Aval * B[nzcol] * alpha
     else
         view(C, 1:nzrow-1) .*= beta
         view(C, nzrow+1:size(C,1)) .*= beta
-    end
-    Aval = A.val
-    if iszero(beta)
-        C[nzrow] = Aval * B[nzcol] * alpha
-    else
         C[nzrow] = Aval * B[nzcol] * alpha + C[nzrow] * beta
     end
     C

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2268,6 +2268,25 @@ end
                 @test mul!(C, O, D, 2, 2) == 2 * O * D .+ 2
             end
         end
+        @testset "array elements" begin
+            A = [SMatrix{2,3}(1:6)*(i+j) for i in 1:3, j in 1:2]
+            B = OneElement(SMatrix{3,2}(1:6), (size(A,2),2), (size(A,2),4))
+            C = [SMatrix{2,2}(1:4) for i in 1:size(A,1), j in 1:size(B,2)]
+            @test mul!(copy(C), A, B) == A * B
+            @test mul!(copy(C), A, B, 2, 2) == 2 * A * B + 2 * C
+            B = OneElement(SMatrix{3,2}(1:6), (size(A,2),), (size(A,2),))
+            C = [SMatrix{2,2}(1:4) for i in 1:size(A,1)]
+            @test mul!(copy(C), A, B) == A * B
+            @test mul!(copy(C), A, B, 2, 2) == 2 * A * B + 2 * C
+        end
+        @testset "non-commutative" begin
+            A = [quat(rand(4)...)*(i+j) for i in 1:2, j in 1:3]
+            B = OneElement(quat(rand(4)...), 1, size(A,2))
+            C = [quat(rand(4)...) for i in axes(A,1)]
+            @test mul!(copy(C), A, B) ≈ A * B
+            α, β = quat(0,0,1,0), quat(1,0,1,0)
+            @test mul!(copy(C), A, B, α, β) ≈ mul!(copy(C), A, Array(B), α, β) ≈ A * B * α + C * β
+        end
     end
 
     @testset "multiplication/division by a number" begin


### PR DESCRIPTION
After this,
```julia
julia> using FillArrays, StaticArrays, LinearAlgebra

julia> A = [SMatrix{2,3}(1:6)*(i+j) for i in 1:3, j in 1:2]
3×2 Matrix{SMatrix{2, 3, Int64, 6}}:
 [2 6 10; 4 8 12]    [3 9 15; 6 12 18]
 [3 9 15; 6 12 18]   [4 12 20; 8 16 24]
 [4 12 20; 8 16 24]  [5 15 25; 10 20 30]

julia> B = OneElement(SMatrix{3,2}(1:6), (2,2), (2,4))
2×4 OneElement{SMatrix{3, 2, Int64, 6}, 2, Tuple{Int64, Int64}, Tuple{Base.OneTo{Int64}, Base.OneTo{Int64}}}:
        ⋅                ⋅                ⋅                ⋅       
        ⋅         [1 4; 2 5; 3 6]         ⋅                ⋅       

julia> C = [SMatrix{2,2}(1:4) for i in 1:size(A,1), j in 1:4]
3×4 Matrix{SMatrix{2, 2, Int64, 4}}:
 [1 3; 2 4]  [1 3; 2 4]  [1 3; 2 4]  [1 3; 2 4]
 [1 3; 2 4]  [1 3; 2 4]  [1 3; 2 4]  [1 3; 2 4]
 [1 3; 2 4]  [1 3; 2 4]  [1 3; 2 4]  [1 3; 2 4]

julia> mul!(copy(C), A, B, 1, 2) == A * B + 2C
true
```