### PR TITLE
Update RectDiagonal broadcasting to accept 2-element size

### DIFF
--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -534,8 +534,9 @@ end
 # Also, maybe this should reuse the broadcasting behavior of the parent,
 # once AbstractFill types implement their own BroadcastStyle
 BroadcastStyle(::Type{<:RectDiagonal}) = LinearAlgebra.StructuredMatrixStyle{RectDiagonal}()
-LinearAlgebra.structured_broadcast_alloc(bc, ::Type{<:RectDiagonal}, ::Type{ElType}, n) where {ElType} =
-    RectDiagonal(Array{ElType}(undef, n), axes(bc))
+function LinearAlgebra.structured_broadcast_alloc(bc, ::Type{<:RectDiagonal}, ::Type{ElType}, n) where {ElType}
+    RectDiagonal(Array{ElType}(undef, minimum(n)), axes(bc))
+end
 @inline LinearAlgebra.fzero(S::RectDiagonal{T}) where {T} = zero(T)
 
 #########


### PR DESCRIPTION
`LinearAlgebra` now passes the 2-element `size` of the matrix to `structured_broadcast_alloc`. This adapts the method in this package to accept the 2-term `size`. This would be backward compatible, as `minimum` is a no-op for a number.

The change here gets tests working on julia v1.14.