### PR TITLE
Hash for infinite Fill arrays

### DIFF
--- a/src/FillArrays.jl
+++ b/src/FillArrays.jl
@@ -853,5 +853,6 @@ function repeat(A::AbstractFill; inner=ntuple(x->1, ndims(A)), outer=ntuple(x->1
 end
 
 include("oneelement.jl")
+include("fillhash.jl")
 
 end # module

--- a/src/fillhash.jl
+++ b/src/fillhash.jl
@@ -39,7 +39,6 @@ function _hash_indices(ax::AbstractUnitRange)
     b = a + hash_nentries - 1
     a:(isinf(last(ax)) ? b : min(last(ax), b))
 end
-_hash_indices(ax) = Iterators.take(ax, hash_nentries)
 
 function _hash_infarray(A::AbstractArray, h::UInt)
     h += hash_infarray_seed

--- a/src/fillhash.jl
+++ b/src/fillhash.jl
@@ -1,0 +1,83 @@
+##
+# hash
+#
+# `Base.hash(::AbstractArray, ::UInt)` hashes the endpoints of the axes and then walks the
+# entries backwards from the last index, which neither terminates nor is well-defined when an
+# axis is infinite — a `Fill(1, (OneToInf(),))` as built by `InfiniteArrays` is an ordinary
+# instantiation of these types, and `IteratorSize` already reports it as `Base.IsInfinite`.
+#
+# Such an array is hashed with the same recipe as `Base`'s, except that the entries are taken from
+# a finite corner at the start of the array. Equal arrays have equal axes and equal entries, so the
+# contract `isequal(a,b) ⟹ hash(a) == hash(b)` is preserved; the price is that arrays which first
+# differ outside the corner collide. Arrays with finite axes are left to `Base`.
+#
+# `ArrayLayouts`, `BlockArrays` and `InfiniteArrays` hash the infinite arrays they own with this
+# same scheme; keep the seeds and the window size in sync so that arrays which compare equal across
+# packages keep hashing alike.
+##
+
+const hash_infinity_seed = UInt === UInt64 ? 0x3a4c1b6d9e2f5087 : 0x9e2f5087
+const hash_infarray_seed = UInt === UInt64 ? 0x5d7e3f11a8c6b024 : 0xa8c6b024
+
+# number of entries hashed along each dimension of an infinite array
+const hash_nentries = 8
+
+# An infinite axis has an infinite endpoint, which `Base` cannot hash, so hash the direction it
+# points in instead: infinities pointing the same way compare equal and hence have to hash alike.
+_hash_endpoint(x, h::UInt) = isinf(x) ? hash(signbit(x), h + hash_infinity_seed) : hash(x, h)
+
+"""
+    _hash_indices(ax)
+
+The indices along the axis `ax` at which entries get hashed: the first `hash_nentries` of them, or
+all of `ax` when it is shorter than that. A bi-infinite axis has no first index, so there the
+window starts at zero instead.
+"""
+function _hash_indices(ax::AbstractUnitRange)
+    a = first(ax)
+    isinf(a) && return 0:hash_nentries-1
+    b = a + hash_nentries - 1
+    a:(isinf(last(ax)) ? b : min(last(ax), b))
+end
+_hash_indices(ax) = Iterators.take(ax, hash_nentries)
+
+function _hash_infarray(A::AbstractArray, h::UInt)
+    h += hash_infarray_seed
+    # the axes are arrays in their own right, so hash their endpoints instead of the axes
+    for ax in axes(A)
+        h = _hash_endpoint(first(ax), h)
+    end
+    for ax in axes(A)
+        h = _hash_endpoint(last(ax), h)
+    end
+    for I in Iterators.product(map(_hash_indices, axes(A))...)
+        h = hash(A[I...], h)
+    end
+    h
+end
+
+# `length` is the product of the axis lengths, and `0 * ℵ₀` throws, so ask the axes one at a time
+_hasinfaxes(A::AbstractArray) = any(ax -> isinf(length(ax)), axes(A))
+
+const HashableFill = Union{AbstractFill,
+                           RectDiagonal,
+                           OneElement,
+                           Diagonal{<:Any,<:AbstractFillVector},
+                           Bidiagonal{<:Any,<:AbstractFillVector},
+                           Tridiagonal{<:Any,<:AbstractFillVector},
+                           SymTridiagonal{<:Any,<:AbstractFillVector},
+                           Symmetric{<:Any,<:AbstractFillMatrix},
+                           Hermitian{<:Any,<:AbstractFillMatrix},
+                           UpperOrLowerTriangular{<:Any,<:AbstractFillMatrix}}
+
+const HashableFills = Union{HashableFill,
+                            LinearAlgebra.AdjOrTrans{<:Any,<:HashableFill},
+                            SubArray{<:Any,<:Any,<:HashableFill}}
+
+Base.hash(A::HashableFills, h::UInt) =
+    _hasinfaxes(A) ? _hash_infarray(A, h) : invoke(hash, Tuple{AbstractArray,UInt}, A, h)
+
+# `Base.isequal(::AbstractArray, ::AbstractArray)` walks the entries, so it does not terminate for
+# two equal infinite fills. Mirror `==` above, which compares the axes and the value.
+Base.isequal(a::AbstractFill, b::AbstractFill) =
+    axes(a) == axes(b) && isequal(getindex_value(a), getindex_value(b))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -609,6 +609,59 @@ end
     @test Ones(5,4) == Fill(1,5,4)
 end
 
+@testset "hash" begin
+    r = InfiniteArrays.OneToInf()
+
+    @testset "finite arrays hash as in Base" begin
+        for (a, b) in ((Fill(1,3), [1,1,1]),
+                       (Zeros(2,3), zeros(2,3)),
+                       (Ones{Int}(4), ones(Int,4)),
+                       (Diagonal(Fill(2,3)), Diagonal([2,2,2])),
+                       (OneElement(2, (3,), (Base.OneTo(5),)), [0,0,2,0,0]),
+                       (RectDiagonal(Fill(2,2), (Base.OneTo(2), Base.OneTo(3))), [2 0 0; 0 2 0]))
+            @test hash(a) == hash(b)
+            @test hash(a, UInt(7)) == hash(b, UInt(7))
+        end
+    end
+
+    @testset "infinite arrays" begin
+        @test hash(Ones((r,))) == hash(Ones{Int}((r,))) == hash(Fill(1.0, (r,)))
+        @test hash(Zeros((r,))) == hash(Fill(0.0, (r,)))
+        @test hash(Zeros((r,))) ≠ hash(Ones((r,)))
+        @test hash(Ones((r,)), UInt(7)) == hash(Ones{Int}((r,)), UInt(7))
+        @test hash(Fill(2, (r,r))) isa UInt
+        @test hash(Fill(2, (r, Base.OneTo(3)))) ≠ hash(Fill(2, (Base.OneTo(3), r)))
+        @test hash(OneElement(2, (3,), (r,))) isa UInt
+        @test hash(OneElement(2, (3,), (r,))) ≠ hash(Zeros{Int}((r,)))
+
+        # an empty axis alongside an infinite one: `length` would throw on `0 * ℵ₀`
+        @test hash(Zeros((Base.OneTo(0), r))) isa UInt
+
+        @testset "wrappers" begin
+            @test hash(Diagonal(Ones((r,)))) == hash(Diagonal(Ones{Int}((r,))))
+            @test hash(Ones((r,))') == hash(transpose(Ones((r,))))
+            @test hash(Symmetric(Ones((r,r)))) isa UInt
+            @test hash(UpperTriangular(Ones((r,r)))) isa UInt
+            @test hash(SymTridiagonal(Fill(2.0, (r,)), Fill(1.0, (r,)))) isa UInt
+            @test hash(Tridiagonal(Fill(1.0, (r,)), Fill(2.0, (r,)), Fill(3.0, (r,)))) isa UInt
+            @test hash(view(Ones((r,)), r)) isa UInt
+        end
+    end
+
+    @testset "isequal" begin
+        @test isequal(Ones((r,)), Ones{Int}((r,)))
+        @test isequal(Zeros((r,)), Fill(0.0, (r,)))
+        @test !isequal(Ones((r,)), Zeros((r,)))
+        @test !isequal(Ones((r,)), Ones((Base.OneTo(3),)))
+        @test length(Set([Ones((r,)), Ones{Int}((r,)), Fill(1.0, (r,))])) == 1
+
+        # `isequal` separates `NaN` from `==`, as for any other array
+        @test isequal(Fill(NaN, 3), Fill(NaN, 3))
+        @test Fill(NaN, 3) ≠ Fill(NaN, 3)
+        @test isequal(Fill(NaN, (r,)), Fill(NaN, (r,)))
+    end
+end
+
 @testset "Rank" begin
     @test rank(Zeros(5,4)) == 0
     @test rank(Ones(5,4)) == 1


### PR DESCRIPTION
Currently, `hash` falls back to the generic method for AbstractArrays that doesn't handle infinite arrays. This adds an  implementation to handle infinite arrays.

On master
```julia
julia> f = Fill(4, ∞)
ℵ₀-element Fill{Int64, 1, Tuple{InfiniteArrays.OneToInf{Int64}}} with indices OneToInf(), with entries equal to 4

julia> hash(f)
ERROR: Overload getindex(::LinearIndices{1, Tuple{InfiniteArrays.OneToInf{Int64}}}, ::InfiniteCardinal{0})
```
vs this PR
```julia
julia> hash(f)
0xd44c310706df880d
```

This only impacts infinite arrays, and finite-sized arrays still reach the `Base` method, and their hashes remain unchanged:
```julia
julia> hash(Fill(4, 4)) == hash(fill(4,4))
true
```