### PR TITLE
Pretty-printing for OneElement

### DIFF
--- a/src/oneelement.jl
+++ b/src/oneelement.jl
@@ -174,3 +174,10 @@ end
 function broadcasted(::DefaultArrayStyle{N}, ::typeof(\), x::Number, r::OneElement{<:Any,N}) where {N}
     OneElement(x \ r.val, r.ind, axes(r))
 end
+
+# show
+_maybesize(t::Tuple{Base.OneTo{Int}, Vararg{Base.OneTo{Int}}}) = size.(t,1)
+_maybesize(t) = t
+Base.show(io::IO, A::OneElement) = print(io, OneElement, "(", A.val, ", ", A.ind, ", ", _maybesize(axes(A)), ")")
+Base.show(io::IO, A::OneElement{<:Any,1,Tuple{Int},Tuple{Base.OneTo{Int}}}) =
+    print(io, OneElement, "(", A.val, ", ", A.ind[1], ", ", size(A,1), ")")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2226,6 +2226,15 @@ end
             @test n .\ v == n .\ w
         end
     end
+
+    @testset "show" begin
+        B = OneElement(2, (1, 2), (3, 4))
+        @test repr(B) == "OneElement(2, (1, 2), (3, 4))"
+        B = OneElement(2, 1, 3)
+        @test repr(B) == "OneElement(2, 1, 3)"
+        B = OneElement(2, (1, 2), (Base.IdentityUnitRange(1:1), Base.IdentityUnitRange(2:2)))
+        @test repr(B) == "OneElement(2, (1, 2), (Base.IdentityUnitRange(1:1), Base.IdentityUnitRange(2:2)))"
+    end
 end
 
 @testset "repeat" begin


### PR DESCRIPTION
After this,
```julia
julia> B = OneElement(2, 1, 3);

julia> show(B)
OneElement(2, 1, 3)
```
The displayed form is a valid constructor, and is a compact representation.