### PR TITLE
Disable downstream tests against broken packages

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -36,9 +36,9 @@ jobs:
         package:
           - {repo: Distributions.jl, group: JuliaStats}
           - {repo: BlockArrays.jl, group: JuliaArrays}
-          - {repo: LazyArrays.jl, group: JuliaArrays}
+          # - {repo: LazyArrays.jl, group: JuliaArrays}
           - {repo: ArrayLayouts.jl, group: JuliaLinearAlgebra}
-          - {repo: LazyBandedMatrices.jl, group: JuliaLinearAlgebra}
+          # - {repo: LazyBandedMatrices.jl, group: JuliaLinearAlgebra}
           - {repo: BandedMatrices.jl, group: JuliaLinearAlgebra}
           - {repo: BlockBandedMatrices.jl, group: JuliaLinearAlgebra}
           - {repo: InfiniteLinearAlgebra.jl, group: JuliaLinearAlgebra}

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -41,7 +41,7 @@ jobs:
           # - {repo: LazyBandedMatrices.jl, group: JuliaLinearAlgebra}
           - {repo: BandedMatrices.jl, group: JuliaLinearAlgebra}
           - {repo: BlockBandedMatrices.jl, group: JuliaLinearAlgebra}
-          - {repo: InfiniteLinearAlgebra.jl, group: JuliaLinearAlgebra}
+          # - {repo: InfiniteLinearAlgebra.jl, group: JuliaLinearAlgebra}
           - {repo: Optim.jl, group: JuliaNLSolvers}
 
     steps:


### PR DESCRIPTION
LazyArrays and LazyBandedMatrices have known breakages on v1.10, so these tests need to be disabled until these are fixed.