### PR TITLE
Use isreal instead of iszero-isimag in ishermitian

### DIFF
--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -67,7 +67,7 @@ rank(F::AbstractFill) = iszero(getindex_value(F)) ? 0 : 1
 IndexStyle(::Type{<:AbstractFill{<:Any,N,<:NTuple{N,Base.OneTo{Int}}}}) where N = IndexLinear()
 
 issymmetric(F::AbstractFillMatrix) = axes(F,1) == axes(F,2)
-ishermitian(F::AbstractFillMatrix) = issymmetric(F) && iszero(imag(getindex_value(F)))
+ishermitian(F::AbstractFillMatrix) = issymmetric(F) && isreal(getindex_value(F))
 
 Base.IteratorSize(::Type{<:AbstractFill{T,N,Axes}}) where {T,N,Axes} = _IteratorSize(Axes)
 _IteratorSize(::Type{Tuple{}}) = Base.HasShape{0}()


### PR DESCRIPTION
The current implementation seems a bit roundabout, and we may directly use `isreal` here.