### PR TITLE
Ensure correct eltype in 3-term dot involving Eye

### DIFF
--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -399,7 +399,7 @@ dot(a::AbstractVector, b::AbstractFillVector) = _fill_dot_rev(a, b)
 function dot(u::AbstractVector, E::Eye, v::AbstractVector)
     length(u) == size(E,1) && length(v) == size(E,2) ||
         throw(DimensionMismatch("dot product arguments have dimensions $(length(u))×$(size(E))×$(length(v))"))
-    dot(u, v)
+    one(eltype(E)) * dot(u, v)
 end
 
 function dot(u::AbstractVector, D::Diagonal{<:Any,<:Fill}, v::AbstractVector)

--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -399,7 +399,9 @@ dot(a::AbstractVector, b::AbstractFillVector) = _fill_dot_rev(a, b)
 function dot(u::AbstractVector, E::Eye, v::AbstractVector)
     length(u) == size(E,1) && length(v) == size(E,2) ||
         throw(DimensionMismatch("dot product arguments have dimensions $(length(u))×$(size(E))×$(length(v))"))
-    one(eltype(E)) * dot(u, v)
+    d = dot(u,v)
+    T = typeof(one(eltype(E)) * d)
+    convert(T, d)
 end
 
 function dot(u::AbstractVector, D::Diagonal{<:Any,<:Fill}, v::AbstractVector)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1927,6 +1927,8 @@ end
         @test dot(Fill(2,N),1:N) == dot(Fill(2,N),1:N) == dot(1:N,Fill(2,N)) == 2*sum(1:N)
     end
 
+    @test dot(1:4, Eye(4), 1:4) === dot(1:4, oneunit(eltype(Eye(4))) * I(4), 1:4)
+
     @test_throws DimensionMismatch dot(u[1:end-1], D, v)
     @test_throws DimensionMismatch dot(u[1:end-1], D, v[1:end-1])
 


### PR DESCRIPTION
Currently,
```julia
julia> dot(1:2, Eye(2), 1:2)
5
```
This ignores the element type of `Eye`. After this PR,
```julia
julia> dot(1:2, Eye(2), 1:2)
5.0
```