### PR TITLE
Don't specialize Base._reshape

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -40,12 +40,13 @@ jobs:
         package:
           - {repo: Distributions.jl, group: JuliaStats}
           - {repo: BlockArrays.jl, group: JuliaArrays}
-          # - {repo: LazyArrays.jl, group: JuliaArrays}
+          - {repo: LazyArrays.jl, group: JuliaArrays}
+          - {repo: InfiniteArrays.jl, group: JuliaArrays}
           - {repo: ArrayLayouts.jl, group: JuliaLinearAlgebra}
-          # - {repo: LazyBandedMatrices.jl, group: JuliaLinearAlgebra}
+          - {repo: LazyBandedMatrices.jl, group: JuliaLinearAlgebra}
           - {repo: BandedMatrices.jl, group: JuliaLinearAlgebra}
           - {repo: BlockBandedMatrices.jl, group: JuliaLinearAlgebra}
-          # - {repo: InfiniteLinearAlgebra.jl, group: JuliaLinearAlgebra}
+          - {repo: InfiniteLinearAlgebra.jl, group: JuliaLinearAlgebra}
           - {repo: Optim.jl, group: JuliaNLSolvers}
 
     steps:

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -272,16 +272,11 @@ reshape(parent::AbstractFill, dims::Tuple{Vararg{Union{Int,Colon}}}) =
     fill_reshape(parent, Base._reshape_uncolon(parent, dims)...)
 reshape(parent::AbstractFill, shp::Tuple{Union{Integer,Base.OneTo}, Vararg{Union{Integer,Base.OneTo}}}) =
     reshape(parent, Base.to_shape(shp))
-reshape(parent::AbstractFill, dims::Dims)        = Base._reshape(parent, dims)
-reshape(parent::AbstractFill, dims::Tuple{Integer, Vararg{Integer}})        = Base._reshape(parent, dims)
+reshape(parent::AbstractFill, dims::Dims) = fill_reshape(parent, dims...)
+reshape(parent::AbstractFill, dims::Tuple{Integer, Vararg{Integer}}) = fill_reshape(parent, dims...)
 
 # resolve ambiguity with Base
 reshape(parent::AbstractFillVector, dims::Tuple{Colon}) = parent
-
-Base._reshape(parent::AbstractFill, dims::Dims) = fill_reshape(parent, dims...)
-Base._reshape(parent::AbstractFill, dims::Tuple{Integer,Vararg{Integer}}) = fill_reshape(parent, dims...)
-# Resolves ambiguity error with `_reshape(v::AbstractArray{T, 1}, dims::Tuple{Int})`
-Base._reshape(parent::AbstractFill{T, 1, Axes}, dims::Tuple{Int}) where {T, Axes} = fill_reshape(parent, dims...)
 
 for (AbsTyp, Typ, funcs, func) in ((:AbstractZeros, :Zeros, :zeros, :zero), (:AbstractOnes, :Ones, :ones, :one))
     @eval begin


### PR DESCRIPTION
The specialized methods seem to merely call `fill_reshape`, so there is no need to specialize this internal function. We may directly call `fill_reshape` instead.