### PR TITLE
Raise a fill to a literal power the way Base does

### DIFF
--- a/src/fillbroadcast.jl
+++ b/src/fillbroadcast.jl
@@ -197,16 +197,20 @@ isfill(f::Number) = true
 isfill(f::Ref) = true
 isfill(::Any) = false
 
+# Pick the fill from the value the operation produced. A zero or a unit value only earns `Zeros` or
+# `Ones` when every argument was itself static, since otherwise the value says nothing about what a
+# different argument of the same type would give.
+function _fill_result(f, v, ax, args...)
+    if all(has_static_value, args)
+        _iszero(v) && return broadcasted_zeros(f, typeof(v), ax, args...)
+        _isone(v) && return broadcasted_ones(f, typeof(v), ax, args...)
+    end
+    return broadcasted_fill(f, v, ax, args...)
+end
+
 # the fill value is computed once and handed to the checks, so that the broadcasted function is
 # evaluated exactly once
-function _copy_fill(bc)
-    v = broadcast_getindex_value(bc)
-    if all(has_static_value, bc.args)
-        _iszero(v) && return broadcasted_zeros(bc.f, typeof(v), axes(bc), bc.args...)
-        _isone(v) && return broadcasted_ones(bc.f, typeof(v), axes(bc), bc.args...)
-    end
-    return broadcasted_fill(bc.f, v, axes(bc), bc.args...)
-end
+_copy_fill(bc) = _fill_result(bc.f, broadcast_getindex_value(bc), axes(bc), bc.args...)
 
 # recursively copy the purely fill components
 function _preprocess_fill(bc::Broadcast.Broadcasted{<:AbstractFillStyle})
@@ -471,10 +475,12 @@ for op in (:+, :-)
 end
 
 # support AbstractFill .^ k
-broadcasted(op::typeof(Base.literal_pow), ::typeof(^), r::AbstractFill{T,N}, ::Val{k}) where {T,N,k} = broadcasted_fill(op, getindex_value(r)^k, axes(r), r)
-broadcasted(op::typeof(Base.literal_pow), ::typeof(^), r::AbstractOnes{T,N}, ::Val{k}) where {T,N,k} = broadcasted_ones(op, T, axes(r), r)
-broadcasted(op::typeof(Base.literal_pow), ::typeof(^), r::AbstractZeros{T,N}, ::Val{0}) where {T,N} = broadcasted_ones(op, T, axes(r), r)
-broadcasted(op::typeof(Base.literal_pow), ::typeof(^), r::AbstractZeros{T,N}, ::Val{k}) where {T,N,k} = broadcasted_zeros(op, T, axes(r), r)
+# `x .^ k` with a literal `k` lowers to `literal_pow`, which this intercepts before any style is
+# consulted. Evaluate the operation on the fill value rather than predicting it from `k`: a `Zeros`
+# raised to a negative power is a division by zero, which no more yields zero here than `x ./ Zeros`
+# does, and `literal_pow` is defined where `^` would throw.
+broadcasted(op::typeof(Base.literal_pow), x::typeof(^), r::AbstractFill, y::Val) =
+    _fill_result(op, op(x, getindex_value(r), y), axes(r), r)
 fill_rule(op::typeof(Base.literal_pow), x::typeof(^), r::AbstractFill, y::Val) = broadcasted(op, x, r, y)
 
 # supports structured broadcast

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1074,6 +1074,29 @@ counted_identity(x) = (CALLS[] += 1; x)
     @test Zeros{Int}(5) .^ 1 ≡ Zeros{Int}(5)
     @test Zeros{Int}(5) .+ Zeros(5) isa Zeros{Float64}
 
+    @testset "negative literal powers" begin
+        # a negative exponent puts the base in the denominator, where a zero no more absorbs than
+        # it does in `x ./ Zeros`, and the result agrees with the dense array either way
+        @test Zeros{Float64}(5) .^ -1 ≡ Zeros{Int}(5) .^ -1 ≡ Fill(Inf, 5)
+        @test Zeros{Float64}(5) .^ -2 ≡ Fill(Inf, 5)
+        @test Zeros{Float64}(5) .^ -1 ≡ inv.(Zeros{Float64}(5)) ≡ Fill(0.0, 5) .^ -1
+        # `isequal`, as the complex case is NaN, which compares unequal to itself
+        @test isequal(Zeros{ComplexF64}(5) .^ -1, Array(Zeros{ComplexF64}(5)) .^ -1)
+        # `literal_pow` is defined where `^` is not, so an integer fill no longer throws
+        @test Fill(2,5) .^ -1 ≡ Fill(0.5, 5)
+        @test Fill(2,5) .^ -2 ≡ Fill(0.25, 5)
+        # `inv` of an integer promotes, so the element type comes from the result, not the input
+        @test Ones{Int}(5) .^ -1 ≡ Ones{Float64}(5)
+        @test Ones{Bool}(5) .^ -1 ≡ Ones{Float64}(5)
+        @testset for k in (-2, -1, 0, 1, 2)
+            for A in (Zeros{Float64}(5), Zeros{Int}(5), Ones{Int}(5), Fill(2,5), Fill(2.0,5))
+                B = Base.broadcasted(Base.literal_pow, ^, A, Val(k))
+                @test isequal(Broadcast.materialize(B),
+                    Broadcast.materialize(Base.broadcasted(Base.literal_pow, ^, Array(A), Val(k))))
+            end
+        end
+    end
+
     # Test for conj, real and imag with complex element types
     @test conj(Zeros{ComplexF64}(10)) isa Zeros{ComplexF64}
     @test conj(Zeros{ComplexF64}(10,10)) isa Zeros{ComplexF64}
@@ -1470,6 +1493,10 @@ counted_identity(x) = (CALLS[] += 1; x)
         @test TaggedZeros{Int}(4) .^ 2 ≡ TaggedZeros{Int}(4)
         @test TaggedZeros{Int}(4) .^ 0 ≡ TaggedOnes{Int}(4)
         @test TaggedOnes{Int}(4) .^ 2 ≡ TaggedOnes{Int}(4)
+        # a negative power of a zero is neither zero nor one, so only `broadcasted_fill` is left to
+        # reach, and these types overload the other two hooks alone
+        @test TaggedZeros{Int}(4) .^ -1 ≡ Fill(Inf, 4)
+        @test TaggedOnes{Int}(4) .^ -1 ≡ TaggedOnes{Float64}(4)
         @test TaggedZeros{Int}(4) .* (1:4) ≡ (1:4) .* TaggedZeros{Int}(4) ≡ TaggedZeros{Int}(4)
         @test TaggedZeros{Int}(4) .* TaggedOnes{Int}(4) ≡ TaggedZeros{Int}(4)
         @test TaggedOnes{Int}(4) ./ TaggedOnes{Int}(4) ≡ TaggedOnes{Float64}(4)


### PR DESCRIPTION
Stacked on #385 — please review that first; this PR targets `jishnub/broadcaststyle` and its diff is a single commit.

`x .^ k` with a literal `k` lowers to a `Base.literal_pow` broadcast, which four styleless rules intercept so a fill raised to a power stays a fill. Each read the answer off the *exponent* rather than off the value the operation produces, and three were wrong for a negative one:

```julia
Zeros{Float64}(3) .^ -1   # Zeros [0.0,0.0,0.0]   Base: [Inf, Inf, Inf]
Zeros{Int}(3)     .^ -1   # Zeros{Int} [0,0,0]    Base: [Inf, Inf, Inf]
Fill(2,3)         .^ -1   # DomainError           Base: [0.5, 0.5, 0.5]
Ones{Int}(3)      .^ -1   # Ones{Int} [1,1,1]     Base: Float64 [1.0,1.0,1.0]
```

Causes: the `AbstractZeros`/`Val{k}` rule asserted `0^k == 0` for every `k != 0`; the `AbstractOnes` rule took the element type from its argument rather than from the result, which `inv` on an integer promotes; and the generic rule evaluated `getindex_value(r)^k`, which is undefined where `literal_pow` is defined (`2^-1` throws, `literal_pow(^, 2, Val(-1))` is `0.5`).

There was also an internal inconsistency: written as a literal, `Zeros{Float64}(3) .^ -1` returned zeros, but with the exponent in a variable — which does not lower to `literal_pow`, and so takes the generic path through `_copy_fill` — the same expression already returned `Inf`.

All of this reproduces on `master`; it is pre-existing rather than a regression from #385, but it sits in code that branch rewrites.

## This restores the strong-zero convention rather than departing from it

`Zeros` is deliberately an absorbing zero, but only **as a factor**. The rule loop generates exactly `(*, Zeros, T)`, `(/, Zeros, T)`, `(*, T, Zeros)` and `(\, T, Zeros)` — every shape where the zero is a factor or a numerator — and `fillalgebra.jl` does the same for matrix products. It deliberately does **not** absorb in a denominator: there is no `(/, T, Zeros)` rule, so `x ./ Zeros` falls through to IEEE and gives `Inf`, and where both sides are `Zeros`, `/` and `\` are routed through `_broadcasted_nan` to construct `Fill(NaN)` — the more expensive answer, pinned by a testset named `"NaN"`.

A negative power is a division with the zero in the denominator, so it belongs in the second group. Three existing behaviours already said so:

- `inv.(Zeros(3))` already returned `Fill(Inf)`,
- `Fill(0.0,3) .^ -1` already returned `Fill(Inf)` while `Zeros(3) .^ -1` returned zeros — two spellings of the same array disagreeing,
- `Twos ./ Zeros === Fill(Inf, ...)` is already asserted in the test suite.

Absorption is unchanged wherever the zero is a factor. (The "avoid `∞ * 0` in InfiniteArrays.jl" comment is not counter-evidence: it sits on `_foldl_length_op` guarding `length(A)*v`, so that `∞` is an infinite *length*, not an infinite *value*.)

## Scope of the behaviour change

Measured over `Zeros`/`Ones` in `Int`, `Float64`, `Float32`, `Bool`, `ComplexF64` and `Fill` of 0, 1, 2, 2.0, against exponents `-3..3`:

- **every changed result has `k < 0`**; nothing at `k >= 0` changes,
- **every changed result moves from disagreeing with the dense array to agreeing with it**, in value and element type,
- no test used a negative exponent, so nothing pinned the old behaviour.

## Implementation

Classifying by the computed value is what `_copy_fill` already does, so the four rules collapse into one that shares it through a new `_fill_result`:

```julia
broadcasted(op::typeof(Base.literal_pow), x::typeof(^), r::AbstractFill, y::Val) =
    _fill_result(op, op(x, getindex_value(r), y), axes(r), r)
```

## Note for downstream packages

A package overloading only `broadcasted_zeros`/`broadcasted_ones` now falls back to `Fill` for `Zeros .^ negative`, since the result is neither zero nor one and only `broadcasted_fill` is left to reach. Recorded in the tests as `TaggedZeros{Int}(4) .^ -1 ≡ Fill(Inf, 4)`.

## Verification

- `Test.detect_ambiguities(FillArrays; recursive=false)` → 0
- A 14.6k-line behavioural snapshot over unary/binary/fused broadcasts, powers, operators and resolved styles, diffed against the parent commit: 78 changed lines, **all** of them negative exponents, nothing else
- Full test suite green, including the customisation hooks, the `DefaultArrayStyle`-forwarded path and the infinite-axes cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)
