### PR TITLE
sum for OneElement

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FillArrays"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "1.12.0"
+version = "1.13.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/oneelement.jl
+++ b/src/oneelement.jl
@@ -433,4 +433,11 @@ Base.show(io::IO, A::OneElement{<:Any,1,Tuple{Int},Tuple{Base.OneTo{Int}}}) =
     print(io, OneElement, "(", A.val, ", ", A.ind[1], ", ", size(A,1), ")")
 
 # mapreduce
-Base.sum(O::OneElement) = sum(getindex_value(O))
+Base.sum(O::OneElement; dims=:) = _sum(O, dims)
+_sum(O::OneElement, ::Colon) = sum(getindex_value(O))
+function _sum(O::OneElement, dims)
+    v = sum(getindex_value(O))
+    ax = Base.reduced_indices(axes(O), dims)
+    ind = ntuple(x -> x in dims ? first(ax[x]) + (O.ind[x] in axes(O)[x]) - 1 : O.ind[x], ndims(O))
+    OneElement(v, ind, ax)
+end

--- a/src/oneelement.jl
+++ b/src/oneelement.jl
@@ -157,13 +157,6 @@ function *(A::OneElementMatrix, B::OneElementVecOrMat)
     OneElement(val, (A.ind[1], B.ind[2:end]...), (axes(A,1), axes(B)[2:end]...))
 end
 
-function *(A::AbstractFillMatrix, x::OneElementVector)
-    check_matmul_sizes(A, x)
-    val = getindex_value(A) * getindex_value(x)
-    Fill(val, (axes(A,1),))
-end
-*(A::AbstractZerosMatrix, x::OneElementVector) = mult_zeros(A, x)
-
 *(A::OneElementMatrix, x::AbstractZerosVector) = mult_zeros(A, x)
 
 function *(A::OneElementMatrix, B::AbstractFillVector)
@@ -438,3 +431,6 @@ _maybesize(t) = t
 Base.show(io::IO, A::OneElement) = print(io, OneElement, "(", A.val, ", ", A.ind, ", ", _maybesize(axes(A)), ")")
 Base.show(io::IO, A::OneElement{<:Any,1,Tuple{Int},Tuple{Base.OneTo{Int}}}) =
     print(io, OneElement, "(", A.val, ", ", A.ind[1], ", ", size(A,1), ")")
+
+# mapreduce
+Base.sum(O::OneElement) = sum(getindex_value(O))

--- a/src/oneelement.jl
+++ b/src/oneelement.jl
@@ -433,10 +433,10 @@ Base.show(io::IO, A::OneElement{<:Any,1,Tuple{Int},Tuple{Base.OneTo{Int}}}) =
     print(io, OneElement, "(", A.val, ", ", A.ind[1], ", ", size(A,1), ")")
 
 # mapreduce
-Base.sum(O::OneElement; dims=:) = _sum(O, dims)
-_sum(O::OneElement, ::Colon) = sum(getindex_value(O))
-function _sum(O::OneElement, dims)
-    v = sum(getindex_value(O))
+Base.sum(O::OneElement; dims=:, kw...) = _sum(O, dims; kw...)
+_sum(O::OneElement, ::Colon; kw...) = sum((getindex_value(O),); kw...)
+function _sum(O::OneElement, dims; kw...)
+    v = _sum(O, :; kw...)
     ax = Base.reduced_indices(axes(O), dims)
     ind = ntuple(x -> x in dims ? first(ax[x]) + (O.ind[x] in axes(O)[x]) - 1 : O.ind[x], ndims(O))
     OneElement(v, ind, ax)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2708,17 +2708,22 @@ end
         O = OneElement(3.0,0,0)
         @test @inferred(sum(O)) === 0.0
 
-        O = OneElement(Int8(2), (1,2), (2,2))
-        A = Array(O)
-        for i in 1:3
-            @test @inferred(sum(O, dims=i)) == sum(A, dims=i)
+        for O in (OneElement(Int8(2), (1,2), (2,4)),
+                    OneElement(3, (1,2,3), (2,4,4)),
+                    OneElement(2.0, (3,2,5), (2,3,2)))
+            A = Array(O)
+            for i in 1:3
+                @test @inferred(sum(O, dims=i)) == sum(A, dims=i)
+            end
+            @test @inferred(sum(O, dims=1:1)) == sum(A, dims=1:1)
+            @test @inferred(sum(O, dims=1:2)) == sum(A, dims=1:2)
+            @test @inferred(sum(O, dims=1:3)) == sum(A, dims=1:3)
+            @test @inferred(sum(O, dims=(1,))) == sum(A, dims=(1,))
+            @test @inferred(sum(O, dims=(1,2))) == sum(A, dims=(1,2))
+            @test @inferred(sum(O, dims=(1,3))) == sum(A, dims=(1,3))
+            @test @inferred(sum(O, dims=(2,3))) == sum(A, dims=(2,3))
+            @test @inferred(sum(O, dims=(1,2,3))) == sum(A, dims=(1,2,3))
         end
-        @test @inferred(sum(O, dims=1:1)) == sum(A, dims=1:1)
-        @test @inferred(sum(O, dims=1:2)) == sum(A, dims=1:2)
-        @test @inferred(sum(O, dims=1:3)) == sum(A, dims=1:3)
-        @test @inferred(sum(O, dims=(1,))) == sum(A, dims=(1,))
-        @test @inferred(sum(O, dims=(1,2))) == sum(A, dims=(1,2))
-        @test @inferred(sum(O, dims=(1,2,3))) == sum(A, dims=(1,2,3))
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2702,11 +2702,23 @@ end
 
     @testset "sum" begin
         O = OneElement(Int8(2),3,4)
-        @test sum(O) === 2
+        @test @inferred(sum(O)) === 2
         O = OneElement(3.0,5,4)
-        @test sum(O) === 0.0
+        @test @inferred(sum(O)) === 0.0
         O = OneElement(3.0,0,0)
-        @test sum(O) === 0.0
+        @test @inferred(sum(O)) === 0.0
+
+        O = OneElement(Int8(2), (1,2), (2,2))
+        A = Array(O)
+        for i in 1:3
+            @test @inferred(sum(O, dims=i)) == sum(A, dims=i)
+        end
+        @test @inferred(sum(O, dims=1:1)) == sum(A, dims=1:1)
+        @test @inferred(sum(O, dims=1:2)) == sum(A, dims=1:2)
+        @test @inferred(sum(O, dims=1:3)) == sum(A, dims=1:3)
+        @test @inferred(sum(O, dims=(1,))) == sum(A, dims=(1,))
+        @test @inferred(sum(O, dims=(1,2))) == sum(A, dims=(1,2))
+        @test @inferred(sum(O, dims=(1,2,3))) == sum(A, dims=(1,2,3))
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2699,6 +2699,15 @@ end
         B = OneElement(2, (1, 2), (Base.IdentityUnitRange(1:1), Base.IdentityUnitRange(2:2)))
         @test repr(B) == "OneElement(2, (1, 2), (Base.IdentityUnitRange(1:1), Base.IdentityUnitRange(2:2)))"
     end
+
+    @testset "sum" begin
+        O = OneElement(Int8(2),3,4)
+        @test sum(O) === 2
+        O = OneElement(3.0,5,4)
+        @test sum(O) === 0.0
+        O = OneElement(3.0,0,0)
+        @test sum(O) === 0.0
+    end
 end
 
 @testset "repeat" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2701,15 +2701,20 @@ end
     end
 
     @testset "sum" begin
-        @testset "OneElement($v, $ind, $sz)" for ((v, ind, sz), s) in (
-                                    ((Int8(2), 3, 4), 2),
-                                    ((3.0, 5, 4), 0.0),
-                                    ((3.0, 0, 0), 0.0),
-                                    ((SMatrix{2,2}(1:4), (4, 2), (12,6)), SMatrix{2,2}(1:4)),
+        @testset "OneElement($v, $ind, $sz)" for (v, ind, sz) in (
+                                    (Int8(2), 3, 4),
+                                    (3.0, 5, 4),
+                                    (3.0, 0, 0),
+                                    (SMatrix{2,2}(1:4), (4, 2), (12,6)),
                                 )
             O = OneElement(v,ind,sz)
-            @test @inferred(sum(O)) === s
-            @test @inferred(sum(O, init=sum((zero(v),)))) === s
+            A = Array(O)
+            if VERSION >= v"1.10"
+                @test @inferred(sum(O)) === sum(A)
+            else
+                @test @inferred(sum(O)) == sum(A)
+            end
+            @test @inferred(sum(O, init=zero(eltype(O)))) === sum(A, init=zero(eltype(O)))
             @test @inferred(sum(x->1, O, init=0)) === sum(Fill(1, axes(O)), init=0)
         end
 


### PR DESCRIPTION
This computes the `sum` over a `OneElement` in O(1). Along with the new `FillMatrix` multiplication method, this also means that we don't need to specialize `::AbstractFillMatrix * ::OneElementVector` anymore. 