### PR TITLE
Remove method overloads that duplicate Base/LinearAlgebra generics

### DIFF
--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -5,7 +5,7 @@ using LinearAlgebra
 import Base: size, getindex, setindex!, IndexStyle, checkbounds, convert,
     +, -, *, /, \, diff, sum, cumsum, maximum, minimum, sort, sort!,
     any, all, axes, isone, iszero, iterate, unique, allunique, permutedims, inv,
-    copy, vec, setindex!, count, ==, reshape, map, zero,
+    copy, setindex!, count, ==, reshape, map, zero,
     show, view, in, mapreduce, one, reverse, promote_op, promote_rule, repeat,
     parent, similar, issorted, add_sum, mul_prod, accumulate, OneTo, permutedims
 
@@ -512,7 +512,7 @@ function diag(E::Eye, k::Integer=0)
 end
 
 # These should actually be in StdLib, LinearAlgebra.jl, for all Diagonal
-for f in (:permutedims, :triu, :triu!, :tril, :tril!, :copy)
+for f in (:triu, :triu!, :tril, :tril!, :copy)
     @eval ($f)(IM::Diagonal{<:Any,<:AbstractFill}) = IM
 end
 

--- a/src/fillalgebra.jl
+++ b/src/fillalgebra.jl
@@ -1,7 +1,3 @@
-## vec
-
-vec(a::AbstractFill) = fillsimilar(a, length(a))
-
 ## Transpose/Adjoint
 # cannot do this for vectors since that would destroy scalar dot product
 
@@ -426,7 +422,6 @@ end
 # Addition and Subtraction
 +(a::AbstractFill) = a
 -(a::AbstractZeros) = a
--(a::AbstractFill) = Fill(-getindex_value(a), size(a))
 
 # special-cased for type-stability, as Ones + Ones is not a Ones
 Base.reduce_first(::typeof(+), x::AbstractOnes) = Fill(Base.reduce_first(+, getindex_value(x)), axes(x))


### PR DESCRIPTION
These all have generic definitions upstream that do the same thing. Using Base's unary `-` also fixes a wee bug by preserving the axes of the inputs such that `-Fill(2, (1:3,)) == Fill(-2, (1:3,))`. The old implementation used `size()` so the result would be `-Fill(2, (3,))`.

Discovered with help from Claude :robot: 