### PR TITLE
Fewer `reshape` methods on julia v1.12

### DIFF
--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -272,23 +272,24 @@ function fill_reshape(parent, dims::Integer...)
     fillsimilar(parent, dims...)
 end
 
-reshape(parent::AbstractFill, dims::Integer...) = reshape(parent, dims)
-reshape(parent::AbstractFill, dims::Union{Int,Colon}...) = reshape(parent, dims)
-reshape(parent::AbstractFill, dims::Union{Integer,Colon}...) = reshape(parent, dims)
-# resolve ambiguity with Base
-reshape(parent::AbstractFillVector, dims::Colon) = parent
-
-reshape(parent::AbstractFill, dims::Tuple{Vararg{Union{Integer,Colon}}}) =
-    fill_reshape(parent, Base._reshape_uncolon(parent, dims)...)
-reshape(parent::AbstractFill, dims::Tuple{Vararg{Union{Int,Colon}}}) =
-    fill_reshape(parent, Base._reshape_uncolon(parent, dims)...)
-reshape(parent::AbstractFill, shp::Tuple{Union{Integer,Base.OneTo}, Vararg{Union{Integer,Base.OneTo}}}) =
-    reshape(parent, Base.to_shape(shp))
+if VERSION < v"1.12.0-DEV.1726"
+    # resolve ambiguity with Base
+    reshape(parent::AbstractFillVector, ::Colon) = parent
+    reshape(parent::AbstractFill, dims::Integer...) = reshape(parent, dims)
+    reshape(parent::AbstractFill, dims::Union{Int,Colon}...) = reshape(parent, dims)
+    reshape(parent::AbstractFill, dims::Union{Integer,Colon}...) = reshape(parent, dims)
+    reshape(parent::AbstractFill, dims::Tuple{Vararg{Union{Integer,Colon}}}) =
+        fill_reshape(parent, Base._reshape_uncolon(parent, dims)...)
+    reshape(parent::AbstractFill, dims::Tuple{Vararg{Union{Int,Colon}}}) =
+        fill_reshape(parent, Base._reshape_uncolon(parent, dims)...)
+    reshape(parent::AbstractFill, shp::Tuple{Union{Integer,Base.OneTo}, Vararg{Union{Integer,Base.OneTo}}}) =
+        reshape(parent, Base.to_shape(shp))
+    # resolve ambiguity with Base
+    reshape(parent::AbstractFillVector, ::Tuple{Colon}) = parent
+end
 reshape(parent::AbstractFill, dims::Dims) = fill_reshape(parent, dims...)
 reshape(parent::AbstractFill, dims::Tuple{Integer, Vararg{Integer}}) = fill_reshape(parent, dims...)
 
-# resolve ambiguity with Base
-reshape(parent::AbstractFillVector, dims::Tuple{Colon}) = parent
 
 for (AbsTyp, Typ, funcs, func) in ((:AbstractZeros, :Zeros, :zeros, :zero), (:AbstractOnes, :Ones, :ones, :one))
     @eval begin


### PR DESCRIPTION
These methods should be unnecessary on a recent v1.12 nightly release, and should avoid issues like those in #373. We therefore limit these to older julia versions.