### PR TITLE
Fix reshape for OneElement when indices lie outside axes

### DIFF
--- a/src/oneelement.jl
+++ b/src/oneelement.jl
@@ -420,9 +420,14 @@ end
 
 function Base.reshape(A::OneElement, shape::Tuple{Vararg{Int}})
     prod(shape) == length(A) || throw(DimensionMismatch("new dimension $shape must be consistent with array size $(length(A))"))
-    # we use the fact that the linear index of the non-zero value is preserved
-    oldlinind = LinearIndices(A)[A.ind...]
-    newcartind = CartesianIndices(shape)[oldlinind]
+    if all(in.(A.ind, axes(A)))
+        # we use the fact that the linear index of the non-zero value is preserved
+        oldlinind = LinearIndices(A)[A.ind...]
+        newcartind = CartesianIndices(shape)[oldlinind]
+    else
+        # arbitrarily set to some value outside the domain
+        newcartind = shape .+ 1
+    end
     OneElement(A.val, Tuple(newcartind), shape)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2326,6 +2326,10 @@ end
         end
         O = OneElement(2, (), ())
         @test reshape(O, ()) === O
+
+        O = OneElement(5, 3)
+        @test reshape(O, 1, 3) == reshape(Array(O), 1, 3)
+        @test reshape(reshape(O, 1, 3), 3) == O
     end
 
     @testset "isassigned" begin


### PR DESCRIPTION
Fixes issues like
```julia
julia> A = OneElement(4, 3)
3-element OneElement{Int64, 1, Tuple{Int64}, Tuple{Base.OneTo{Int64}}}:
 ⋅
 ⋅
 ⋅

julia> reshape(A, 1, 3)
ERROR: BoundsError: attempt to access 3-element LinearIndices{1, Tuple{Base.OneTo{Int64}}} at index [4]
```
After this,
```julia
julia> reshape(A, 1, 3)
1×3 OneElement{Int64, 2, Tuple{Int64, Int64}, Tuple{Base.OneTo{Int64}, Base.OneTo{Int64}}}:
 ⋅  ⋅  ⋅
```
The index of the non-zero element is arbitrarily chosen to lie beyond the range of the Cartesian indices.