### PR TITLE
Add Static Arrays Extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,11 +9,13 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 PDMats = "90014a1f-27ba-587c-ab20-58faa44d9150"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [extensions]
 FillArraysPDMatsExt = "PDMats"
 FillArraysSparseArraysExt = "SparseArrays"
 FillArraysStatisticsExt = "Statistics"
+FillArraysStaticArraysExt = "StaticArrays"
 
 [compat]
 Aqua = "0.8"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FillArrays"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "1.15.0"
+version = "1.16.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/ext/FillArraysStaticArraysExt.jl
+++ b/ext/FillArraysStaticArraysExt.jl
@@ -1,0 +1,28 @@
+module FillArraysStaticArraysExt
+
+using FillArrays
+using StaticArrays
+
+import Base: promote_op
+import FillArrays: elconvert
+
+# Disambiguity methods for StaticArrays
+
+function Base.:+(a::FillArrays.Zeros, b::StaticArray)
+    promote_shape(a,b)
+    return elconvert(promote_op(+,eltype(a),eltype(b)),b)
+end
+function Base.:+(a::StaticArray, b::FillArrays.Zeros)
+    promote_shape(a,b)
+    return elconvert(promote_op(+,eltype(a),eltype(b)),a)
+end
+function Base.:-(a::StaticArray, b::FillArrays.Zeros)
+    promote_shape(a,b)
+    return elconvert(promote_op(-,eltype(a),eltype(b)),a)
+end
+function Base.:-(a::FillArrays.Zeros, b::StaticArray)
+    promote_shape(a,b)
+    return elconvert(promote_op(-,eltype(a),eltype(b)),-b)
+end
+
+end # module

--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -436,12 +436,25 @@ function +(a::AbstractZeros{T}, b::AbstractZeros{V}) where {T, V} # for disambig
     promote_shape(a,b)
     return elconvert(promote_op(+,T,V),a)
 end
-# no AbstractArray. Otherwise incompatible with StaticArrays.jl
-# AbstractFill for disambiguity
-for TYPE in (:Array, :AbstractFill, :AbstractRange, :Diagonal)
+
+function -(a::AbstractZeros{T}, b::AbstractZeros{V}) where {T, V} # for disambiguity
+    promote_shape(a,b)
+    return elconvert(promote_op(-,T,V),-b)
+end
+
+# AbstractFill and Array for disambiguity
+for TYPE in (:Array, :AbstractFill, :AbstractRange, :AbstractArray)
     @eval function +(a::$TYPE{T}, b::AbstractZeros{V}) where {T, V}
         promote_shape(a,b)
         return elconvert(promote_op(+,T,V),a)
+    end
+     @eval function -(a::$TYPE{T}, b::AbstractZeros{V}) where {T, V}
+        promote_shape(a,b)
+        return elconvert(promote_op(-,T,V),a)
+    end
+    @eval function -(a::AbstractZeros{T}, b::$TYPE{V}) where {T, V}
+        promote_shape(a,b)
+        return elconvert(promote_op(-,T,V),-b)
     end
     @eval +(a::AbstractZeros, b::$TYPE) = b + a
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -505,6 +505,19 @@ end
         for A in As, Z in (TZ -> Zeros{TZ}(3)).((Int, Float64, Int8, ComplexF64))
             test_addition_and_subtraction_dim_mismatch(A, Z)
         end
+
+        # Zeros should act as an additive identity
+        # Arbitrary AbstractMatrix
+        D = Diagonal([1, 1])
+        Z = Zeros(2, 2)
+        @test D + Z isa Diagonal
+        @test D + Z == D
+        @test D - Z == D
+        @test Z - D == -D
+
+        @test Z + Z isa Zeros
+        @test Z + Z == Z
+        @test Z - Z == Z
     end
 end
 


### PR DESCRIPTION
This is a continuation of [this PR](https://github.com/JuliaArrays/FillArrays.jl/pull/422/files).

This PR adds an extension of StaticArrays.jl. This ends up fixing an issue where adding or subtracting by `Zeros` always returns a dense `Array `. By adding this extension, we resolve ambiguity issues and thus are able to override `+(a::AbstractArray, b::Zeros)` so that it preserves the type of `a`.

