### PR TITLE
Make error messages lazy strings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,12 +32,13 @@ jobs:
   test:
     needs: pre_job
     if: needs.pre_job.outputs.should_skip != 'true'
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         version:
+          - 'min'
           - 'lts'
           - '1'
           - 'pre'
@@ -45,14 +46,11 @@ jobs:
           - ubuntu-latest
           - macOS-latest
           - windows-latest
-        arch:
-          - x64
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1

--- a/Project.toml
+++ b/Project.toml
@@ -1,12 +1,9 @@
 name = "FillArrays"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "1.14.0"
+version = "1.15.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-PDMats = "90014a1f-27ba-587c-ab20-58faa44d9150"
-SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
-Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [weakdeps]
 PDMats = "90014a1f-27ba-587c-ab20-58faa44d9150"
@@ -22,16 +19,16 @@ FillArraysStatisticsExt = "Statistics"
 Aqua = "0.8"
 Documenter = "1"
 Infinities = "0.1"
-LinearAlgebra = "1.6"
+LinearAlgebra = "1"
 PDMats = "0.11.17"
 Quaternions = "0.7"
-Random = "1.6"
+Random = "1"
 ReverseDiff = "1"
-SparseArrays = "1.6"
+SparseArrays = "1"
 StaticArrays = "1"
-Statistics = "1.6"
-Test = "1.6"
-julia = "1.6"
+Statistics = "1"
+Test = "1"
+julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/ext/FillArraysSparseArraysExt.jl
+++ b/ext/FillArraysSparseArraysExt.jl
@@ -61,11 +61,6 @@ end
 @deprecate kron(E1::RectDiagonalFill, E2::RectDiagonalFill) kron(sparse(E1), sparse(E2))
 
 # Ambiguity. see #178
-if VERSION >= v"1.8"
-    dot(x::AbstractFillVector, y::SparseVectorUnion) = _fill_dot(x, y)
-else
-    dot(x::AbstractFillVector{<:Number}, y::SparseVectorUnion{<:Number}) = _fill_dot(x, y)
-end
-
+dot(x::AbstractFillVector, y::SparseVectorUnion) = _fill_dot(x, y)
 
 end # module

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -738,12 +738,6 @@ include("fillalgebra.jl")
 include("fillbroadcast.jl")
 include("trues.jl")
 
-if !isdefined(Base, :get_extension)
-    include("../ext/FillArraysPDMatsExt.jl")
-    include("../ext/FillArraysSparseArraysExt.jl")
-    include("../ext/FillArraysStatisticsExt.jl")
-end
-
 ##
 # print
 ##

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -48,18 +48,18 @@ Base.@propagate_inbounds getindex(F::AbstractFill{T, N}, kj::Vararg{Integer, N})
 
 @inline function setindex!(F::AbstractFill, v, k::Integer)
     @boundscheck checkbounds(F, k)
-    v == getindex_value(F) || throw(ArgumentError("Cannot setindex! to $v for an AbstractFill with value $(getindex_value(F))."))
+    v == getindex_value(F) || throw(ArgumentError(lazy"Cannot setindex! to $v for an AbstractFill with value $(getindex_value(F))."))
     F
 end
 
 @inline function setindex!(F::AbstractFill{T, N}, v, kj::Vararg{Integer, N}) where {T, N}
     @boundscheck checkbounds(F, kj...)
-    v == getindex_value(F) || throw(ArgumentError("Cannot setindex! to $v for an AbstractFill with value $(getindex_value(F))."))
+    v == getindex_value(F) || throw(ArgumentError(lazy"Cannot setindex! to $v for an AbstractFill with value $(getindex_value(F))."))
     F
 end
 
 @inline function fill!(F::AbstractFill, v)
-    v == getindex_value(F) || throw(ArgumentError("Cannot fill! with $v an AbstractFill with value $(getindex_value(F))."))
+    v == getindex_value(F) || throw(ArgumentError(lazy"Cannot fill! with $v an AbstractFill with value $(getindex_value(F))."))
     F
 end
 
@@ -182,7 +182,7 @@ function unique_value(arr::AbstractArray)
     val = first(arr)
     for x in arr
         if x !== val
-            error("Input array contains both $x and $val. Cannot convert to Fill")
+            error(lazy"Input array contains both $x and $val. Cannot convert to Fill")
         end
     end
     return val
@@ -255,12 +255,9 @@ end
 
 svdvals!(a::AbstractFillMatrix) = [getindex_value(a)*sqrt(prod(size(a))); Zeros(min(size(a)...)-1)]
 
-@noinline function _throw_dmrs(n, str, dims)
-    throw(DimensionMismatch("parent has $n elements, which is incompatible with $str $dims"))
-end
 function fill_reshape(parent, dims::Integer...)
     n = length(parent)
-    prod(dims) == n || _throw_dmrs(n, "size", dims)
+    prod(dims) == n || throw(DimensionMismatch(lazy"parent has $n elements, which is incompatible with $str $dims"))
     fillsimilar(parent, dims...)
 end
 
@@ -339,10 +336,10 @@ for (AbsTyp, Typ, funcs, func) in ((:AbstractZeros, :Zeros, :zeros, :zero), (:Ab
         convert(::Type{$Typ{T,N}}, A::$AbsTyp{V,N,Axes}) where {T,V,N,Axes} = convert($Typ{T,N,Axes}, A)
         convert(::Type{$Typ{T}}, A::$AbsTyp{V,N,Axes}) where {T,V,N,Axes} = convert($Typ{T,N,Axes}, A)
         function convert(::Type{Typ}, A::AbstractFill{V,N}) where {T,V,N,Axes,Typ<:$AbsTyp{T,N,Axes}}
-            axes(A) isa Axes || throw(ArgumentError("cannot convert, as axes of array are not $Axes"))
+            axes(A) isa Axes || throw(ArgumentError(lazy"cannot convert, as axes of array are not $Axes"))
             val = getindex_value(A)
             y = convert(T, val)
-            y == $func(T) || throw(ArgumentError(string("cannot convert an array containinig $val to ", $Typ)))
+            y == $func(T) || throw(ArgumentError(lazy"cannot convert an array containinig $val to $Typ"))
             Typ(axes(A))
         end
         function convert(::Type{$Typ{T,N}}, A::AbstractFill{<:Any,N}) where {T,N}
@@ -381,7 +378,7 @@ fillsimilar(a::AbstractFill, axes...) = Fill(getindex_value(a), axes...)
 # functions
 function Base.sqrt(a::AbstractFillMatrix{<:Union{Real, Complex}})
     Base.require_one_based_indexing(a)
-    size(a,1) == size(a,2) || throw(DimensionMismatch("matrix is not square: dimensions are $(size(a))"))
+    size(a,1) == size(a,2) || throw(DimensionMismatch(lazy"matrix is not square: dimensions are $(size(a))"))
     _sqrt(a)
 end
 _sqrt(a::AbstractZerosMatrix) = float(a)
@@ -393,7 +390,7 @@ function _sqrt(a::AbstractFillMatrix)
 end
 function Base.cbrt(a::AbstractFillMatrix{<:Real})
     Base.require_one_based_indexing(a)
-    size(a,1) == size(a,2) || throw(DimensionMismatch("matrix is not square: dimensions are $(size(a))"))
+    size(a,1) == size(a,2) || throw(DimensionMismatch(lazy"matrix is not square: dimensions are $(size(a))"))
     _cbrt(a)
 end
 _cbrt(a::AbstractZerosMatrix) = float(a)
@@ -452,7 +449,7 @@ function setindex!(rd::RectDiagonal, v, i::Integer, j::Integer)
     if i == j
         @inbounds rd.diag[i] = v
     elseif !iszero(v)
-        throw(ArgumentError("cannot set off-diagonal entry ($i, $j) to a nonzero value ($v)"))
+        throw(ArgumentError(lazy"cannot set off-diagonal entry ($i, $j) to a nonzero value ($v)"))
     end
     return v
 end
@@ -851,11 +848,9 @@ end
 function _repeat(A; inner=ntuple(x->1, ndims(A)), outer=ntuple(x->1, ndims(A)))
     Base.require_one_based_indexing(A)
     length(inner) >= ndims(A) ||
-        throw(ArgumentError("number of inner repetitions $(length(inner)) cannot be "*
-            "less than number of dimensions of input array $(ndims(A))"))
+        throw(ArgumentError(lazy"number of inner repetitions $(length(inner)) cannot be less than number of dimensions of input array $(ndims(A))"))
     length(outer) >= ndims(A) ||
-        throw(ArgumentError("number of outer repetitions $(length(outer)) cannot be "*
-            "less than number of dimensions of input array $(ndims(A))"))
+        throw(ArgumentError(lazy"number of outer repetitions $(length(outer)) cannot be less than number of dimensions of input array $(ndims(A))"))
     sz = _repeat_size(size(A), Tuple(inner), Tuple(outer))
     fillsimilar(A, sz)
 end

--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -72,18 +72,10 @@ ishermitian(F::AbstractFillMatrix) = axes(F,1) == axes(F,2) && (isempty(F) || is
 Base.IteratorSize(::Type{<:AbstractFill{T,N,Axes}}) where {T,N,Axes} = _IteratorSize(Axes)
 _IteratorSize(::Type{Tuple{}}) = Base.HasShape{0}()
 _IteratorSize(::Type{Tuple{T}}) where {T} = Base.IteratorSize(T)
-# Julia Base has an optimized any for Tuples on versions >= v1.9
-# On lower versions, a recursive implementation helps with type-inference
-if VERSION >= v"1.9.0-beta3"
-    _any(f, t::Tuple) = any(f, t)
-else
-    _any(f, ::Tuple{}) = false
-    _any(f, t::Tuple) = f(t[1]) || _any(f, Base.tail(t))
-end
 function _IteratorSize(::Type{T}) where {T<:Tuple}
     N = fieldcount(T)
     s = ntuple(i-> Base.IteratorSize(fieldtype(T, i)), N)
-    _any(x -> x isa Base.IsInfinite, s) ? Base.IsInfinite() : Base.HasShape{N}()
+    any(x -> x isa Base.IsInfinite, s) ? Base.IsInfinite() : Base.HasShape{N}()
 end
 
 
@@ -746,15 +738,9 @@ Base.replace_in_print_matrix(::AbstractZeros, ::Integer, ::Integer, s::AbstractS
 
 # following support blocked fill array printing via
 # BlockArrays.jl
-if VERSION < v"1.8-"
-    axes_print_matrix_row(lay, io, X, A, i, cols, sep) =
-        Base.invoke(Base.print_matrix_row, Tuple{IO,AbstractVecOrMat,Vector,Integer,AbstractVector,AbstractString},
-                    io, X, A, i, cols, sep)
-else
-    axes_print_matrix_row(lay, io, X, A, i, cols, sep, idxlast::Integer=last(axes(X, 2))) =
-        Base.invoke(Base.print_matrix_row, Tuple{IO,AbstractVecOrMat,Vector,Integer,AbstractVector,AbstractString,Integer},
+axes_print_matrix_row(lay, io, X, A, i, cols, sep, idxlast::Integer=last(axes(X, 2))) =
+    Base.invoke(Base.print_matrix_row, Tuple{IO,AbstractVecOrMat,Vector,Integer,AbstractVector,AbstractString,Integer},
                     io, X, A, i, cols, sep, idxlast)
-end
 
 Base.print_matrix_row(io::IO,
         X::Union{AbstractFillVector,

--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -65,7 +65,7 @@ end
 function mult_axes(a, b)
     Base.require_one_based_indexing(a, b)
     size(a, 2) ≠ size(b, 1) &&
-        throw(DimensionMismatch("A has dimensions $(size(a)) but B has dimensions $(size(b))"))
+        throw(DimensionMismatch(lazy"A has dimensions $(size(a)) but B has dimensions $(size(b))"))
     return (axes(a, 1), axes(b)[2:end]...)
 end
 
@@ -115,11 +115,11 @@ function *(F::AbstractFillMatrix, v::AbstractVector)
 end
 
 function lmul_diag(a::Diagonal, b)
-    size(a,2) == size(b,1) || throw(DimensionMismatch("A has dimensions $(size(a)) but B has dimensions $(size(b))"))
+    size(a,2) == size(b,1) || throw(DimensionMismatch(lazy"A has dimensions $(size(a)) but B has dimensions $(size(b))"))
     parent(a) .* b # use special broadcast
 end
 function rmul_diag(a, b::Diagonal)
-    size(a,2) == size(b,1) || throw(DimensionMismatch("A has dimensions $(size(a)) but B has dimensions $(size(b))"))
+    size(a,2) == size(b,1) || throw(DimensionMismatch(lazy"A has dimensions $(size(a)) but B has dimensions $(size(b))"))
     a .* permutedims(parent(b)) # use special broadcast
 end
 
@@ -132,26 +132,26 @@ end
 @noinline function check_matmul_sizes(A::AbstractMatrix, x::AbstractVector)
     Base.require_one_based_indexing(A, x)
     size(A,2) == size(x,1) ||
-        throw(DimensionMismatch("second dimension of A, $(size(A,2)) does not match length of x $(length(x))"))
+        throw(DimensionMismatch(lazy"second dimension of A, $(size(A,2)) does not match length of x $(length(x))"))
 end
 @noinline function check_matmul_sizes(A::AbstractMatrix, B::AbstractMatrix)
     Base.require_one_based_indexing(A, B)
     size(A,2) == size(B,1) ||
-        throw(DimensionMismatch("second dimension of A, $(size(A,2)) does not match first dimension of B, $(size(B,1))"))
+        throw(DimensionMismatch(lazy"second dimension of A, $(size(A,2)) does not match first dimension of B, $(size(B,1))"))
 end
 @noinline function check_matmul_sizes(y::AbstractVector, A::AbstractMatrix, x::AbstractVector)
     Base.require_one_based_indexing(A, x, y)
     size(A,2) == size(x,1) ||
-        throw(DimensionMismatch("second dimension of A, $(size(A,2)) does not match length of x $(length(x))"))
+        throw(DimensionMismatch(lazy"second dimension of A, $(size(A,2)) does not match length of x $(length(x))"))
     size(y,1) == size(A,1) ||
-        throw(DimensionMismatch("first dimension of A, $(size(A,1)) does not match length of y $(length(y))"))
+        throw(DimensionMismatch(lazy"first dimension of A, $(size(A,1)) does not match length of y $(length(y))"))
 end
 @noinline function check_matmul_sizes(C::AbstractMatrix, A::AbstractMatrix, B::AbstractMatrix)
     Base.require_one_based_indexing(A, B, C)
     size(A,2) == size(B,1) ||
-        throw(DimensionMismatch("second dimension of A, $(size(A,2)) does not match first dimension of B, $(size(B,1))"))
+        throw(DimensionMismatch(lazy"second dimension of A, $(size(A,2)) does not match first dimension of B, $(size(B,1))"))
     size(C,1) == size(A,1) && size(C,2) == size(B,2) ||
-        throw(DimensionMismatch("A has size $(size(A)), B has size $(size(B)), C has size $(size(C))"))
+        throw(DimensionMismatch(lazy"A has size $(size(A)), B has size $(size(B)), C has size $(size(C))"))
 end
 
 function mul!(y::AbstractVector, A::AbstractFillMatrix, b::AbstractFillVector, alpha::Number, beta::Number)
@@ -314,7 +314,7 @@ end
 function _adjvec_mul_zeros(a, b)
     la, lb = length(a), length(b)
     if la ≠ lb
-        throw(DimensionMismatch("dot product arguments have lengths $la and $lb"))
+        throw(DimensionMismatch(lazy"dot product arguments have lengths $la and $lb"))
     end
     # ensure that all the elements of `a` are of the same size,
     # so that ∑ᵢaᵢbᵢ = b₁∑ᵢaᵢ makes sense
@@ -324,7 +324,7 @@ function _adjvec_mul_zeros(a, b)
     end
     a1 = a[1]
     sza1 = size(a1)
-    all(x -> size(x) == sza1, a) || throw(DimensionMismatch("not all elements of A are of size $sza1"))
+    all(x -> size(x) == sza1, a) || throw(DimensionMismatch(lazy"not all elements of A are of size $sza1"))
     # we replace b₁∑ᵢaᵢ by b₁a₁, as we know that b₁ is zero.
     # Each term in the summation is zero, so the sum is equal to the first term
     return a1 * b[1]
@@ -365,7 +365,7 @@ end
 *(a::TransposeAbsVec{<:Any,<:AbstractZerosVector}, D::Diagonal) = transpose(D*transpose(a))
 function _triple_zeromul(x, D::Diagonal, y)
     if !(length(x) == length(D.diag) == length(y))
-        throw(DimensionMismatch("x has length $(length(x)), D has size $(size(D)), and y has $(length(y))"))
+        throw(DimensionMismatch(lazy"x has length $(length(x)), D has size $(size(D)), and y has $(length(y))"))
     end
     zero(promote_type(eltype(x), eltype(D), eltype(y)))
 end
@@ -381,7 +381,7 @@ end
 function *(a::Transpose{T, <:AbstractVector}, b::AbstractZerosVector{T}) where T<:Real
     la, lb = length(a), length(b)
     if la ≠ lb
-        throw(DimensionMismatch("dot product arguments have lengths $la and $lb"))
+        throw(DimensionMismatch(lazy"dot product arguments have lengths $la and $lb"))
     end
     return zero(T)
 end
@@ -391,12 +391,12 @@ end
 # infinite cases should be supported in InfiniteArrays.jl
 # type issues of Bool dot are ignored at present.
 function _fill_dot(a::AbstractFillVector{T}, b::AbstractVector{V}) where {T,V}
-    axes(a) == axes(b) || throw(DimensionMismatch("dot product arguments have lengths $(length(a)) and $(length(b))"))
+    axes(a) == axes(b) || throw(DimensionMismatch(lazy"dot product arguments have lengths $(length(a)) and $(length(b))"))
     dot(getindex_value(a), sum(b))
 end
 
 function _fill_dot_rev(a::AbstractVector{T}, b::AbstractFillVector{V}) where {T,V}
-    axes(a) == axes(b) || throw(DimensionMismatch("dot product arguments have lengths $(length(a)) and $(length(b))"))
+    axes(a) == axes(b) || throw(DimensionMismatch(lazy"dot product arguments have lengths $(length(a)) and $(length(b))"))
     dot(sum(a), getindex_value(b))
 end
 
@@ -406,7 +406,7 @@ dot(a::AbstractVector, b::AbstractFillVector) = _fill_dot_rev(a, b)
 
 function dot(u::AbstractVector, E::Eye, v::AbstractVector)
     length(u) == size(E,1) && length(v) == size(E,2) ||
-        throw(DimensionMismatch("dot product arguments have dimensions $(length(u))×$(size(E))×$(length(v))"))
+        throw(DimensionMismatch(lazy"dot product arguments have dimensions $(length(u))×$(size(E))×$(length(v))"))
     d = dot(u,v)
     T = typeof(one(eltype(E)) * d)
     convert(T, d)
@@ -414,13 +414,13 @@ end
 
 function dot(u::AbstractVector, D::Diagonal{<:Any,<:Fill}, v::AbstractVector)
     length(u) == size(D,1) && length(v) == size(D,2) ||
-        throw(DimensionMismatch("dot product arguments have dimensions $(length(u))×$(size(D))×$(length(v))"))
+        throw(DimensionMismatch(lazy"dot product arguments have dimensions $(length(u))×$(size(D))×$(length(v))"))
     D.diag.value*dot(u, v)
 end
 
 function dot(u::AbstractVector{T}, D::Diagonal{U,<:Zeros}, v::AbstractVector{V}) where {T,U,V}
     length(u) == size(D,1) && length(v) == size(D,2) ||
-        throw(DimensionMismatch("dot product arguments have dimensions $(length(u))×$(size(D))×$(length(v))"))
+        throw(DimensionMismatch(lazy"dot product arguments have dimensions $(length(u))×$(size(D))×$(length(v))"))
     zero(promote_type(T,U,V))
 end
 
@@ -510,7 +510,7 @@ function lmul!(x::Number, z::AbstractFill)
     λ = getindex_value(z)
     # Following check ensures consistency w/ lmul!(x, Array(z))
     # for, e.g., lmul!(NaN, z)
-    x*λ == λ || throw(ArgumentError("Cannot scale by $x"))
+    x*λ == λ || throw(ArgumentError(lazy"Cannot scale by $x"))
     z
 end
 
@@ -518,13 +518,13 @@ function rmul!(z::AbstractFill, x::Number)
     λ = getindex_value(z)
     # Following check ensures consistency w/ lmul!(x, Array(z))
     # for, e.g., lmul!(NaN, z)
-    λ*x == λ || throw(ArgumentError("Cannot scale by $x"))
+    λ*x == λ || throw(ArgumentError(lazy"Cannot scale by $x"))
     z
 end
 
 fillzero(::Type{Fill{T,N,AXIS}}, n, m) where {T,N,AXIS} = Fill{T,N,AXIS}(zero(T), (n, m))
 fillzero(::Type{<:AbstractZeros{T,N,AXIS}}, n, m) where {T,N,AXIS} = Zeros{T,N,AXIS}((n, m))
-fillzero(::Type{F}, n, m) where F = throw(ArgumentError("Cannot create a zero array of type $F"))
+fillzero(::Type{F}, n, m) where F = throw(ArgumentError(lazy"Cannot create a zero array of type $F"))
 
 diagzero(D::Diagonal{F}, i, j) where F<:AbstractFill = fillzero(F, axes(D.diag[i], 1), axes(D.diag[j], 2))
 

--- a/src/fillbroadcast.jl
+++ b/src/fillbroadcast.jl
@@ -24,7 +24,7 @@ function _maplinear(rs...) # tries to match Base's behaviour, could perhaps hook
         r1 = axes(first(rs))
         for r in rs
             axes(r) == r1 || throw(DimensionMismatch(
-            "dimensions must match: a has dims $r1, b has dims $(axes(r))"))
+            lazy"dimensions must match: a has dims $r1, b has dims $(axes(r))"))
         end
         return false
     end
@@ -206,13 +206,13 @@ _range_convert(::Type{AbstractVector{T}}, a::ZerosVector) where T = ZerosVector{
 # end
 
 function broadcasted(::DefaultArrayStyle{1}, ::typeof(*), a::AbstractOnesVector, b::AbstractRange)
-    broadcast_shape(axes(a), axes(b)) == axes(b) || throw(ArgumentError("Cannot broadcast $a and $b. Convert $b to a Vector first."))
+    broadcast_shape(axes(a), axes(b)) == axes(b) || throw(ArgumentError(lazy"Cannot broadcast $a and $b. Convert $b to a Vector first."))
     TT = typeof(zero(eltype(a)) * zero(eltype(b)))
     return _range_convert(AbstractVector{TT}, b)
 end
 
 function broadcasted(::DefaultArrayStyle{1}, ::typeof(*), a::AbstractRange, b::AbstractOnesVector)
-    broadcast_shape(axes(a), axes(b)) == axes(a) || throw(ArgumentError("Cannot broadcast $a and $b. Convert $b to a Vector first."))
+    broadcast_shape(axes(a), axes(b)) == axes(a) || throw(ArgumentError(lazy"Cannot broadcast $a and $b. Convert $b to a Vector first."))
     TT = typeof(zero(eltype(a)) * zero(eltype(b)))
     return _range_convert(AbstractVector{TT}, a)
 end
@@ -220,13 +220,13 @@ end
 for op in (:+, :-)
     @eval begin
         function broadcasted(::DefaultArrayStyle{1}, ::typeof($op), a::AbstractVector, b::AbstractZerosVector)
-            broadcast_shape(axes(a), axes(b)) == axes(a) || throw(ArgumentError("Cannot broadcast $a and $b. Convert $b to a Vector first."))
+            broadcast_shape(axes(a), axes(b)) == axes(a) || throw(ArgumentError(lazy"Cannot broadcast $a and $b. Convert $b to a Vector first."))
             TT = typeof($op(zero(eltype(a)), zero(eltype(b))))
             # Use `TT ∘ (+)` to fix AD issues with `broadcasted(TT, x)`
             eltype(a) === TT ? a : broadcasted(TT ∘ (+), a)
         end
         function broadcasted(::DefaultArrayStyle{1}, ::typeof($op), a::AbstractZerosVector, b::AbstractVector)
-            broadcast_shape(axes(a), axes(b)) == axes(b) || throw(ArgumentError("Cannot broadcast $a and $b. Convert $a to a Vector first."))
+            broadcast_shape(axes(a), axes(b)) == axes(b) || throw(ArgumentError(lazy"Cannot broadcast $a and $b. Convert $a to a Vector first."))
             TT = typeof($op(zero(eltype(a)), zero(eltype(b))))
             $op === (+) && eltype(b) === TT ? b : broadcasted(TT ∘ ($op), b)
         end
@@ -245,12 +245,12 @@ _broadcast_getindex_value(a::AbstractFill) = Ref(getindex_value(a))
 
 
 function broadcasted(::DefaultArrayStyle{1}, ::typeof(*), a::AbstractFill, b::AbstractRange)
-    broadcast_shape(axes(a), axes(b)) == axes(b) || throw(ArgumentError("Cannot broadcast $a and $b. Convert $b to a Vector first."))
+    broadcast_shape(axes(a), axes(b)) == axes(b) || throw(ArgumentError(lazy"Cannot broadcast $a and $b. Convert $b to a Vector first."))
     return broadcasted(*, _broadcast_getindex_value(a), b)
 end
 
 function broadcasted(::DefaultArrayStyle{1}, ::typeof(*), a::AbstractRange, b::AbstractFill)
-    broadcast_shape(axes(a), axes(b)) == axes(a) || throw(ArgumentError("Cannot broadcast $a and $b. Convert $b to a Vector first."))
+    broadcast_shape(axes(a), axes(b)) == axes(a) || throw(ArgumentError(lazy"Cannot broadcast $a and $b. Convert $b to a Vector first."))
     return broadcasted(*, a, _broadcast_getindex_value(b))
 end
 

--- a/src/oneelement.jl
+++ b/src/oneelement.jl
@@ -423,7 +423,7 @@ end
 # reshape
 
 function Base.reshape(A::OneElement, shape::Tuple{Vararg{Int}})
-    prod(shape) == length(A) || throw(DimensionMismatch("new dimension $shape must be consistent with array size $(length(A))"))
+    prod(shape) == length(A) || throw(DimensionMismatch(lazy"new dimension $shape must be consistent with array size $(length(A))"))
     if all(in.(A.ind, axes(A)))
         # we use the fact that the linear index of the non-zero value is preserved
         oldlinind = LinearIndices(A)[A.ind...]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -407,15 +407,12 @@ function test_addition_subtraction_dot(As, Bs, Tout::Type)
             @test @inferred(B - A) isa Tout{promote_type(eltype(B), eltype(A))}
             @test isapprox_or_undef(as_array(B - A), as_array(B) - as_array(A))
 
-            # Julia 1.6 doesn't support dot(UniformScaling)
-            if VERSION < v"1.6.0" || VERSION >= v"1.8.0"
-                d1 = dot(A, B)
-                d2 = dot(as_array(A), as_array(B))
-                d3 = dot(B, A)
-                d4 = dot(as_array(B), as_array(A))
-                @test d1 ≈ d2 || d1 ≡ d2
-                @test d3 ≈ d4 || d3 ≡ d4
-            end
+            d1 = dot(A, B)
+            d2 = dot(as_array(A), as_array(B))
+            d3 = dot(B, A)
+            d4 = dot(as_array(B), as_array(A))
+            @test d1 ≈ d2 || d1 ≡ d2
+            @test d3 ≈ d4 || d3 ≡ d4
         end
     end
 end
@@ -1930,9 +1927,7 @@ end
     E = Eye(2)
     K = kron(E, E)
     @test K isa Diagonal
-    if VERSION >= v"1.9"
-        @test K isa typeof(E)
-    end
+    @test K isa typeof(E)
     C = collect(E)
     @test K == kron(C, C)
 
@@ -2789,11 +2784,7 @@ end
                                 )
             O = OneElement(v,ind,sz)
             A = Array(O)
-            if VERSION >= v"1.10"
-                @test @inferred(sum(O)) === sum(A)
-            else
-                @test @inferred(sum(O)) == sum(A)
-            end
+            @test @inferred(sum(O)) === sum(A)
             @test @inferred(sum(O, init=zero(eltype(O)))) === sum(A, init=zero(eltype(O)))
             @test @inferred(sum(x->1, O, init=0)) === sum(Fill(1, axes(O)), init=0)
         end
@@ -2948,13 +2939,7 @@ end
 end
 
 @testset "structured matrix" begin
-    # strange bug on Julia v1.6, see
-    # https://discourse.julialang.org/t/strange-seemingly-out-of-bounds-access-bug-in-julia-v1-6/101041
-    bands = if VERSION >= v"1.9"
-        ((Fill(2,3), Fill(6,2)), (Zeros(3), Zeros(2)))
-    else
-        ((Fill(2,3), Fill(6,2)),)
-    end
+    bands = ((Fill(2,3), Fill(6,2)), (Zeros(3), Zeros(2)))
     @testset for (dv, ev) in bands
         for D in (Diagonal(dv), Bidiagonal(dv, ev, :U),
                     Tridiagonal(ev, dv, ev), SymTridiagonal(dv, ev))


### PR DESCRIPTION
Based on #419 since `LazyString` and `lazy"..."` are only available in Julia >= 1.8.

---

The PR changes all error messages to lazy strings to delay string interpolation and `print`ing of the involved quantities until the error message is displayed (and hence skip it completely if the error path is not hit). Using `LazyString`s in error messages generally also helps with type inference (see e.g. https://github.com/JuliaLang/julia/pull/58672 and https://github.com/JuliaLang/julia/pull/54737).