### PR TITLE
Unique may return an AbstractFill

### DIFF
--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -607,7 +607,7 @@ diff(x::AbstractFillVector{T}) where T = Zeros{T}(length(x)-1)
 # unique
 #########
 
-unique(x::AbstractFill{T}) where T = isempty(x) ? T[] : T[getindex_value(x)]
+unique(x::AbstractFill{T}) where T = fillsimilar(x, Int(!isempty(x)))
 allunique(x::AbstractFill) = length(x) < 2
 
 #########

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -607,7 +607,7 @@ diff(x::AbstractFillVector{T}) where T = Zeros{T}(length(x)-1)
 # unique
 #########
 
-unique(x::AbstractFill{T}) where T = fillsimilar(x, Int(!isempty(x)))
+unique(x::AbstractFill) = fillsimilar(x, Int(!isempty(x)))
 allunique(x::AbstractFill) = length(x) < 2
 
 #########

--- a/src/oneelement.jl
+++ b/src/oneelement.jl
@@ -432,6 +432,14 @@ permutedims(o::OneElementMatrix) = OneElement(o.val, reverse(o.ind), reverse(o.a
 permutedims(o::OneElementVector) = reshape(o, (1, length(o)))
 permutedims(o::OneElement, dims) = OneElement(o.val, _permute(o.ind, dims), _permute(o.axes, dims))
 
+# unique
+function unique(O::OneElement)
+    v = getindex_value(O)
+    len = iszero(v) ? 1 : min(2, length(O))
+    OneElement(getindex_value(O), len, len)
+end
+allunique(O::OneElement) = length(O) <= 1 || (length(O) < 3 && !iszero(getindex_value(O)))
+
 # show
 _maybesize(t::Tuple{Base.OneTo{Int}, Vararg{Base.OneTo{Int}}}) = size.(t,1)
 _maybesize(t) = t

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2699,6 +2699,25 @@ end
         B = OneElement(2, (1, 2), (Base.IdentityUnitRange(1:1), Base.IdentityUnitRange(2:2)))
         @test repr(B) == "OneElement(2, (1, 2), (Base.IdentityUnitRange(1:1), Base.IdentityUnitRange(2:2)))"
     end
+
+    @testset "unique" begin
+        @testset for n in 1:3
+            O = OneElement(5, 2, n)
+            @test unique(O) == unique(Array(O))
+            @test allunique(O) == allunique(Array(O))
+            O = OneElement(0, 2, n)
+            @test unique(O) == unique(Array(O))
+            @test allunique(O) == allunique(Array(O))
+            @testset for m in 1:4
+                O2 = OneElement(2, (2,1), (m,n))
+                @test unique(O2) == unique(Array(O2))
+                @test allunique(O2) == allunique(Array(O2))
+                O2 = OneElement(0, (2,1), (m,n))
+                @test unique(O2) == unique(Array(O2))
+                @test allunique(O2) == allunique(Array(O2))
+            end
+        end
+    end
 end
 
 @testset "repeat" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1245,7 +1245,7 @@ end
 @testset "unique" begin
     @test unique(Fill(12, 20)) == unique(fill(12, 20))
     @test unique(Fill(1, 0)) == []
-    @test unique(Zeros(0)) isa Vector{Float64}
+    @test unique(Zeros(0)) == Zeros(0)
     @test !allunique(Fill("a", 2))
     @test allunique(Ones(0))
 end


### PR DESCRIPTION
After this
```julia
julia> unique(Fill(3, 4))
1-element Fill{Int64}, with entry equal to 3

julia> unique(Zeros(4, 4))
1-element Zeros{Float64}

julia> unique(Ones(0))
0-element Ones{Float64}

julia> unique(OneElement(2, 3, 4))
2-element OneElement{Int64, 1, Tuple{Int64}, Tuple{Base.OneTo{Int64}}}:
 ⋅
 2
```