### PR TITLE
Fix bug in converting Zeros matrix to Diagonal

### DIFF
--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -532,7 +532,7 @@ end
 Diagonal{T}(A::AbstractFillMatrix) where T = Diagonal{T}(diag(A))
 function convert(::Type{T}, A::AbstractFillMatrix) where T<:Diagonal
     checksquare(A)
-    isdiag(A) ? T(A) : throw(InexactError(:convert, T, A))
+    isdiag(A) ? T(diag(A)) : throw(InexactError(:convert, T, A))
 end
 
 Base.StepRangeLen(F::AbstractFillVector{T}) where T = StepRangeLen(getindex_value(F), zero(T), length(F))

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -554,11 +554,13 @@ for (Typ, funcs, func) in ((:AbstractZeros, :zeros, :zero), (:AbstractOnes, :one
     end
 end
 
-# temporary patch. should be a PR(#48895) to LinearAlgebra
-Diagonal{T}(A::AbstractFillMatrix) where T = Diagonal{T}(diag(A))
-function convert(::Type{T}, A::AbstractFillMatrix) where T<:Diagonal
-    checksquare(A)
-    isdiag(A) ? T(diag(A)) : throw(InexactError(:convert, T, A))
+if VERSION < v"1.11-"
+    # temporary patch. should be a PR(#48895) to LinearAlgebra
+    Diagonal{T}(A::AbstractFillMatrix) where T = Diagonal{T}(diag(A))
+    function convert(::Type{T}, A::AbstractFillMatrix) where T<:Diagonal
+        checksquare(A)
+        isdiag(A) ? T(diag(A)) : throw(InexactError(:convert, T, A))
+    end
 end
 
 Base.StepRangeLen(F::AbstractFillVector{T}) where T = StepRangeLen(getindex_value(F), zero(T), length(F))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2963,6 +2963,8 @@ end
 @testset "Diagonal conversion (#389)" begin
     @test convert(Diagonal{Int, Vector{Int}}, Zeros(5,5)) isa Diagonal{Int,Vector{Int}}
     @test convert(Diagonal{Int, Vector{Int}}, Zeros(5,5)) == zeros(5,5)
+    @test Diagonal{Int}(Zeros(5,5)) ≡ Diagonal(Zeros{Int}(5))
+    @test Diagonal{Int}(Ones(5,5)) ≡ Diagonal(Ones{Int}(5))
 end
 
 @testset "sqrt/cbrt" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2959,3 +2959,9 @@ end
     @test triu(Z, 2) === Z
     @test tril(Z, 2) === Z
 end
+
+
+@testset "Diagonal conversion" begin
+    @test convert(Diagonal{Int, Vector{Int}}, Zeros(5,5)) isa Diagonal{Int,Vector{Int}}
+    @test convert(Diagonal{Int, Vector{Int}}, Zeros(5,5)) == zeros(5,5)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2961,7 +2961,7 @@ end
 end
 
 
-@testset "Diagonal conversion" begin
+@testset "Diagonal conversion (#389)" begin
     @test convert(Diagonal{Int, Vector{Int}}, Zeros(5,5)) isa Diagonal{Int,Vector{Int}}
     @test convert(Diagonal{Int, Vector{Int}}, Zeros(5,5)) == zeros(5,5)
 end


### PR DESCRIPTION
Fixes this bug on master:
```julia
julia> convert(Diagonal{Int,Vector{Int}}, Zeros{Int}(5,5))
ERROR: MethodError: no method matching Vector{Int64}(::Zeros{Int64, 2, Tuple{Base.OneTo{Int64}, Base.OneTo{Int64}}})

Closest candidates are:
  Array{T, N}(::FillArrays.AbstractZeros{V, N}) where {T, V, N}
   @ FillArrays ~/.julia/packages/FillArrays/eOEVm/src/FillArrays.jl:532
  Array{T, N}(::FillArrays.AbstractFill{V, N}) where {T, V, N}
   @ FillArrays ~/.julia/packages/FillArrays/eOEVm/src/FillArrays.jl:526
  Array{T, N}(::AbstractArray{S, N}) where {T, N, S}
   @ Base array.jl:673
  ...

Stacktrace:
 [1] convert(::Type{Vector{Int64}}, a::Zeros{Int64, 2, Tuple{Base.OneTo{Int64}, Base.OneTo{Int64}}})
   @ Base ./array.jl:665
 [2] Diagonal{Int64, Vector{Int64}}(diag::Zeros{Int64, 2, Tuple{Base.OneTo{Int64}, Base.OneTo{Int64}}})
   @ LinearAlgebra ~/Projects/julia-1.10/usr/share/julia/stdlib/v1.10/LinearAlgebra/src/diagonal.jl:10
 [3] convert(::Type{Diagonal{Int64, Vector{Int64}}}, A::Zeros{Int64, 2, Tuple{Base.OneTo{Int64}, Base.OneTo{Int64}}})
   @ FillArrays ~/.julia/packages/FillArrays/eOEVm/src/FillArrays.jl:540
 [4] top-level scope
   @ REPL[3]:1


```