### PR TITLE
Specialize isassigned for AbstractFill

### DIFF
--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -33,7 +33,7 @@ const AbstractFillVecOrMat{T} = Union{AbstractFillVector{T},AbstractFillMatrix{T
 ==(a::AbstractFill, b::AbstractFill) = axes(a) == axes(b) && getindex_value(a) == getindex_value(b)
 
 @inline function Base.isassigned(F::AbstractFill, i::Integer...)
-    @boundscheck checkbounds(Bool, F, i...) || return false
+    @boundscheck checkbounds(Bool, F, to_indices(F, i)...) || return false
     return true
 end
 

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -41,6 +41,11 @@ end
 Base.@propagate_inbounds getindex(F::AbstractFill, k::Integer) = _fill_getindex(F, k)
 Base.@propagate_inbounds getindex(F::AbstractFill{T, N}, kj::Vararg{Integer, N}) where {T, N} = _fill_getindex(F, kj...)
 
+@inline function Base.isassigned(F::AbstractFill, i::Union{Integer, CartesianIndex}...)
+    @boundscheck checkbounds(Bool, F, i...) || return false
+    return true
+end
+
 @inline function setindex!(F::AbstractFill, v, k::Integer)
     @boundscheck checkbounds(F, k)
     v == getindex_value(F) || throw(ArgumentError("Cannot setindex! to $v for an AbstractFill with value $(getindex_value(F))."))

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -32,6 +32,10 @@ const AbstractFillVecOrMat{T} = Union{AbstractFillVector{T},AbstractFillMatrix{T
 
 ==(a::AbstractFill, b::AbstractFill) = axes(a) == axes(b) && getindex_value(a) == getindex_value(b)
 
+@inline function Base.isassigned(F::AbstractFill, i::Integer...)
+    @boundscheck checkbounds(Bool, F, i...) || return false
+    return true
+end
 
 @inline function _fill_getindex(F::AbstractFill, kj::Integer...)
     @boundscheck checkbounds(F, kj...)
@@ -40,11 +44,6 @@ end
 
 Base.@propagate_inbounds getindex(F::AbstractFill, k::Integer) = _fill_getindex(F, k)
 Base.@propagate_inbounds getindex(F::AbstractFill{T, N}, kj::Vararg{Integer, N}) where {T, N} = _fill_getindex(F, kj...)
-
-@inline function Base.isassigned(F::AbstractFill, i::Union{Integer, CartesianIndex}...)
-    @boundscheck checkbounds(Bool, F, i...) || return false
-    return true
-end
 
 @inline function setindex!(F::AbstractFill, v, k::Integer)
     @boundscheck checkbounds(F, k)

--- a/src/oneelement.jl
+++ b/src/oneelement.jl
@@ -49,6 +49,11 @@ end
 
 getindex_value(A::OneElement) = all(in.(A.ind, axes(A))) ? A.val : zero(eltype(A))
 
+@inline function Base.isassigned(F::OneElement, i::Integer...)
+    @boundscheck checkbounds(Bool, F, to_indices(F, i)...) || return false
+    return true
+end
+
 Base.AbstractArray{T,N}(A::OneElement{<:Any,N}) where {T,N} = OneElement(T(A.val), A.ind, A.axes)
 
 Base.replace_in_print_matrix(o::OneElementVector, k::Integer, j::Integer, s::AbstractString) =

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -261,6 +261,14 @@ end
     end
 end
 
+@testset "isassigned" begin
+    for f in (Fill("", 3, 4), Zeros(3,4), Ones(3,4))
+        @test !isassigned(f, 0, 0)
+        @test isassigned(f, 2, 2)
+        @test !isassigned(f, 10, 10)
+    end
+end
+
 @testset "indexing" begin
     A = Fill(3.0,5)
     @test A[1:3] ≡ Fill(3.0,3)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -266,6 +266,7 @@ end
         @test !isassigned(f, 0, 0)
         @test isassigned(f, 2, 2)
         @test !isassigned(f, 10, 10)
+        @test_throws ArgumentError isassigned(f, true)
     end
 end
 
@@ -2125,6 +2126,14 @@ end
         @test adjoint(A) isa Adjoint
         @test transpose(A) == OneElement(3, (1,2), (1,4))
         @test adjoint(A) == OneElement(3, (1,2), (1,4))
+    end
+
+    @testset "isassigned" begin
+        f = OneElement(2, (3,3), (4,4))
+        @test !isassigned(f, 0, 0)
+        @test isassigned(f, 2, 2)
+        @test !isassigned(f, 10, 10)
+        @test_throws ArgumentError isassigned(f, true)
     end
 
     @testset "matmul" begin


### PR DESCRIPTION
Since an `AbstractFill` is by definition filled with values, we may short-circuit `isassigned`:
```julia
julia> F = Fill(3, 100, 100);

julia> @btime isassigned($(Ref(F))[], 1, 1)
  24.297 ns (0 allocations: 0 bytes) # master
  3.360 ns (0 allocations: 0 bytes) # PR
```