### PR TITLE
Remove single-argument map tests on nightly

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1132,7 +1132,7 @@ end
     @test_throws DimensionMismatch map(+, x2', x2)
 
     # Issue https://github.com/JuliaArrays/FillArrays.jl/issues/179
-    if VERSION < v"1.11.0-"
+    if VERSION < v"1.11.0-"  # In 1.11, 1-arg map & mapreduce was removed
         @test map(() -> "ok") == "ok"  # was MethodError: reducing over an empty collection is not allowed
         @test mapreduce(() -> "ok", *) == "ok"
     else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1132,8 +1132,13 @@ end
     @test_throws DimensionMismatch map(+, x2', x2)
 
     # Issue https://github.com/JuliaArrays/FillArrays.jl/issues/179
-    @test map(() -> "ok") == "ok"  # was MethodError: reducing over an empty collection is not allowed
-    @test mapreduce(() -> "ok", *) == "ok"
+    if VERSION < v"1.11.0-"
+        @test map(() -> "ok") == "ok"  # was MethodError: reducing over an empty collection is not allowed
+        @test mapreduce(() -> "ok", *) == "ok"
+    else
+        @test_throws "no method matching map" map(() -> "ok")
+        @test_throws "no method matching map" mapreduce(() -> "ok", *)
+    end
 end
 
 @testset "mapreduce" begin


### PR DESCRIPTION
The single-argument `map(f)` method has been removed in https://github.com/JuliaLang/julia/pull/52631, so the explicit tests for these need to be altered. These tests aren't directly related to this package, and were checking for type-piracy.