### PR TITLE
Improve performance in Fill addition

### DIFF
--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -463,7 +463,7 @@ end
 
 @inline function fill_add(a::AbstractArray, b::AbstractFill)
     promote_shape(a, b)
-    a .+ [getindex_value(b)]
+    a .+ (getindex_value(b),)
 end
 @inline function fill_add(a::AbstractArray{<:Number}, b::AbstractFill)
     promote_shape(a, b)


### PR DESCRIPTION
On master
```julia
julia> F = Fill(SMatrix{2,2}(1:4), 2, 2); M = Matrix(F);

julia> @btime $F + $M;
  65.964 ns (2 allocations: 288 bytes)
```
This PR
```julia
julia> @btime $F + $M;
  44.739 ns (1 allocation: 192 bytes)
```
We avoid the extra allocation of a 1-element vector that is there to only ensure scalar-like broadcasting. The same may be achieved by using a `Tuple`.