### PR TITLE
Function to query the non-zero index of a OneElement

### DIFF
--- a/src/oneelement.jl
+++ b/src/oneelement.jl
@@ -47,6 +47,15 @@ Base.@propagate_inbounds function Base.getindex(A::OneElement{T,N}, kj::Vararg{I
     ifelse(kj == A.ind, A.val, zero(T))
 end
 
+"""
+    nzind(A::OneElement)
+
+Return the index where `A` contains a non-zero value.
+The indices are not guaranteed to lie within the valid index bounds for `A`,
+and if `all(!in.(nzind(A), axes(A)))` then `all(iszero, A)`.
+"""
+nzind(f::OneElement) = f.ind
+
 getindex_value(A::OneElement) = all(in.(A.ind, axes(A))) ? A.val : zero(eltype(A))
 
 Base.AbstractArray{T,N}(A::OneElement{<:Any,N}) where {T,N} = OneElement(T(A.val), A.ind, A.axes)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2044,13 +2044,13 @@ end
 
 @testset "OneElement" begin
     A = OneElement(2, (), ())
-    @test FillArrays.nzind(A) == ()
+    @test FillArrays.nzind(A) == CartesianIndex()
     @test A == Fill(2, ())
     @test A[] === 2
 
     e₁ = OneElement(2, 5)
     @test e₁ == [0,1,0,0,0]
-    @test FillArrays.nzind(e₁) == (2,)
+    @test FillArrays.nzind(e₁) == CartesianIndex(2)
     @test_throws BoundsError e₁[6]
 
     f₁ = AbstractArray{Float64}(e₁)
@@ -2070,7 +2070,7 @@ end
 
     V = OneElement(2, (2,3), (3,4))
     @test V == [0 0 0 0; 0 0 2 0; 0 0 0 0]
-    @test FillArrays.nzind(V) == (2,3)
+    @test FillArrays.nzind(V) == CartesianIndex(2,3)
 
     Vf = AbstractArray{Float64}(V)
     @test Vf isa OneElement{Float64,2}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2044,11 +2044,13 @@ end
 
 @testset "OneElement" begin
     A = OneElement(2, (), ())
+    @test FillArrays.nzind(A) == ()
     @test A == Fill(2, ())
     @test A[] === 2
 
     e₁ = OneElement(2, 5)
     @test e₁ == [0,1,0,0,0]
+    @test FillArrays.nzind(e₁) == (2,)
     @test_throws BoundsError e₁[6]
 
     f₁ = AbstractArray{Float64}(e₁)
@@ -2068,6 +2070,7 @@ end
 
     V = OneElement(2, (2,3), (3,4))
     @test V == [0 0 0 0; 0 0 2 0; 0 0 0 0]
+    @test FillArrays.nzind(V) == (2,3)
 
     Vf = AbstractArray{Float64}(V)
     @test Vf isa OneElement{Float64,2}


### PR DESCRIPTION
This adds a public function to query the index at which a `OneElement` contains a non-zero value.
```julia
julia> O = OneElement(3, (1,2), (4,5))
4×5 OneElement{Int64, 2, Tuple{Int64, Int64}, Tuple{Base.OneTo{Int64}, Base.OneTo{Int64}}}:
 ⋅  3  ⋅  ⋅  ⋅
 ⋅  ⋅  ⋅  ⋅  ⋅
 ⋅  ⋅  ⋅  ⋅  ⋅
 ⋅  ⋅  ⋅  ⋅  ⋅

julia> FillArrays.nzind(O)
CartesianIndex(1, 2)
```
This complements `getindex_value`, which returns the stored value, and `size`, which returns the size. With this, we may obtain all the input arguments without accessing the fields of the struct.