### PR TITLE
remove dependancy on internal base func

### DIFF
--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -725,23 +725,6 @@ include("trues.jl")
 Base.replace_in_print_matrix(::AbstractZeros, ::Integer, ::Integer, s::AbstractString) =
     Base.replace_with_centered_mark(s)
 
-# following support blocked fill array printing via
-# BlockArrays.jl
-axes_print_matrix_row(lay, io, X, A, i, cols, sep, idxlast::Integer=last(axes(X, 2))) =
-    Base.invoke(Base.print_matrix_row, Tuple{IO,AbstractVecOrMat,Vector,Integer,AbstractVector,AbstractString,Integer},
-                    io, X, A, i, cols, sep, idxlast)
-
-Base.print_matrix_row(io::IO,
-        X::Union{AbstractFillVector,
-                 AbstractFillMatrix,
-                 Diagonal{<:Any,<:AbstractFillVector},
-                 RectDiagonal,
-                 UpperOrLowerTriangular{<:Any,<:AbstractFillMatrix}
-                 }, A::Vector,
-        i::Integer, cols::AbstractVector, sep::AbstractString, idxlast::Integer=last(axes(X, 2))) =
-        axes_print_matrix_row(axes(X), io, X, A, i, cols, sep)
-
-
 # Display concise description of a Fill.
 
 function Base.show(io::IO, ::MIME"text/plain", x::Union{Eye, AbstractFill})


### PR DESCRIPTION
it doesn't seem like it even changes anything, just calls an expensive `invoke` for some reason? I don't know what this was trying to do but I'll fix it if it breaks anything somehow; trying to clean up these internal array print functions in base and found your package complaining that "`print_matrix_row` not defined in `Base`" when importing a downstream package

edit: ok, I think I'm starting to see what this is trying to do. prob should have started at block arrays as mentioned in the comment...