### PR TITLE
Disable tests against `Optim` temporarily

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -47,7 +47,7 @@ jobs:
           - {repo: BandedMatrices.jl, group: JuliaLinearAlgebra}
           - {repo: BlockBandedMatrices.jl, group: JuliaLinearAlgebra}
           - {repo: InfiniteLinearAlgebra.jl, group: JuliaLinearAlgebra}
-          - {repo: Optim.jl, group: JuliaNLSolvers}
+          # - {repo: Optim.jl, group: JuliaNLSolvers} # Enable when their CI is fixed
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Given that their CI is currently broken (and has been broken for months now), we may disable the tests against `Optim` temporarily.