### PR TITLE
Skip Aqua stale deps check in downstream tests

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -69,7 +69,7 @@ jobs:
             # force it to use this PR's version of the package
             Pkg.develop(PackageSpec(path="."))  # resolver may fail with main deps
             Pkg.update()
-            Pkg.test(; coverage = true)  # resolver may fail with test time deps
+            Pkg.test(; coverage = true, test_args=["--downstream_integration_test"])  # resolver may fail with test time deps
           catch err
             err isa Pkg.Resolve.ResolverError || rethrow()
             # If we can't resolve that means this is incompatible by SemVer and this is fine

--- a/test/aqua.jl
+++ b/test/aqua.jl
@@ -1,9 +1,11 @@
 using Aqua
 using FillArrays
 using Test
+downstream_test = "--downstream_integration_test" in ARGS
 @testset "Project quality" begin
     Aqua.test_all(FillArrays;
         # https://github.com/JuliaArrays/FillArrays.jl/issues/105#issuecomment-1582516319
         ambiguities=(; broken=true),
+        stale_deps = !downstream_test,
     )
 end


### PR DESCRIPTION
Also, pass the cmd line flag --downstream_integration_test to downstream tests, which may be used to filter tests.