### PR TITLE
Faster `sparse` for `AbstractFill`

### DIFF
--- a/ext/FillArraysSparseArraysExt.jl
+++ b/ext/FillArraysSparseArraysExt.jl
@@ -5,7 +5,7 @@ using SparseArrays: SparseVectorUnion
 import Base: convert, kron
 using FillArrays
 using FillArrays: RectDiagonalFill, RectOrDiagonalFill, ZerosVector, ZerosMatrix, getindex_value, AbstractFillVector, _fill_dot
-using FillArrays: AbstractFill
+using FillArrays: AbstractFillMatrix
 # Specifying the full namespace is necessary because of https://github.com/JuliaLang/julia/issues/48533
 # See https://github.com/JuliaStats/LogExpFunctions.jl/pull/63
 using FillArrays.LinearAlgebra
@@ -14,16 +14,23 @@ import LinearAlgebra: dot, kron, I
 ##################
 ## Sparse arrays
 ##################
+function SparseVector{Tv,Ti}(F::AbstractFillVector) where {Tv,Ti}
+    SparseVector{Tv,Ti}(length(F),
+        convert(Vector{Ti}, axes(F,1)),
+        fill(convert(Tv, getindex_value(F)), length(F))
+        )
+end
+
 SparseVector{T}(Z::ZerosVector) where T = spzeros(T, length(Z))
 SparseVector{Tv,Ti}(Z::ZerosVector) where {Tv,Ti} = spzeros(Tv, Ti, length(Z))
 
 convert(::Type{AbstractSparseVector}, Z::ZerosVector{T}) where T = spzeros(T, length(Z))
 convert(::Type{AbstractSparseVector{T}}, Z::ZerosVector) where T= spzeros(T, length(Z))
 
-function SparseMatrixCSC{T,Ti}(F::AbstractFill) where {T, Ti<:Integer}
+function SparseMatrixCSC{T,Ti}(F::AbstractFillMatrix) where {T, Ti<:Integer}
     SparseMatrixCSC{T,Ti}(size(F)...,
-        Vector(StepRangeLen(1, size(F,1), size(F,2)+1)),
-        convert(Vector, reduce(vcat, fill(axes(F,1), size(F,2)))),
+        convert(Vector{Ti}, StepRangeLen(1, size(F,1), size(F,2)+1)),
+        convert(Vector{Ti}, reduce(vcat, fill(axes(F,1), size(F,2)))),
         fill(convert(T, getindex_value(F)), length(F)))
 end
 

--- a/ext/FillArraysSparseArraysExt.jl
+++ b/ext/FillArraysSparseArraysExt.jl
@@ -29,8 +29,8 @@ convert(::Type{AbstractSparseVector{T}}, Z::ZerosVector) where T= spzeros(T, len
 
 function SparseMatrixCSC{T,Ti}(F::AbstractFillMatrix) where {T, Ti<:Integer}
     SparseMatrixCSC{T,Ti}(size(F)...,
-        convert(Vector{Ti}, StepRangeLen(1, size(F,1), size(F,2)+1)),
-        convert(Vector{Ti}, reduce(vcat, fill(axes(F,1), size(F,2)))),
+        convert(Vector{Ti}, StepRangeLen(oneunit(Ti), Ti(size(F,1)), size(F,2)+1)),
+        convert(Vector{Ti}, reduce(vcat, fill(map(Ti, axes(F,1)), size(F,2)))),
         fill(convert(T, getindex_value(F)), length(F)))
 end
 

--- a/ext/FillArraysSparseArraysExt.jl
+++ b/ext/FillArraysSparseArraysExt.jl
@@ -5,6 +5,7 @@ using SparseArrays: SparseVectorUnion
 import Base: convert, kron
 using FillArrays
 using FillArrays: RectDiagonalFill, RectOrDiagonalFill, ZerosVector, ZerosMatrix, getindex_value, AbstractFillVector, _fill_dot
+using FillArrays: AbstractFill
 # Specifying the full namespace is necessary because of https://github.com/JuliaLang/julia/issues/48533
 # See https://github.com/JuliaStats/LogExpFunctions.jl/pull/63
 using FillArrays.LinearAlgebra
@@ -18,6 +19,13 @@ SparseVector{Tv,Ti}(Z::ZerosVector) where {Tv,Ti} = spzeros(Tv, Ti, length(Z))
 
 convert(::Type{AbstractSparseVector}, Z::ZerosVector{T}) where T = spzeros(T, length(Z))
 convert(::Type{AbstractSparseVector{T}}, Z::ZerosVector) where T= spzeros(T, length(Z))
+
+function SparseMatrixCSC{T,Ti}(F::AbstractFill) where {T, Ti<:Integer}
+    SparseMatrixCSC{T,Ti}(size(F)...,
+        Vector(StepRangeLen(1, size(F,1), size(F,2)+1)),
+        convert(Vector, reduce(vcat, fill(axes(F,1), size(F,2)))),
+        fill(convert(T, getindex_value(F)), length(F)))
+end
 
 SparseMatrixCSC{T}(Z::ZerosMatrix) where T = spzeros(T, size(Z)...)
 SparseMatrixCSC{Tv,Ti}(Z::Zeros{T,2,Axes}) where {Tv,Ti<:Integer,T,Axes} = spzeros(Tv, Ti, size(Z)...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -591,6 +591,8 @@ end
             testsparsediag(E)
         end
     end
+
+    @test sparse(Fill(3, 4, 4)) == sparse(fill(3, 4, 4))
 end
 
 @testset "==" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -592,7 +592,13 @@ end
         end
     end
 
-    @test sparse(Fill(3, 4, 4)) == sparse(fill(3, 4, 4))
+    F = Fill(3, 4, 4)
+    @test sparse(F) == sparse(fill(3, size(F)...))
+    @test SparseMatrixCSC{Int8,Int16}(F) isa SparseMatrixCSC{Int8,Int16}
+
+    F = Fill(3, 4)
+    @test sparse(F) == sparse(fill(3, size(F)...))
+    @test SparseVector{Int8,Int16}(F) isa SparseVector{Int8,Int16}
 end
 
 @testset "==" begin


### PR DESCRIPTION
There aren't particularly useful, but can't hurt to have some faster methods.
```julia
julia> F = Fill(3, 4_000);

julia> @b sparse(F)
11.541 μs (19 allocs: 197.219 KiB) # master
3.501 μs (7 allocs: 62.656 KiB) # This PR

julia> F = Fill(3, 1_000, 1_000);

julia> @b SparseMatrixCSC{Int32,Int32}(F)
5.623 ms (52 allocs: 17.417 MiB) # master
546.454 μs (19 allocs: 7.653 MiB) # This PR
```