### PR TITLE
Disallow empty arrays in maximum/minimum

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FillArrays"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "1.13.0"
+version = "1.13.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -584,7 +584,11 @@ end
 #########
 
 for op in (:maximum, :minimum)
-    @eval $op(x::AbstractFill) = getindex_value(x)
+    @eval function $op(x::AbstractFill)
+        length(x) == 0 && throw(ArgumentError(
+            "reducing over an empty collection is not allowed; consider supplying `init` to the reducer"))
+        getindex_value(x)
+    end
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -827,6 +827,9 @@ end
     @test_throws MethodError issorted(Fill(im, 2))
     @test_throws MethodError sort(Fill(im, 2))
     @test_throws MethodError sort!(Fill(im, 2))
+
+    @test_throws ArgumentError maximum(Fill(3, 0))
+    @test_throws ArgumentError minimum(Fill(3, 0))
 end
 
 @testset "Cumsum, accumulate and diff" begin


### PR DESCRIPTION
This mirrors the behavior of `Array`s:
Currently:
```julia
julia> maximum(Fill(3, 0))
3
```
After this PR
```julia
julia> maximum(fill(3, 0))
ERROR: MethodError: reducing over an empty collection is not allowed; consider supplying `init` to the reducer

julia> maximum(Fill(3, 0))
ERROR: ArgumentError: reducing over an empty collection is not allowed; consider supplying `init` to the reducer
```