### PR TITLE
Change downstream tests fail fast to false

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -29,7 +29,7 @@ jobs:
     name: ${{ matrix.package.group }}/${{ matrix.package.repo }}/${{ matrix.julia-version }}
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         julia-version: ['1']
         os: [ubuntu-latest]


### PR DESCRIPTION
This should indicate the exact number of downstream packages that are broken by a change.