### PR TITLE
Change reshape methods to accept a single argument at least

### DIFF
--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -267,13 +267,14 @@ reshape(parent::AbstractFill, dims::Union{Integer,Colon}...) = reshape(parent, d
 # resolve ambiguity with Base
 reshape(parent::AbstractFillVector, dims::Colon) = parent
 
-reshape(parent::AbstractFill, dims::Tuple{Vararg{Union{Integer,Colon}}}) =
+reshape(parent::AbstractFill, dims::Tuple{Union{Integer,Colon}, Vararg{Union{Integer,Colon}}}) =
     fill_reshape(parent, Base._reshape_uncolon(parent, dims)...)
-reshape(parent::AbstractFill, dims::Tuple{Vararg{Union{Int,Colon}}}) =
+reshape(parent::AbstractFill, dims::Tuple{Union{Int,Colon}, Vararg{Union{Int,Colon}}}) =
     fill_reshape(parent, Base._reshape_uncolon(parent, dims)...)
 reshape(parent::AbstractFill, shp::Tuple{Union{Integer,Base.OneTo}, Vararg{Union{Integer,Base.OneTo}}}) =
     reshape(parent, Base.to_shape(shp))
-reshape(parent::AbstractFill, dims::Dims) = fill_reshape(parent, dims...)
+reshape(parent::AbstractFill, dims::Tuple{Int, Vararg{Int}}) = fill_reshape(parent, dims...)
+reshape(parent::AbstractFill, dims::Tuple{}) = fill_reshape(parent, dims...)
 reshape(parent::AbstractFill, dims::Tuple{Integer, Vararg{Integer}}) = fill_reshape(parent, dims...)
 
 # resolve ambiguity with Base


### PR DESCRIPTION
Most of these `reshape` methods are simply to avoid method ambiguities with `Base`. I am planning an overhaul of the `reshape` methods in `Base` in https://github.com/JuliaLang/julia/pull/56850, after which a large fraction of these methods may be removed (or version-capped). This PR is to update the methods to dispatch on `Tuple`s with at least one argument, which firstly avoids any ambiguities with an empty `Tuple`, and secondly makes this package more resilient to changes to `Base`.