### PR TITLE
Bugfix in matrix multiplication involving adj/trans

### DIFF
--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -237,7 +237,12 @@ end
 _firstcol(C::AbstractMatrix) = first(eachcol(C))
 
 function copyfirstrow!(C)
-    C[begin+1:end, :] .= permutedims(_firstrow(C))
+    # C[begin+1:end, ind] .= permutedims(_firstrow(C))
+    # we loop here as the aliasing check isn't smart enough to
+    # detect that the two sides don't alias, and ends up materializing the RHS
+    for (ind, v) in pairs(_firstrow(C))
+        C[begin+1:end, ind] .= Ref(v)
+    end
     return C
 end
 _firstrow(C::AbstractMatrix) = first(eachrow(C))

--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -230,7 +230,9 @@ function mul!(C::AbstractMatrix, A::AbstractFillMatrix, B::AbstractFillMatrix, a
 end
 
 function copyfirstcol!(C)
-    C[:, begin+1:end] .= _firstcol(C)
+    @views for i in axes(C,2)[2:end]
+        C[:, i] .= C[:, 1]
+    end
     return C
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1701,7 +1701,7 @@ end
     @test (1:5)'E == (1.0:5)'
     @test E*E ≡ E
 
-    @testset for T in (Float64, ComplexF64)
+    for T in (Float64, ComplexF64)
         fv = T == Float64 ? Float64(1.6) : ComplexF64(1.6, 1.3)
         n  = 10
         k  = 12

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1701,7 +1701,7 @@ end
     @test (1:5)'E == (1.0:5)'
     @test E*E ≡ E
 
-    for T in (Float64, ComplexF64)
+    @testset for T in (Float64, ComplexF64)
         fv = T == Float64 ? Float64(1.6) : ComplexF64(1.6, 1.3)
         n  = 10
         k  = 12
@@ -1716,6 +1716,16 @@ end
         @test transpose(A)*fillmat ≈ transpose(A)*Array(fillmat)
         @test adjoint(A)*fillvec ≈ adjoint(A)*Array(fillvec)
         @test adjoint(A)*fillmat ≈ adjoint(A)*Array(fillmat)
+
+        # inplace C = F * B' * alpha + C * beta
+        F = Fill(fv, m, k)
+        A = Array(F)
+        B = rand(T, n, k)
+        C = rand(T, m, n)
+        @testset for f in (adjoint, transpose)
+            @test mul!(copy(C), F, f(B)) ≈ mul!(copy(C), A, f(B))
+            @test mul!(copy(C), F, f(B), 1.0, 2.0) ≈ mul!(copy(C), A, f(B), 1.0, 2.0)
+        end
     end
 
     @testset "non-commutative" begin


### PR DESCRIPTION
The current implementation evaluated the matrix multiplication by computing the first column, and then copying it over to the other columns. This was incorrect for the 5-term case with a non-zero beta, in which the destination was being overwritten instead of being added to. This PR fixes this. To evaluate the 5-term multiplication efficiently, we now allocate one row/column of `A*B*alpha`, and broadcast this over `C`. This leads to `O(N)` allocations in `mul!`, but reduces the time complexity from `O(N^3)` to `O(N^2)`. To me, this compromise seems reasonable. There is no allocation necessary in the 3-term multiplication case, so `A*B` is not impacted by this.

We now also have matrix-multiplication implementations for both the orderings `mul!(C, F::Fill, B, alpha, beta)` and `mul!(C, A, F::Fill, alpha, beta)`. We implement this by specializing the internal function `_mulfill!`. This way, we don't need to compute `mul!(C, F, B', alpha, beta)` as `mul!(C', B, F', alpha, beta)` anymore. The latter may be incorrect for non-commuting numbers such as quaternions. The implementation in this PR is more general and makes no assumptions, so this should be correct for all element types.

Performance:
```julia
julia> C = rand(ComplexF64, 400, 400); A = Fill(2.0im, 400, 400); B = rand(ComplexF64,400,400);

julia> @btime mul!($C, $A, $B, 1.0, 1.0);
  358.940 μs (3 allocations: 6.47 KiB)

julia> @btime mul!($C, $A, $B', 1.0, 1.0);
  401.662 μs (3 allocations: 6.47 KiB)

julia> @btime mul!($C, $(Array(A)), $B, 1.0, 1.0);
  3.543 ms (0 allocations: 0 bytes)
```