### PR TITLE
Zeros and OneElement addition/subtraction

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ version = "1.15.0"
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
-
 [weakdeps]
 PDMats = "90014a1f-27ba-587c-ab20-58faa44d9150"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"

--- a/Project.toml
+++ b/Project.toml
@@ -5,14 +5,17 @@ version = "1.15.0"
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
+
 [weakdeps]
 PDMats = "90014a1f-27ba-587c-ab20-58faa44d9150"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [extensions]
 FillArraysPDMatsExt = "PDMats"
 FillArraysSparseArraysExt = "SparseArrays"
+FillArraysStaticArraysExt = "StaticArrays"
 FillArraysStatisticsExt = "Statistics"
 
 [compat]

--- a/ext/FillArraysSparseArraysExt.jl
+++ b/ext/FillArraysSparseArraysExt.jl
@@ -4,7 +4,7 @@ using SparseArrays
 using SparseArrays: SparseVectorUnion
 import Base: convert, kron
 using FillArrays
-using FillArrays: RectDiagonalFill, RectOrDiagonalFill, ZerosVector, ZerosMatrix, getindex_value, AbstractFillVector, _fill_dot, OneElementVector
+using FillArrays: RectDiagonalFill, RectOrDiagonalFill, ZerosVector, ZerosMatrix, getindex_value, AbstractFillVector, _fill_dot, OneElementVector, OneElementMatrix
 # Specifying the full namespace is necessary because of https://github.com/JuliaLang/julia/issues/48533
 # See https://github.com/JuliaStats/LogExpFunctions.jl/pull/63
 using FillArrays.LinearAlgebra
@@ -69,7 +69,7 @@ function FillArrays.oneelement_addsub(a::OneElementVector, b::OneElementVector, 
     return sparsevec([a.ind[1], b.ind[1]], [aval, bval], length(a))
 end
 
-function FillArrays.oneelement_addsub(a::OneElement, b::OneElement, aval, bval)
+function FillArrays.oneelement_addsub(a::OneElementMatrix, b::OneElementMatrix, aval, bval)
     nzval = [aval, bval]
     nzind = ntuple(i -> [a.ind[i], b.ind[i]], ndims(a))
     return sparse(nzind..., nzval, size(a)...)

--- a/ext/FillArraysSparseArraysExt.jl
+++ b/ext/FillArraysSparseArraysExt.jl
@@ -4,7 +4,7 @@ using SparseArrays
 using SparseArrays: SparseVectorUnion
 import Base: convert, kron
 using FillArrays
-using FillArrays: RectDiagonalFill, RectOrDiagonalFill, ZerosVector, ZerosMatrix, getindex_value, AbstractFillVector, _fill_dot
+using FillArrays: RectDiagonalFill, RectOrDiagonalFill, ZerosVector, ZerosMatrix, getindex_value, AbstractFillVector, _fill_dot, OneElementVector
 # Specifying the full namespace is necessary because of https://github.com/JuliaLang/julia/issues/48533
 # See https://github.com/JuliaStats/LogExpFunctions.jl/pull/63
 using FillArrays.LinearAlgebra
@@ -62,5 +62,17 @@ end
 
 # Ambiguity. see #178
 dot(x::AbstractFillVector, y::SparseVectorUnion) = _fill_dot(x, y)
+
+# OneElements with different indices should return
+# SparseArrays under addition
+function FillArrays.oneelement_addsub(a::OneElementVector, b::OneElementVector, aval, bval)
+    return sparsevec([a.ind[1], b.ind[1]], [aval, bval], length(a))
+end
+
+function FillArrays.oneelement_addsub(a::OneElement, b::OneElement, aval, bval)
+    nzval = [aval, bval]
+    nzind = ntuple(i -> [a.ind[i], b.ind[i]], ndims(a))
+    return sparse(nzind..., nzval, size(a)...)
+end
 
 end # module

--- a/ext/FillArraysStaticArraysExt.jl
+++ b/ext/FillArraysStaticArraysExt.jl
@@ -1,0 +1,28 @@
+module FillArraysStaticArraysExt
+
+using FillArrays
+using StaticArrays
+
+import Base: promote_op
+import FillArrays: elconvert
+
+# Disambiguity methods for StaticArrays
+
+function Base.:+(a::FillArrays.Zeros, b::StaticArray)
+    promote_shape(a,b)
+    return elconvert(promote_op(+,eltype(a),eltype(b)),b)
+end
+function Base.:+(a::StaticArray, b::FillArrays.Zeros)
+    promote_shape(a,b)
+    return elconvert(promote_op(+,eltype(a),eltype(b)),a)
+end
+function Base.:-(a::StaticArray, b::FillArrays.Zeros)
+    promote_shape(a,b)
+    return elconvert(promote_op(-,eltype(a),eltype(b)),a)
+end
+function Base.:-(a::FillArrays.Zeros, b::StaticArray)
+    promote_shape(a,b)
+    return elconvert(promote_op(-,eltype(a),eltype(b)),-b)
+end
+
+end # module

--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -436,30 +436,25 @@ function +(a::AbstractZeros{T}, b::AbstractZeros{V}) where {T, V} # for disambig
     promote_shape(a,b)
     return elconvert(promote_op(+,T,V),a)
 end
-# concrete Zeros used to stop a variety of ambiguity issues
-# AbstractFill for disambiguity
+
+# AbstractFill and Array for disambiguity
 for TYPE in (:Array, :AbstractFill, :AbstractRange, :AbstractArray)
-    @eval function +(a::$TYPE{T}, b::Zeros{V}) where {T, V}
+    @eval function +(a::$TYPE{T}, b::AbstractZeros{V}) where {T, V}
         promote_shape(a,b)
         return elconvert(promote_op(+,T,V),a)
     end
-    @eval function -(a::$TYPE{T}, b::Zeros{V}) where {T, V}
+    @eval function -(a::$TYPE{T}, b::AbstractZeros{V}) where {T, V}
         promote_shape(a,b)
         return elconvert(promote_op(-,T,V),a)
     end
-    @eval function -(a::Zeros{T}, b::$TYPE{V}) where {T, V}
+    @eval function -(a::AbstractZeros{T}, b::$TYPE{V}) where {T, V}
         promote_shape(a,b)
         return elconvert(promote_op(-,T,V),-b)
     end
-    @eval +(a::Zeros, b::$TYPE) = b + a
+    @eval +(a::AbstractZeros, b::$TYPE) = b + a
 end
 
-function +(a::Zeros, b::Zeros)
-    promote_shape(a,b)
-    return elconvert(promote_type(eltype(a), eltype(b)),a)
-end
-
-function -(a::Zeros, b::Zeros)
+function -(a::AbstractZeros, b::AbstractZeros)
     promote_shape(a,b)
     return elconvert(promote_type(eltype(a), eltype(b)),-b)
 end

--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -36,6 +36,29 @@ Base.@propagate_inbounds function reverse(A::AbstractFill, start::Integer, stop:
 end
 reverse(A::AbstractFill; dims=:) = A
 
+## addition/subtraction with Zeros
+# Zeros should function as an identity
+
+function add_zeros(z::AbstractZeros, v::AbstractArray)
+    axes(z) == axes(v) || throw(DimensionMismatch(LazyString("A has dimensions ", size(z), " but B has dimensions ", size(v))))
+    return v
+end
+
+function sub_zeros(v::AbstractArray, z::AbstractZeros)
+    axes(z) == axes(v) || throw(DimensionMismatch(LazyString("A has dimensions ", size(z), " but B has dimensions ", size(v))))
+    return v
+end
+
+function sub_zeros(z::AbstractZeros, v::AbstractArray)
+    axes(z) == axes(v) || throw(DimensionMismatch(LazyString("A has dimensions ", size(z), " but B has dimensions ", size(v))))
+    return -v
+end
+
++(a::AbstractZeros, b::AbstractArray) = add_zeros(a, b)
++(a::AbstractArray, b::AbstractZeros) = add_zeros(b, a)
+-(a::AbstractArray, b::AbstractZeros) = sub_zeros(a, b)
+-(a::AbstractZeros, b::AbstractArray) = sub_zeros(a, b)
+
 ## Algebraic identities
 
 # Default outputs, can overload to customize

--- a/src/oneelement.jl
+++ b/src/oneelement.jl
@@ -158,11 +158,10 @@ function add_one_elem(a::OneElement, b::AbstractArray)
     try
         ret[a.ind...] += getindex_value(a)
     catch
-        print("Exception")
         # Fallback to materialising dense array if setindex!
         # goes wrong (e.g on a Diagonal)
         ret = Array(ret)
-        ret[a.ind...] += getindex_value(a)
+        checkbounds(Bool, ret, a.ind...) && (ret[a.ind...] += getindex_value(a))
     end
     return ret
 end
@@ -176,7 +175,7 @@ function sub_one_elem(a::AbstractArray, b::OneElement)
         # Fallback to materialising dense array if setindex!
         # goes wrong (e.g on a Diagonal)
         ret = Array(ret)
-        ret[b.ind...] -= getindex_value(b)
+        checkbounds(Bool, ret, b.ind...) && (ret[b.ind...] -= getindex_value(b))
     end
     return ret
 end
@@ -190,7 +189,7 @@ function sub_one_elem(a::OneElement, b::AbstractArray)
         # Fallback to materialising dense array if setindex!
         # goes wrong (e.g on a Diagonal)
         ret = Array(ret)
-        ret[a.ind...] += getindex_value(a)
+        checkbounds(Bool, ret, a.ind...) && (ret[a.ind...] += getindex_value(a))
     end
     return ret
 end

--- a/src/oneelement.jl
+++ b/src/oneelement.jl
@@ -199,8 +199,12 @@ end
 -(a::AbstractArray, b::OneElement) = sub_one_elem(a, b)
 -(a::OneElement, b::AbstractArray) = sub_one_elem(a, b)
 # disambiguity
-+(a::AbstractZeros, b::OneElement) = add_zeros(a, b)
-+(a::OneElement, b::AbstractZeros) = add_zeros(b, a)
+function +(a::AbstractZeros, b::OneElement)
+    promote_shape(a,b)
+    return elconvert(promote_op(+,eltype(a),eltype(b)),b)
+end
+
++(a::OneElement, b::AbstractZeros) = b + a
 
 # Adding/subtracting OneElements
 # (Without SparseArrays) materialise dense vector if indices are different

--- a/src/oneelement.jl
+++ b/src/oneelement.jl
@@ -209,7 +209,7 @@ end
 # Adding/subtracting OneElements
 # (Without SparseArrays) materialise dense vector if indices are different
 
-# This is overridden by the SparseArrays extension to return sparse arrays
+# Sparse Arrays extension overrides this for OneElementVector and OneElementMatrix
 function oneelement_addsub(a::OneElement, b::OneElement, aval, bval)
     ret = similar(a)
     fill!(ret, zero(eltype(ret)))

--- a/src/oneelement.jl
+++ b/src/oneelement.jl
@@ -148,6 +148,87 @@ end
 /(x::OneElement, b::Number) = OneElement(x.val / b, x.ind, x.axes)
 \(b::Number, x::OneElement) = OneElement(b \ x.val, x.ind, x.axes)
 
+# Addition
+
+# O(1) addition with arbitrary array types
+function add_one_elem(a::OneElement, b::AbstractArray)
+    axes(a) == axes(b) || throw(DimensionMismatch(LazyString("A has dimensions ", size(a), " but B has dimensions ", size(b))))
+
+    ret = copy(b)
+    try
+        ret[a.ind...] += getindex_value(a)
+    catch
+        print("Exception")
+        # Fallback to materialising dense array if setindex!
+        # goes wrong (e.g on a Diagonal)
+        ret = Array(ret)
+        ret[a.ind...] += getindex_value(a)
+    end
+    return ret
+end
+
+function sub_one_elem(a::AbstractArray, b::OneElement)
+    axes(a) == axes(b) || throw(DimensionMismatch(LazyString("A has dimensions ", size(a), " but B has dimensions ", size(b))))
+    ret = copy(a)
+    try
+        ret[b.ind...] -= getindex_value(b)
+    catch
+        # Fallback to materialising dense array if setindex!
+        # goes wrong (e.g on a Diagonal)
+        ret = Array(ret)
+        ret[b.ind...] -= getindex_value(b)
+    end
+    return ret
+end
+
+function sub_one_elem(a::OneElement, b::AbstractArray)
+    axes(a) == axes(b) || throw(DimensionMismatch(LazyString("A has dimensions ", size(a), " but B has dimensions ", size(b))))
+    ret = copy(-b)
+    try
+        ret[a.ind...] += getindex_value(a)
+    catch
+        # Fallback to materialising dense array if setindex!
+        # goes wrong (e.g on a Diagonal)
+        ret = Array(ret)
+        ret[a.ind...] += getindex_value(a)
+    end
+    return ret
+end
+
++(a::OneElement, b::AbstractArray) = add_one_elem(a, b)
++(a::AbstractArray, b::OneElement) = add_one_elem(b, a)
+-(a::AbstractArray, b::OneElement) = sub_one_elem(a, b)
+-(a::OneElement, b::AbstractArray) = sub_one_elem(a, b)
+# disambiguity
++(a::AbstractZeros, b::OneElement) = add_zeros(a, b)
++(a::OneElement, b::AbstractZeros) = add_zeros(b, a)
+
+# Adding/subtracting OneElements
+# (Without SparseArrays) materialise dense vector if indices are different
+
+# This is overridden by the SparseArrays extension to return sparse arrays
+function oneelement_addsub(a::OneElement, b::OneElement, aval, bval)
+    ret = similar(a)
+    fill!(ret, zero(eltype(ret)))
+    ret[a.ind...] = aval
+    ret[b.ind...] = bval
+    return ret
+end
+
+for (op, bop) in (:+ => :(getindex_value(b)),
+                  :- => :(-getindex_value(b)))
+    @eval begin
+        function $op(a::OneElement, b::OneElement)
+            axes(a) == axes(b) || throw(DimensionMismatch(LazyString("A has dimensions ", size(a), " but B has dimensions ", size(b))))
+            if a.ind == b.ind
+                return OneElement($op(getindex_value(a), getindex_value(b)), a.ind, axes(a))
+            else
+                return oneelement_addsub(a, b, getindex_value(a), $bop)
+            end
+        end
+    end
+end
+
 # matrix-vector and matrix-matrix multiplication
 
 # Fill and OneElement

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -505,6 +505,14 @@ end
         for A in As, Z in (TZ -> Zeros{TZ}(3)).((Int, Float64, Int8, ComplexF64))
             test_addition_and_subtraction_dim_mismatch(A, Z)
         end
+
+        # Zeros should be additive identity for matrices
+        D = Diagonal([1, 1])
+        Z = Zeros(2, 2)
+        @test D + Z isa Diagonal
+        @test D + Z == D
+        @test D - Z == D
+        @test Z - D == -D
     end
 end
 
@@ -588,6 +596,12 @@ end
             testsparsediag(E)
         end
     end
+
+    # Adding one elements with different indices should return a sparse array.
+    A = OneElement(2, 5)
+    B = OneElement(3, 5)
+    @test A + B isa SparseVector
+    @test A + B == [0, 1, 1, 0, 0]
 end
 
 @testset "==" begin
@@ -2372,6 +2386,19 @@ end
         @test isassigned(f, 2, 2)
         @test !isassigned(f, 10, 10)
         @test_throws ArgumentError isassigned(f, true)
+    end
+
+    @testset "Addition/Subtraction" begin
+        A = OneElement(2, 5)
+        B = OneElement(3, 5)
+
+        @test A + A isa OneElement
+        @test A + A == OneElement(2, 2, 5)
+        @test A + B == [0, 1, 1, 0, 0]
+
+        @test B - B isa OneElement
+        @test B - B == OneElement(0, 2, 5)
+        @test B - A == [0, -1, 1, 0, 0]
     end
 
     @testset "matmul" begin


### PR DESCRIPTION
This pull request alters some behaviour of addition/subtraction of the `Zeros` and `OneElement` types. It ensures that the sparsity of any array structure that undergoes addition or subtraction with one of these types preserves its sparsity by avoiding the materialisation of dense arrays where possible:

-Adding or subtracting a `Zeros` and any array `v` now preserves the type of `v` (while still obeying type promotion rules)
-Adding or subtracting a `OneElement` to any array `v` is now O(1) and preserves the type of `v` unless the underlying `setindex!` operation is invalid (e.g adding a `OneElement` with a nondiagonal entry to a `Diagonal`), in which case a dense array is materialised
-Adding or subtracting two `OneElements` now returns a `OneElement` if their indices are the same. Otherwise it materialises a dense vector. If `SparseArrays` is imported, it instead creates a SparseArray.

Changes have been covered with unit tests