### PR TITLE
Specialize broadcasting more unary functions over a OneElement

### DIFF
--- a/src/oneelement.jl
+++ b/src/oneelement.jl
@@ -394,14 +394,10 @@ end
 
 # broadcast
 
-function broadcasted(::DefaultArrayStyle{N}, ::typeof(conj), r::OneElement{<:Any,N}) where {N}
-    OneElement(conj(r.val), r.ind, axes(r))
-end
-function broadcasted(::DefaultArrayStyle{N}, ::typeof(real), r::OneElement{<:Any,N}) where {N}
-    OneElement(real(r.val), r.ind, axes(r))
-end
-function broadcasted(::DefaultArrayStyle{N}, ::typeof(imag), r::OneElement{<:Any,N}) where {N}
-    OneElement(imag(r.val), r.ind, axes(r))
+for f in (:abs, :abs2, :conj, :real, :imag)
+    @eval function broadcasted(::DefaultArrayStyle{N}, ::typeof($f), r::OneElement{<:Any,N}) where {N}
+        OneElement($f(r.val), r.ind, axes(r))
+    end
 end
 function broadcasted(::DefaultArrayStyle{N}, ::typeof(^), r::OneElement{<:Any,N}, x::Number) where {N}
     OneElement(r.val^x, r.ind, axes(r))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2667,9 +2667,11 @@ end
     end
 
     @testset "broadcasting" begin
-        for v in (OneElement(2, 3, 4), OneElement(2im, (1,2), (3,4)))
+        for v in (OneElement(-2, 3, 4), OneElement(2im, (1,2), (3,4)))
             w = Array(v)
             n = 2
+            @test abs.(v) == abs.(w)
+            @test abs2.(v) == abs2.(w)
             @test real.(v) == real.(w)
             @test imag.(v) == imag.(w)
             @test conj.(v) == conj.(w)


### PR DESCRIPTION
After this,
```julia
julia> O = OneElement(-4, (4,2), (4,4))
4×4 OneElement{Int64, 2, Tuple{Int64, Int64}, Tuple{Base.OneTo{Int64}, Base.OneTo{Int64}}}:
 ⋅   ⋅  ⋅  ⋅
 ⋅   ⋅  ⋅  ⋅
 ⋅   ⋅  ⋅  ⋅
 ⋅  -4  ⋅  ⋅

julia> abs.(O)
4×4 OneElement{Int64, 2, Tuple{Int64, Int64}, Tuple{Base.OneTo{Int64}, Base.OneTo{Int64}}}:
 ⋅  ⋅  ⋅  ⋅
 ⋅  ⋅  ⋅  ⋅
 ⋅  ⋅  ⋅  ⋅
 ⋅  4  ⋅  ⋅
```