### PR TITLE
Negating a OneElement produces a OneElement

### DIFF
--- a/src/oneelement.jl
+++ b/src/oneelement.jl
@@ -141,6 +141,8 @@ function isone(A::OneElementMatrix)
     isone(getindex_value(A))
 end
 
+-(O::OneElement) = OneElement(-O.val, O.ind, O.axes)
+
 *(x::OneElement, b::Number) = OneElement(x.val * b, x.ind, x.axes)
 *(b::Number, x::OneElement) = OneElement(b * x.val, x.ind, x.axes)
 /(x::OneElement, b::Number) = OneElement(x.val / b, x.ind, x.axes)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2171,6 +2171,7 @@ end
     @test FillArrays.nzind(e₁) == CartesianIndex(2)
     @test e₁[2] === e₁[2,1] === e₁[2,1,1] === 1
     @test_throws BoundsError e₁[6]
+    @test -e₁ === OneElement(-1, 2, 5)
 
     f₁ = AbstractArray{Float64}(e₁)
     @test f₁ isa OneElement{Float64,1}
@@ -2190,6 +2191,7 @@ end
     V = OneElement(2, (2,3), (3,4))
     @test V == [0 0 0 0; 0 0 2 0; 0 0 0 0]
     @test FillArrays.nzind(V) == CartesianIndex(2,3)
+    @test -V == OneElement(-2, (2,3), (3,4))
 
     Vf = AbstractArray{Float64}(V)
     @test Vf isa OneElement{Float64,2}


### PR DESCRIPTION
Currently,
```julia
julia> O = OneElement(3, (5,5), (6,6));

julia> -O
6×6 Matrix{Int64}:
 0  0  0  0   0  0
 0  0  0  0   0  0
 0  0  0  0   0  0
 0  0  0  0   0  0
 0  0  0  0  -3  0
 0  0  0  0   0  0
```
After this,
```julia
julia> -O
6×6 OneElement{Int64, 2, Tuple{Int64, Int64}, Tuple{Base.OneTo{Int64}, Base.OneTo{Int64}}}:
 ⋅  ⋅  ⋅  ⋅   ⋅  ⋅
 ⋅  ⋅  ⋅  ⋅   ⋅  ⋅
 ⋅  ⋅  ⋅  ⋅   ⋅  ⋅
 ⋅  ⋅  ⋅  ⋅   ⋅  ⋅
 ⋅  ⋅  ⋅  ⋅  -3  ⋅
 ⋅  ⋅  ⋅  ⋅   ⋅  ⋅
```