### PR TITLE
Fix issymmetric/ishermitian for block and empty matrices

### DIFF
--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -66,8 +66,8 @@ end
 rank(F::AbstractFill) = iszero(getindex_value(F)) ? 0 : 1
 IndexStyle(::Type{<:AbstractFill{<:Any,N,<:NTuple{N,Base.OneTo{Int}}}}) where N = IndexLinear()
 
-issymmetric(F::AbstractFillMatrix) = axes(F,1) == axes(F,2)
-ishermitian(F::AbstractFillMatrix) = issymmetric(F) && iszero(imag(getindex_value(F)))
+issymmetric(F::AbstractFillMatrix) = axes(F,1) == axes(F,2) && (isempty(F) || issymmetric(getindex_value(F)))
+ishermitian(F::AbstractFillMatrix) = axes(F,1) == axes(F,2) && (isempty(F) || ishermitian(getindex_value(F)))
 
 Base.IteratorSize(::Type{<:AbstractFill{T,N,Axes}}) where {T,N,Axes} = _IteratorSize(Axes)
 _IteratorSize(::Type{Tuple{}}) = Base.HasShape{0}()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -608,7 +608,7 @@ end
 end
 
 @testset "ishermitian" begin
-    for el in (2, 3+0im, 4+5im), size in [(3,3), (3,4)]
+    @testset for el in (2, 3+0im, 4+5im, [1 2; 3 4], fill(2, 2, 2)), size in [(3,3), (3,4), (0,0), (0,1)]
         @test issymmetric(Fill(el, size...)) == issymmetric(fill(el, size...))
         @test ishermitian(Fill(el, size...)) == ishermitian(fill(el, size...))
     end


### PR DESCRIPTION
Fixes the following discrepancies, accounting for the fact that `issymmetric` returns true for an empty matrix, and that it acts recursively:
```julia
julia> F = Fill([1 2; 3 4], 2, 2);

julia> issymmetric(F)
true

julia> issymmetric(Array(F))
false

julia> F = Fill(im, 0, 0);

julia> ishermitian(F)
false

julia> ishermitian(Array(F))
true
```