### PR TITLE
Specialize sqrt and cbrt

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FillArrays"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "1.12.0"
+version = "1.13.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -374,6 +374,20 @@ fillsimilar(a::Ones{T}, axes...) where T = Ones{T}(axes...)
 fillsimilar(a::Zeros{T}, axes...) where T = Zeros{T}(axes...)
 fillsimilar(a::AbstractFill, axes...) = Fill(getindex_value(a), axes...)
 
+# functions
+function Base.sqrt(a::AbstractFillMatrix)
+    Base.require_one_based_indexing(a)
+    size(a,1) == size(a,2) || throw(DimensionMismatch("matrix is not square: dimensions are $(size(a))"))
+    _sqrt(a)
+end
+_sqrt(a::AbstractZerosMatrix) = float(a)
+function _sqrt(a::AbstractFillMatrix{<:Real})
+    n = size(a,1)
+    n == 0 && return float(a)
+    v = getindex_value(a)
+    Fill(√(v/n), axes(a))
+end
+
 struct RectDiagonal{T,V<:AbstractVector{T},Axes<:Tuple{Vararg{AbstractUnitRange,2}}} <: AbstractMatrix{T}
     diag::V
     axes::Axes

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -375,17 +375,29 @@ fillsimilar(a::Zeros{T}, axes...) where T = Zeros{T}(axes...)
 fillsimilar(a::AbstractFill, axes...) = Fill(getindex_value(a), axes...)
 
 # functions
-function Base.sqrt(a::AbstractFillMatrix)
+function Base.sqrt(a::AbstractFillMatrix{<:Union{Real, Complex}})
     Base.require_one_based_indexing(a)
     size(a,1) == size(a,2) || throw(DimensionMismatch("matrix is not square: dimensions are $(size(a))"))
     _sqrt(a)
 end
 _sqrt(a::AbstractZerosMatrix) = float(a)
-function _sqrt(a::AbstractFillMatrix{<:Real})
+function _sqrt(a::AbstractFillMatrix)
     n = size(a,1)
     n == 0 && return float(a)
     v = getindex_value(a)
     Fill(√(v/n), axes(a))
+end
+function Base.cbrt(a::AbstractFillMatrix{<:Real})
+    Base.require_one_based_indexing(a)
+    size(a,1) == size(a,2) || throw(DimensionMismatch("matrix is not square: dimensions are $(size(a))"))
+    _cbrt(a)
+end
+_cbrt(a::AbstractZerosMatrix) = float(a)
+function _cbrt(a::AbstractFillMatrix)
+    n = size(a,1)
+    n == 0 && return float(a)
+    v = getindex_value(a)
+    Fill(cbrt(v)/cbrt(n)^2, axes(a))
 end
 
 struct RectDiagonal{T,V<:AbstractVector{T},Axes<:Tuple{Vararg{AbstractUnitRange,2}}} <: AbstractMatrix{T}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2876,8 +2876,12 @@ end
 @testset "sqrt/cbrt" begin
     F = Fill(4, 4, 4)
     @test sqrt(F)^2 ≈ F
+    F = Fill(4+4im, 4, 4)
+    @test sqrt(F)^2 ≈ F
+    F = Fill(-4, 4, 4)
     @test cbrt(F)^3 ≈ F
 
+    # avoid overflow
     F = Fill(4, typemax(Int), typemax(Int))
     @test sqrt(F)^2 ≈ F
     @test cbrt(F)^3 ≈ F

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2885,4 +2885,9 @@ end
     F = Fill(4, typemax(Int), typemax(Int))
     @test sqrt(F)^2 ≈ F
     @test cbrt(F)^3 ≈ F
+
+    # zeros
+    F = Zeros(4, 4)
+    @test sqrt(F)^2 == F
+    @test cbrt(F)^3 == F
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2884,7 +2884,9 @@ end
     @test sqrt(F)^2 ≈ F
     F = Fill(-4, 4, 4)
     A = Array(F)
-    @test cbrt(F) ≈ cbrt(A) rtol=1e-5
+    if VERSION >= v"1.11.0-rc3"
+        @test cbrt(F) ≈ cbrt(A) rtol=1e-5
+    end
     @test cbrt(F)^3 ≈ F
 
     # avoid overflow

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2872,3 +2872,8 @@ end
     @test triu(Z, 2) === Z
     @test tril(Z, 2) === Z
 end
+
+@testset "sqrt" begin
+    F = Fill(4, 4, 4)
+    @test sqrt(F)^2 == F
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2873,7 +2873,12 @@ end
     @test tril(Z, 2) === Z
 end
 
-@testset "sqrt" begin
+@testset "sqrt/cbrt" begin
     F = Fill(4, 4, 4)
-    @test sqrt(F)^2 == F
+    @test sqrt(F)^2 ≈ F
+    @test cbrt(F)^3 ≈ F
+
+    F = Fill(4, typemax(Int), typemax(Int))
+    @test sqrt(F)^2 ≈ F
+    @test cbrt(F)^3 ≈ F
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2875,10 +2875,16 @@ end
 
 @testset "sqrt/cbrt" begin
     F = Fill(4, 4, 4)
+    A = Array(F)
+    @test sqrt(F) ≈ sqrt(A) rtol=3e-8
     @test sqrt(F)^2 ≈ F
     F = Fill(4+4im, 4, 4)
+    A = Array(F)
+    @test sqrt(F) ≈ sqrt(A) rtol=1e-8
     @test sqrt(F)^2 ≈ F
     F = Fill(-4, 4, 4)
+    A = Array(F)
+    @test cbrt(F) ≈ cbrt(A) rtol=1e-5
     @test cbrt(F)^3 ≈ F
 
     # avoid overflow
@@ -2888,6 +2894,8 @@ end
 
     # zeros
     F = Zeros(4, 4)
+    A = Array(F)
+    @test sqrt(F) ≈ sqrt(A) atol=1e-14
     @test sqrt(F)^2 == F
     @test cbrt(F)^3 == F
 end


### PR DESCRIPTION
After this,
```julia
julia> F = Fill(4, 4, 4)
4×4 Fill{Int64}, with entries equal to 4

julia> sqrt(F)
4×4 Fill{Float64}, with entries equal to 1.0

julia> sqrt(F)^2 == F
true

julia> F = Fill(-8, 8, 8)
8×8 Fill{Int64}, with entries equal to -8

julia> cbrt(F)
8×8 Fill{Float64}, with entries equal to -0.5

julia> cbrt(F)^3 == F
true
```
`cbrt` doesn't work with complex values because which the definition isn't obvious (https://github.com/JuliaLang/julia/issues/36534).